### PR TITLE
feat: add zsh task completion plugin docs and script

### DIFF
--- a/zsh/compozy-completion/README.md
+++ b/zsh/compozy-completion/README.md
@@ -1,0 +1,52 @@
+# Compozy Completion Plugin
+
+This plugin adds shell completion for `compozy tasks run` so task slugs are completed from the
+nearest `.compozy/tasks` directory relative to your current working directory.
+
+## What it does
+
+- Completes `tasks` after `compozy`
+- Completes `run` after `compozy tasks`
+- Completes all directories under `.compozy/tasks` after `compozy tasks run`
+- Works in worktrees and repository copies by scanning upward from `$PWD` until it finds `.compozy/tasks`
+
+## Installation
+
+1. Copy the plugin file into your shell folder (already placed by default at:
+   `~/.zsh/compozy-completion/compozy-completion.plugin.zsh`).
+
+   ```zsh
+   # if needed
+   cp /path/to/compozy/zsh/compozy-completion/compozy-completion.plugin.zsh \
+     "$HOME/.zsh/compozy-completion/compozy-completion.plugin.zsh"
+   ```
+
+2. Source it from your `~/.zshrc`:
+
+   ```zsh
+   if [[ -f "$HOME/.zsh/compozy-completion/compozy-completion.plugin.zsh" ]]; then
+     source "$HOME/.zsh/compozy-completion/compozy-completion.plugin.zsh"
+   fi
+   ```
+
+3. Reload your shell:
+
+   ```zsh
+   source ~/.zshrc
+   ```
+
+## Quick usage
+
+From any Compozy workspace:
+
+```zsh
+cd /path/to/repo/.compozy-task-root
+compozy tasks run <TAB>
+```
+
+The command will suggest task directory names found in `.compozy/tasks`.
+
+## Notes
+
+- Keep `.compozy/tasks` present in the workspace root or an ancestor directory.
+- If there are no tasks, completion will fall back to default zsh behavior for that command position.

--- a/zsh/compozy-completion/compozy-completion.plugin.zsh
+++ b/zsh/compozy-completion/compozy-completion.plugin.zsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env zsh
 
+# Finds the nearest .compozy/tasks directory by walking up from the current
+# working directory.
 _compozy_tasks_workspace() {
   local dir="$PWD"
 
@@ -16,31 +18,34 @@ _compozy_tasks_workspace() {
   return 1
 }
 
+# Provides zsh completion for:
+# - `compozy tasks`
+# - `compozy tasks run`
+# - task slugs found under the discovered .compozy/tasks directory
 _compozy() {
   local -a comps
   local tasks_path
   local -a task_slugs
   local task_path
 
-  if (( CURRENT == 1 )); then
+  if (( CURRENT == 2 )); then
     comps=(tasks)
     compadd -Q -- "$comps[@]"
     return 0
   fi
 
-  if (( CURRENT == 2 )) && [[ $words[2] == "tasks" ]]; then
+  if (( CURRENT == 3 )) && [[ $words[2] == "tasks" ]]; then
     comps=(run)
     compadd -Q -- "$comps[@]"
     return 0
   fi
 
-  if (( CURRENT >= 3 )) && [[ $words[2] == "tasks" ]] && [[ $words[3] == "run" ]]; then
+  if (( CURRENT >= 4 )) && [[ $words[2] == "tasks" ]] && [[ $words[3] == "run" ]]; then
     tasks_path="$(_compozy_tasks_workspace)"
 
     if [[ -n "$tasks_path" && -d "$tasks_path" ]]; then
       task_slugs=()
-      for task_path in "$tasks_path"/*(N); do
-        [[ -e "$task_path" ]] || continue
+      for task_path in "$tasks_path"/*(N/); do
         task_slugs+=("${task_path:t}")
       done
 

--- a/zsh/compozy-completion/compozy-completion.plugin.zsh
+++ b/zsh/compozy-completion/compozy-completion.plugin.zsh
@@ -1,0 +1,57 @@
+#!/usr/bin/env zsh
+
+_compozy_tasks_workspace() {
+  local dir="$PWD"
+
+  while [[ -n "$dir" ]]; do
+    if [[ -d "$dir/.compozy/tasks" ]]; then
+      print -r -- "$dir/.compozy/tasks"
+      return 0
+    fi
+
+    [[ "$dir" == "/" ]] && break
+    dir="${dir:h}"
+  done
+
+  return 1
+}
+
+_compozy() {
+  local -a comps
+  local tasks_path
+  local -a task_slugs
+  local task_path
+
+  if (( CURRENT == 1 )); then
+    comps=(tasks)
+    compadd -Q -- "$comps[@]"
+    return 0
+  fi
+
+  if (( CURRENT == 2 )) && [[ $words[2] == "tasks" ]]; then
+    comps=(run)
+    compadd -Q -- "$comps[@]"
+    return 0
+  fi
+
+  if (( CURRENT >= 3 )) && [[ $words[2] == "tasks" ]] && [[ $words[3] == "run" ]]; then
+    tasks_path="$(_compozy_tasks_workspace)"
+
+    if [[ -n "$tasks_path" && -d "$tasks_path" ]]; then
+      task_slugs=()
+      for task_path in "$tasks_path"/*(N); do
+        [[ -e "$task_path" ]] || continue
+        task_slugs+=("${task_path:t}")
+      done
+
+      if (( ${#task_slugs} > 0 )); then
+        compadd -Q -a task_slugs
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
+}
+
+compdef _compozy compozy


### PR DESCRIPTION
## Why

  Running `compozy tasks run` in worktrees has a small UX gap: task names are not completed from
  `.compozy/tasks` today, which slows down command entry.

  ## What this adds

  - Adds a zsh completion plugin at `zsh/compozy-completion/compozy-completion.plugin.zsh`.
    - Completes:
      - `compozy` → `tasks`
      - `compozy tasks` → `run`
      - `compozy tasks run` → task slugs from the nearest `.compozy/tasks` folder, walking upward from `$PWD` (supports worktrees).
  - Adds `zsh/compozy-completion/README.md` with:
    - plugin description
    - install snippet
    - quick usage instructions.

  ## Notes

  - Completion is intentionally workspace-aware and does not assume a fixed repo path.
  - No runtime behavior changes in Go/Rust; this is shell-only tooling for local dev ergonomics.

  ## Verification

  - Commit: `7d71e53`
  - `make verify` run attempted.
    - Frontend checks passed.
    - Final `make fmt` step failed in this environment because `golangci-lint` is not installed (`make: golangci-lint: No such file or directory`).

  ## Files

  - `zsh/compozy-completion/compozy-completion.plugin.zsh`
  - `zsh/compozy-completion/README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zsh shell completion plugin for the compozy command.
  * Provides contextual, position-aware auto-completion for task commands (e.g., suggesting tasks and run).
  * Auto-discovers nearest workspace task configuration to list available task names for completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->