### PR TITLE
feat: discover task files recursively in nested subdirectories

### DIFF
--- a/.agents/skills/compozy/SKILL.md
+++ b/.agents/skills/compozy/SKILL.md
@@ -73,7 +73,7 @@ For a detailed step-by-step walkthrough of each phase, read `references/workflow
 | **Workflow Execution** | | |
 | `compozy daemon` | Manage the home-scoped daemon lifecycle | `start`, `status`, `stop` |
 | `compozy workspaces` | Inspect and manage daemon workspace registrations | `list`, `show`, `register`, `unregister`, `resolve` |
-| `compozy tasks run` | Execute PRD task files through the daemon | `--name`, `--attach`, `--ui`, `--stream`, `--detach`, `--task-runtime` |
+| `compozy tasks run` | Execute PRD task files through the daemon | `--name`, `--recursive` / `-r`, `--attach`, `--ui`, `--stream`, `--detach`, `--task-runtime` |
 | `compozy exec` | Execute an ad hoc prompt | `--agent`, `--format`, `--prompt-file`, `--tui`, `--persist`, `--run-id` |
 | `compozy runs` | Attach, watch, and purge daemon-managed runs | `attach`, `watch`, `purge` |
 | **Review** | | |
@@ -172,6 +172,7 @@ types = ["frontend", "backend", "docs", "test", "infra", "refactor", "chore", "b
 
 [tasks.run]
 include_completed = false
+recursive = false
 
 [fix_reviews]
 concurrent = 2

--- a/.agents/skills/compozy/references/cli-reference.md
+++ b/.agents/skills/compozy/references/cli-reference.md
@@ -57,6 +57,7 @@ Execute PRD task files sequentially from a workflow directory through the shared
 | --- | --- | --- | --- |
 | `--name` | string | | Task workflow name (resolves to `.compozy/tasks/<name>`) |
 | `--include-completed` | bool | false | Include tasks already marked as completed |
+| `--recursive`, `-r` | bool | false | Discover `task_NNN.md` files in nested subdirectories of the workflow root |
 | `--skip-validation` | bool | false | Skip task metadata preflight check |
 | `--force` | bool | false | Continue after validation fails in non-interactive mode |
 | `--attach` | string | auto | Attach mode: auto, ui, stream, detach |

--- a/.agents/skills/compozy/references/config-reference.md
+++ b/.agents/skills/compozy/references/config-reference.md
@@ -33,6 +33,7 @@ Options specific to `compozy tasks run`.
 | Field | Type | Description |
 | --- | --- | --- |
 | `include_completed` | bool | Include tasks already marked as completed |
+| `recursive` | bool | Discover `task_NNN.md` files in nested subdirectories. Equivalent to `--recursive` on the CLI |
 | `task_runtime_rules` | `array<table>` | Type-scoped runtime overrides applied after `[defaults]` for `compozy tasks run` |
 
 #### `[[tasks.run.task_runtime_rules]]`
@@ -226,6 +227,7 @@ types = ["frontend", "backend", "docs", "test", "infra", "refactor", "chore", "b
 
 [tasks.run]
 include_completed = false
+recursive = false
 
 [fix_reviews]
 concurrent = 2

--- a/.agents/skills/compozy/references/workflow-guide.md
+++ b/.agents/skills/compozy/references/workflow-guide.md
@@ -83,6 +83,7 @@ Install flow: `compozy ext install --yes compozy/compozy --remote github --ref <
 - `--auto-commit` -- create a local commit after each task completes cleanly.
 - `--dry-run` -- generate prompts without running the IDE tool.
 - `--include-completed` -- re-process tasks already marked as completed.
+- `--recursive` / `-r` -- discover `task_NNN.md` files in nested subdirectories (e.g., `features/auth/task_01.md`). Root tasks run first, then each subdirectory alphabetically, numerically within. Dot- and underscore-prefixed directories, `reviews-*`, `adrs/`, and `memory/` are skipped.
 
 **Interactive mode:** In interactive terminals, `tasks run` attaches to the TUI by default; use `--ui`, `--stream`, `--detach`, or `--attach` to override that behavior.
 

--- a/README.md
+++ b/README.md
@@ -608,6 +608,7 @@ The CLI resolves workspace defaults locally, validates the task metadata, auto-s
 | --------------------- | ------- | ----------------------------------------------------------------------------------- |
 | `--name`              |         | Workflow slug (defaults to the positional slug)                                     |
 | `--include-completed` | `false` | Re-run completed tasks                                                              |
+| `--recursive`, `-r`   | `false` | Discover `task_NNN.md` files in nested subdirectories of the workflow root          |
 | `--skip-validation`   | `false` | Skip task metadata preflight; use only when validation already ran elsewhere        |
 | `--force`             | `false` | Continue after task metadata validation fails in non-interactive mode               |
 | `--attach`            | `auto`  | Attach mode: `auto`, `ui`, `stream`, or `detach`                                    |
@@ -615,6 +616,8 @@ The CLI resolves workspace defaults locally, validates the task metadata, auto-s
 | `--stream`            | `false` | Force textual stream attach mode                                                    |
 | `--detach`            | `false` | Start the run without attaching a client                                            |
 | `--task-runtime`      |         | Per-task runtime override rule (`type=...`, `id=...`, `ide=...`, `model=...`, etc.) |
+
+When `--recursive` is set, tasks are grouped by directory (root tasks first, then each subdirectory in alphabetical order, numerically within), and `_`/`.`-prefixed directories, `reviews-*` rounds, `adrs/`, and `memory/` are skipped. The same setting can be persisted as `[tasks.run] recursive = true` in workspace TOML or chosen from the interactive task-runtime form.
 
 </details>
 

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
 	core "github.com/compozy/compozy/internal/core"
@@ -107,6 +108,25 @@ func TestNewTasksRunCommandDefaultsAttachModeToAuto(t *testing.T) {
 	}
 	if cmd.Flags().Lookup("tui") != nil {
 		t.Fatal("expected tasks run to omit legacy --tui flag")
+	}
+}
+
+func TestNewTasksRunCommandRegistersRecursiveFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := newTasksRunCommandWithDefaults(nil, defaultCommandStateDefaults())
+	flag := cmd.Flags().Lookup("recursive")
+	if flag == nil {
+		t.Fatal("expected --recursive flag on tasks run")
+	}
+	if flag.Shorthand != "r" {
+		t.Fatalf("expected --recursive shorthand %q, got %q", "r", flag.Shorthand)
+	}
+	if flag.DefValue != "false" {
+		t.Fatalf("expected --recursive default false, got %q", flag.DefValue)
+	}
+	if !strings.Contains(flag.Usage, "Recursively discover task_NNN.md") {
+		t.Fatalf("expected --recursive help text to describe nested task discovery, got %q", flag.Usage)
 	}
 }
 

--- a/internal/cli/daemon_commands.go
+++ b/internal/cli/daemon_commands.go
@@ -100,6 +100,7 @@ type daemonRuntimeOverrides struct {
 	Verbose                    *bool                       `json:"verbose,omitempty"`
 	Persist                    *bool                       `json:"persist,omitempty"`
 	IncludeCompleted           *bool                       `json:"include_completed,omitempty"`
+	Recursive                  *bool                       `json:"recursive,omitempty"`
 	TaskRuntimeRules           *[]model.TaskRuntimeRule    `json:"task_runtime_rules,omitempty"`
 	EnableExecutableExtensions *bool                       `json:"enable_executable_extensions,omitempty"`
 }
@@ -276,6 +277,15 @@ is running, and then sends the workflow request over the daemon transport.`,
 	addCommonFlags(cmd, state, commonFlagOptions{})
 	cmd.Flags().StringVar(&state.name, "name", "", "Task workflow slug (defaults to the positional slug)")
 	cmd.Flags().BoolVar(&state.includeCompleted, "include-completed", false, "Include completed tasks")
+	cmd.Flags().BoolVarP(
+		&state.recursive,
+		"recursive",
+		"r",
+		false,
+		"Recursively discover task_NNN.md files in subdirectories. "+
+			"Skips dot-, underscore-prefixed, reviews-*, adrs, and memory directories. "+
+			"Note: DB sync and extension Host API still operate on the slug root only.",
+	)
 	cmd.Flags().BoolVar(
 		&state.skipValidation,
 		"skip-validation",
@@ -509,6 +519,9 @@ func (s *commandState) buildTaskRunRuntimeOverrides(cmd *cobra.Command) (json.Ra
 	})
 	set(commandFlagChanged(cmd, "include-completed"), func() {
 		overrides.IncludeCompleted = boolPointer(s.includeCompleted)
+	})
+	set(commandFlagChanged(cmd, "recursive"), func() {
+		overrides.Recursive = boolPointer(s.recursive)
 	})
 	set(commandFlagChanged(cmd, "task-runtime") || s.replaceConfiguredTaskRunRules, func() {
 		rules := model.CloneTaskRuntimeRules(s.taskRuntimeRules())

--- a/internal/cli/daemon_commands_test.go
+++ b/internal/cli/daemon_commands_test.go
@@ -2134,6 +2134,59 @@ func TestBuildTaskRunRuntimeOverridesIncludesOnlyExplicitFlags(t *testing.T) {
 	}
 }
 
+func TestBuildTaskRunRuntimeOverridesIncludesRecursiveWhenExplicit(t *testing.T) {
+	t.Parallel()
+
+	state := newCommandState(commandKindTasksRun, "")
+	cmd := newTaskRunPresentationCommand(state)
+	addCommonFlags(cmd, state, commonFlagOptions{})
+	cmd.Flags().BoolVarP(&state.recursive, "recursive", "r", false, "recursive discovery")
+
+	if err := cmd.Flags().Set("recursive", "true"); err != nil {
+		t.Fatalf("set recursive: %v", err)
+	}
+	state.recursive = true
+
+	raw, err := state.buildTaskRunRuntimeOverrides(cmd)
+	if err != nil {
+		t.Fatalf("buildTaskRunRuntimeOverrides: %v", err)
+	}
+	overrides := decodeTaskRunOverrides(t, raw)
+	if overrides.Recursive == nil || !*overrides.Recursive {
+		t.Fatalf("expected explicit recursive override, got %#v", overrides)
+	}
+	if overrides.IncludeCompleted != nil {
+		t.Fatalf("expected unset include-completed to remain absent, got %#v", overrides)
+	}
+}
+
+func TestBuildTaskRunRuntimeOverridesOmitsRecursiveWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	state := newCommandState(commandKindTasksRun, "")
+	cmd := newTaskRunPresentationCommand(state)
+	addCommonFlags(cmd, state, commonFlagOptions{})
+	cmd.Flags().BoolVarP(&state.recursive, "recursive", "r", false, "recursive discovery")
+
+	if err := cmd.Flags().Set("dry-run", "true"); err != nil {
+		t.Fatalf("set dry-run: %v", err)
+	}
+	state.dryRun = true
+
+	raw, err := state.buildTaskRunRuntimeOverrides(cmd)
+	if err != nil {
+		t.Fatalf("buildTaskRunRuntimeOverrides: %v", err)
+	}
+	overrides := decodeTaskRunOverrides(t, raw)
+	if overrides.Recursive != nil {
+		t.Fatalf("expected recursive override to remain absent, got %#v", overrides)
+	}
+	rawJSON := string(raw)
+	if containsAll(rawJSON, "\"recursive\"") {
+		t.Fatalf("expected JSON to omit recursive key, got %s", rawJSON)
+	}
+}
+
 func TestBuildTaskRunRuntimeOverridesIncludesAllExplicitRuntimeFlags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/form.go
+++ b/internal/cli/form.go
@@ -69,6 +69,7 @@ type formInputs struct {
 	reasoningEffort   string
 	defineTaskRuntime bool
 	includeCompleted  bool
+	recursive         bool
 	includeResolved   bool
 	dryRun            bool
 	autoCommit        bool
@@ -106,6 +107,7 @@ func newFormInputsFromState(state *commandState) *formInputs {
 	inputs.reasoningEffort = state.reasoningEffort
 	inputs.defineTaskRuntime = len(state.taskRuntimeRules()) > 0
 	inputs.includeCompleted = state.includeCompleted
+	inputs.recursive = state.recursive
 	inputs.includeResolved = state.includeResolved
 	inputs.dryRun = state.dryRun
 	inputs.autoCommit = state.autoCommit
@@ -154,6 +156,12 @@ func (fi *formInputs) register(builder *formBuilder) {
 		&fi.includeCompleted,
 	)
 	builder.addConfirmField(
+		"recursive",
+		"Recursive Task Discovery?",
+		"Discover task_NNN.md files in nested subdirectories",
+		&fi.recursive,
+	)
+	builder.addConfirmField(
 		"include-resolved",
 		"Include Resolved Review Issues?",
 		"Process issues already marked as resolved",
@@ -180,6 +188,9 @@ func (fi *formInputs) apply(cmd *cobra.Command, state *commandState) {
 	applyInput(cmd, "auto-commit", fi.autoCommit, passThroughInput[bool], func(val bool) { state.autoCommit = val })
 	applyInput(cmd, "include-completed", fi.includeCompleted, passThroughInput[bool], func(val bool) {
 		state.includeCompleted = val
+	})
+	applyInput(cmd, "recursive", fi.recursive, passThroughInput[bool], func(val bool) {
+		state.recursive = val
 	})
 	applyInput(cmd, "include-resolved", fi.includeResolved, passThroughInput[bool], func(val bool) {
 		state.includeResolved = val

--- a/internal/cli/form_test.go
+++ b/internal/cli/form_test.go
@@ -418,6 +418,80 @@ func TestTaskRunRuntimeFormPreseedsConfiguredTypeRules(t *testing.T) {
 	})
 }
 
+func TestTaskRuntimeFormUsesRecursiveWalkerWhenEnabled(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	tasksDir := filepath.Join(workspaceRoot, ".compozy", "tasks", "demo")
+	nestedDir := filepath.Join(tasksDir, "features", "auth")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+	writeFormTaskFile(t, tasksDir, "task_01.md", "pending")
+	writeFormTaskFile(t, nestedDir, "task_01.md", "pending")
+
+	entries, err := readTaskRuntimeFormEntries(tasksDir, false, true)
+	if err != nil {
+		t.Fatalf("readTaskRuntimeFormEntries(recursive=true): %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("recursive walker should discover root + nested entries, got %d: %#v", len(entries), entries)
+	}
+
+	state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
+	state.workspaceRoot = workspaceRoot
+	state.name = "demo"
+	state.recursive = true
+
+	form, err := newTaskRunRuntimeForm(state)
+	if err != nil {
+		t.Fatalf("newTaskRunRuntimeForm() error = %v", err)
+	}
+	if form == nil {
+		t.Fatal("expected task runtime form")
+	}
+	if len(form.taskOptions) != 2 {
+		t.Fatalf("expected recursive form to discover 2 tasks, got %d: %#v", len(form.taskOptions), form.taskOptions)
+	}
+}
+
+func TestTaskRuntimeFormUsesFlatWalkerByDefault(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	tasksDir := filepath.Join(workspaceRoot, ".compozy", "tasks", "demo")
+	nestedDir := filepath.Join(tasksDir, "features", "auth")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested dir: %v", err)
+	}
+	writeFormTaskFile(t, tasksDir, "task_01.md", "pending")
+	writeFormTaskFile(t, nestedDir, "task_01.md", "pending")
+
+	entries, err := readTaskRuntimeFormEntries(tasksDir, false, false)
+	if err != nil {
+		t.Fatalf("readTaskRuntimeFormEntries(recursive=false): %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("flat walker should ignore nested entries, got %d: %#v", len(entries), entries)
+	}
+
+	state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
+	state.workspaceRoot = workspaceRoot
+	state.name = "demo"
+	state.recursive = false
+
+	form, err := newTaskRunRuntimeForm(state)
+	if err != nil {
+		t.Fatalf("newTaskRunRuntimeForm() error = %v", err)
+	}
+	if form == nil {
+		t.Fatal("expected task runtime form")
+	}
+	if len(form.taskOptions) != 1 {
+		t.Fatalf("expected flat form to discover 1 task, got %d: %#v", len(form.taskOptions), form.taskOptions)
+	}
+}
+
 func TestClearTaskRunRuntimeRulesRemovesConfiguredAndExecutionRules(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/kernel_dispatch_test.go
+++ b/internal/cli/kernel_dispatch_test.go
@@ -150,6 +150,43 @@ func TestNewRunWorkflowDispatchesStartCommand(t *testing.T) {
 	}
 }
 
+func TestNewRunWorkflowPassesRecursiveFlagThroughKernel(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := kernel.NewDispatcher()
+	handler := &runStartCaptureHandler{}
+	kernel.Register(dispatcher, handler)
+
+	runWorkflow := newRunWorkflow(dispatcher)
+	if err := runWorkflow(context.Background(), core.Config{
+		WorkspaceRoot:          "/workspace",
+		Name:                   "demo",
+		TasksDir:               "/workspace/.compozy/tasks/demo",
+		Recursive:              true,
+		Mode:                   core.ModePRDTasks,
+		IDE:                    core.IDECodex,
+		Concurrent:             1,
+		BatchSize:              1,
+		ReasoningEffort:        "medium",
+		AccessMode:             core.AccessModeFull,
+		Timeout:                time.Minute,
+		MaxRetries:             0,
+		RetryBackoffMultiplier: 1.5,
+	}); err != nil {
+		t.Fatalf("runWorkflow: %v", err)
+	}
+	if !handler.called {
+		t.Fatal("expected dispatcher handler to be called")
+	}
+	runtime := handler.got.RuntimeConfig()
+	if runtime == nil {
+		t.Fatal("expected runtime config")
+	}
+	if !runtime.Recursive {
+		t.Fatalf("expected runtime.Recursive=true, got %#v", runtime)
+	}
+}
+
 func TestNewRunWorkflowUsesPRReviewModeForFixReviews(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1859,6 +1859,107 @@ func TestRunPreparedStartNonInteractiveValidationFailureBlocksWorkflow(t *testin
 	}
 }
 
+func TestRunPreparedStartFlatValidationIgnoresNestedDrafts(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot, tasksDir := makeValidateTasksWorkspace(t, "demo")
+	writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
+		[]string{"status: pending", "title: Root", "type: backend", "complexity: low"},
+		"# Root",
+	))
+	nestedDir := filepath.Join(tasksDir, "features", "auth")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writeRawTaskFileForCLI(t, nestedDir, "task_01.md", cliTaskMarkdown(
+		[]string{"status: pending", "type: backend", "complexity: low"},
+		"# Nested Draft",
+	))
+
+	state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
+	allowBundledSkillsForStartTest(state)
+	state.isInteractive = func() bool { return false }
+	state.workspaceRoot = workspaceRoot
+
+	runnerCalled := false
+	state.runWorkflow = func(context.Context, core.Config) error {
+		runnerCalled = true
+		return nil
+	}
+
+	cmd := newTestCommand(state)
+	cmd.Use = "start"
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	err := state.runPrepared(context.Background(), cmd, core.Config{
+		IDE:      core.IDECodex,
+		Mode:     core.ModePRDTasks,
+		TasksDir: tasksDir,
+	})
+	if err != nil {
+		t.Fatalf("runPrepared flat validation: %v", err)
+	}
+	if !runnerCalled {
+		t.Fatal("expected workflow runner when nested draft is outside flat discovery")
+	}
+	if !strings.Contains(output.String(), "preflight=ok") {
+		t.Fatalf("expected ok preflight log, got %q", output.String())
+	}
+}
+
+func TestRunPreparedStartRecursiveValidationChecksNestedTasks(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot, tasksDir := makeValidateTasksWorkspace(t, "demo")
+	writeRawTaskFileForCLI(t, tasksDir, "task_01.md", cliTaskMarkdown(
+		[]string{"status: pending", "title: Root", "type: backend", "complexity: low"},
+		"# Root",
+	))
+	nestedDir := filepath.Join(tasksDir, "features", "auth")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writeRawTaskFileForCLI(t, nestedDir, "task_01.md", cliTaskMarkdown(
+		[]string{"status: pending", "type: backend", "complexity: low"},
+		"# Nested Draft",
+	))
+
+	state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
+	allowBundledSkillsForStartTest(state)
+	state.isInteractive = func() bool { return false }
+	state.workspaceRoot = workspaceRoot
+
+	runnerCalled := false
+	state.runWorkflow = func(context.Context, core.Config) error {
+		runnerCalled = true
+		return nil
+	}
+
+	cmd := newTestCommand(state)
+	cmd.Use = "start"
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+
+	err := state.runPrepared(context.Background(), cmd, core.Config{
+		IDE:       core.IDECodex,
+		Mode:      core.ModePRDTasks,
+		TasksDir:  tasksDir,
+		Recursive: true,
+	})
+	if err == nil {
+		t.Fatal("expected recursive task validation failure")
+	}
+	if runnerCalled {
+		t.Fatal("did not expect workflow runner when recursive preflight aborts")
+	}
+	if !strings.Contains(output.String(), "title is required") {
+		t.Fatalf("expected nested validation issue in output, got %q", output.String())
+	}
+}
+
 func TestRunPreparedStartNonInteractiveForceContinuesPastValidationFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -217,6 +217,7 @@ func (s *commandState) preflightTaskMetadata(ctx context.Context, cmd *cobra.Com
 	preflightCfg := coreRun.PreflightConfig{
 		Force:          s.force,
 		SkipValidation: s.skipValidation,
+		Recursive:      cfg.Recursive,
 		IsInteractive:  s.isInteractive,
 		Stderr:         cmd.ErrOrStderr(),
 		Logger:         slog.New(slog.NewTextHandler(cmd.ErrOrStderr(), nil)),

--- a/internal/cli/state.go
+++ b/internal/cli/state.go
@@ -54,6 +54,7 @@ type runtimeConfig struct {
 	executionTaskRuntimeRules     []model.TaskRuntimeRule
 	replaceConfiguredTaskRunRules bool
 	includeCompleted              bool
+	recursive                     bool
 	includeResolved               bool
 	soundEnabled                  bool
 	soundOnCompleted              string
@@ -324,6 +325,7 @@ func (s *commandState) buildConfig() (core.Config, error) {
 		ExplicitRuntime:  s.explicitRuntime,
 		TaskRuntimeRules: s.taskRuntimeRules(),
 		IncludeCompleted: s.includeCompleted,
+		Recursive:        s.recursive,
 		IncludeResolved:  s.includeResolved,
 
 		Mode:                       s.mode,

--- a/internal/cli/task_runtime_form.go
+++ b/internal/cli/task_runtime_form.go
@@ -55,12 +55,19 @@ func collectTaskRunRuntimeForm(cmd *cobra.Command, state *commandState) error {
 	return nil
 }
 
+func readTaskRuntimeFormEntries(tasksDir string, includeCompleted, recursive bool) ([]model.IssueEntry, error) {
+	if recursive {
+		return tasks.ReadTaskEntriesRecursive(tasksDir, includeCompleted)
+	}
+	return tasks.ReadTaskEntries(tasksDir, includeCompleted)
+}
+
 func newTaskRunRuntimeForm(state *commandState) (*taskRunRuntimeForm, error) {
 	tasksDir, err := resolveTaskWorkflowDir(state.workspaceRoot, state.name, state.tasksDir)
 	if err != nil {
 		return nil, err
 	}
-	entries, err := tasks.ReadTaskEntries(tasksDir, state.includeCompleted)
+	entries, err := readTaskRuntimeFormEntries(tasksDir, state.includeCompleted, state.recursive)
 	if err != nil {
 		return nil, fmt.Errorf("read task entries for runtime overrides: %w", err)
 	}

--- a/internal/cli/testdata/tasks_run_help.golden
+++ b/internal/cli/testdata/tasks_run_help.golden
@@ -27,6 +27,7 @@ Flags:
       --model string                     Model to use. Leave empty to use the selected runtime default.
       --name string                      Task workflow slug (defaults to the positional slug)
       --reasoning-effort string          Reasoning effort for runtimes that support bootstrap reasoning flags (low, medium, high, xhigh). (default "medium")
+  -r, --recursive                        Recursively discover task_NNN.md files in subdirectories. Skips dot-, underscore-prefixed, reviews-*, adrs, and memory directories. Note: DB sync and extension Host API still operate on the slug root only.
       --retry-backoff-multiplier float   Multiplier applied to the next activity timeout after each retry (default 1.5)
       --skip-validation                  Skip task metadata preflight; use only when tasks were validated separately
       --stream                           Force textual stream attach mode

--- a/internal/cli/workspace_config.go
+++ b/internal/cli/workspace_config.go
@@ -128,18 +128,7 @@ func (s *commandState) applyProjectConfig(cmd *cobra.Command, cfg workspace.Proj
 
 	switch s.kind {
 	case commandKindTasksRun:
-		applyConfig(cmd, "attach", cfg.Runs.DefaultAttachMode, func(val string) { s.attachMode = val })
-		applyConfig(cmd, "format", cfg.Tasks.Run.OutputFormat, func(val string) { s.outputFormat = val })
-		applyConfig(cmd, "tui", cfg.Tasks.Run.TUI, func(val bool) { s.tui = val })
-		s.configuredTaskRuntimeRules = model.CloneTaskRuntimeRules(
-			derefTaskRuntimeRulesConfig(cfg.Tasks.Run.TaskRuntimeRules),
-		)
-		applyConfig(
-			cmd,
-			"include-completed",
-			cfg.Tasks.Run.IncludeCompleted,
-			func(val bool) { s.includeCompleted = val },
-		)
+		s.applyTasksRunConfig(cmd, cfg)
 	case commandKindFixReviews:
 		applyConfig(cmd, "format", cfg.FixReviews.OutputFormat, func(val string) { s.outputFormat = val })
 		applyConfig(cmd, "tui", cfg.FixReviews.TUI, func(val bool) { s.tui = val })
@@ -181,6 +170,27 @@ func (s *commandState) applyProjectConfig(cmd *cobra.Command, cfg workspace.Proj
 			func(val float64) { s.retryBackoffMultiplier = val },
 		)
 	}
+}
+
+func (s *commandState) applyTasksRunConfig(cmd *cobra.Command, cfg workspace.ProjectConfig) {
+	applyConfig(cmd, "attach", cfg.Runs.DefaultAttachMode, func(val string) { s.attachMode = val })
+	applyConfig(cmd, "format", cfg.Tasks.Run.OutputFormat, func(val string) { s.outputFormat = val })
+	applyConfig(cmd, "tui", cfg.Tasks.Run.TUI, func(val bool) { s.tui = val })
+	s.configuredTaskRuntimeRules = model.CloneTaskRuntimeRules(
+		derefTaskRuntimeRulesConfig(cfg.Tasks.Run.TaskRuntimeRules),
+	)
+	applyConfig(
+		cmd,
+		"include-completed",
+		cfg.Tasks.Run.IncludeCompleted,
+		func(val bool) { s.includeCompleted = val },
+	)
+	applyConfig(
+		cmd,
+		"recursive",
+		cfg.Tasks.Run.Recursive,
+		func(val bool) { s.recursive = val },
+	)
 }
 
 func (s *commandState) applyWatchReviewsConfig(cmd *cobra.Command, cfg workspace.ProjectConfig) {

--- a/internal/cli/workspace_config_test.go
+++ b/internal/cli/workspace_config_test.go
@@ -713,6 +713,62 @@ output_format = "text"
 	}
 }
 
+func TestApplyConfigRecursivePopulatesState(t *testing.T) {
+	isolateCLIConfigHome(t)
+	root := t.TempDir()
+	startDir := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("mkdir start dir: %v", err)
+	}
+	writeCLIWorkspaceConfig(t, root, `
+[tasks.run]
+recursive = true
+`)
+
+	state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
+	cmd := newTestCommand(state)
+	cmd.Flags().BoolVarP(&state.recursive, "recursive", "r", false, "recursive discovery")
+
+	chdirCLITest(t, startDir)
+
+	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
+		t.Fatalf("apply workspace defaults: %v", err)
+	}
+	if !state.recursive {
+		t.Fatal("expected tasks.run.recursive=true to populate state.recursive")
+	}
+}
+
+func TestApplyConfigRecursiveRespectsExplicitFlag(t *testing.T) {
+	isolateCLIConfigHome(t)
+	root := t.TempDir()
+	startDir := filepath.Join(root, "pkg", "feature")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatalf("mkdir start dir: %v", err)
+	}
+	writeCLIWorkspaceConfig(t, root, `
+[tasks.run]
+recursive = true
+`)
+
+	state := newCommandState(commandKindTasksRun, core.ModePRDTasks)
+	cmd := newTestCommand(state)
+	cmd.Flags().BoolVarP(&state.recursive, "recursive", "r", false, "recursive discovery")
+
+	chdirCLITest(t, startDir)
+
+	if err := cmd.Flags().Set("recursive", "false"); err != nil {
+		t.Fatalf("set recursive: %v", err)
+	}
+
+	if err := state.applyWorkspaceDefaults(context.Background(), cmd); err != nil {
+		t.Fatalf("apply workspace defaults: %v", err)
+	}
+	if state.recursive {
+		t.Fatal("expected explicit --recursive=false flag to win over TOML")
+	}
+}
+
 func TestApplyWorkspaceDefaultsKeepsWorkspaceDefaultsAheadOfGlobalExecOverrides(t *testing.T) {
 	root := t.TempDir()
 	homeDir := isolateCLIConfigHome(t)

--- a/internal/core/api.go
+++ b/internal/core/api.go
@@ -126,6 +126,7 @@ type Config struct {
 	ReadPromptStdin            bool
 	ResolvedPromptText         string
 	IncludeCompleted           bool
+	Recursive                  bool
 	IncludeResolved            bool
 	Timeout                    time.Duration
 	MaxRetries                 int
@@ -369,6 +370,7 @@ func (cfg Config) RuntimeConfig() *model.RuntimeConfig {
 		ReadPromptStdin:            cfg.ReadPromptStdin,
 		ResolvedPromptText:         cfg.ResolvedPromptText,
 		IncludeCompleted:           cfg.IncludeCompleted,
+		Recursive:                  cfg.Recursive,
 		IncludeResolved:            cfg.IncludeResolved,
 		Timeout:                    cfg.Timeout,
 		MaxRetries:                 cfg.MaxRetries,

--- a/internal/core/memory/store.go
+++ b/internal/core/memory/store.go
@@ -57,7 +57,11 @@ func WorkflowPath(tasksDir string) string {
 }
 
 func TaskPath(tasksDir, taskFileName string) string {
-	return filepath.Join(Directory(tasksDir), filepath.Base(taskFileName))
+	rel := sanitizeTaskMemoryRelpath(taskFileName)
+	if rel == "" {
+		return Directory(tasksDir)
+	}
+	return filepath.Join(Directory(tasksDir), filepath.FromSlash(rel))
 }
 
 func ResolveDocumentPath(tasksDir, taskFileName string) string {
@@ -65,6 +69,49 @@ func ResolveDocumentPath(tasksDir, taskFileName string) string {
 		return WorkflowPath(tasksDir)
 	}
 	return TaskPath(tasksDir, taskFileName)
+}
+
+func sanitizeTaskMemoryRelpath(taskFileName string) string {
+	trimmed := strings.TrimSpace(taskFileName)
+	if trimmed == "" {
+		return ""
+	}
+	clean := filepath.ToSlash(strings.ReplaceAll(trimmed, `\`, "/"))
+	parts := make([]string, 0, strings.Count(clean, "/")+1)
+	for _, seg := range strings.Split(clean, "/") {
+		seg = strings.TrimSpace(seg)
+		if seg == "" || seg == "." || seg == ".." {
+			continue
+		}
+		parts = append(parts, seg)
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "/")
+}
+
+func validateTaskMemoryRelpath(taskFileName string) (string, error) {
+	trimmed := strings.TrimSpace(taskFileName)
+	if trimmed == "" {
+		return "", fmt.Errorf("task file name is required")
+	}
+	clean := filepath.ToSlash(strings.ReplaceAll(trimmed, `\`, "/"))
+	if strings.HasPrefix(clean, "/") {
+		return "", fmt.Errorf("task file name %q: leading slash not allowed", taskFileName)
+	}
+	for _, seg := range strings.Split(clean, "/") {
+		if seg == "" {
+			return "", fmt.Errorf("task file name %q: empty path segment", taskFileName)
+		}
+		if seg == ".." {
+			return "", fmt.Errorf("task file name %q: %q segment not allowed", taskFileName, "..")
+		}
+	}
+	if filepath.Base(clean) == "." {
+		return "", fmt.Errorf("task file name %q: missing basename", taskFileName)
+	}
+	return clean, nil
 }
 
 func ReadDocument(tasksDir, taskFileName string) (Document, error) {
@@ -99,6 +146,9 @@ func WriteDocument(tasksDir, taskFileName, content string, mode WriteMode) (Docu
 	}
 
 	path := ResolveDocumentPath(tasksDir, taskFileName)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return Document{}, 0, fmt.Errorf("prepare memory document dir: %w", err)
+	}
 	finalContent, err := renderedDocumentContent(path, content, mode)
 	if err != nil {
 		return Document{}, 0, err
@@ -116,9 +166,9 @@ func WriteDocument(tasksDir, taskFileName, content string, mode WriteMode) (Docu
 }
 
 func Prepare(tasksDir, taskFileName string) (Context, error) {
-	taskBase := filepath.Base(strings.TrimSpace(taskFileName))
-	if taskBase == "" || taskBase == "." {
-		return Context{}, fmt.Errorf("prepare workflow memory: task file name is required")
+	rel, err := validateTaskMemoryRelpath(taskFileName)
+	if err != nil {
+		return Context{}, fmt.Errorf("prepare workflow memory: %w", err)
 	}
 
 	dir := Directory(tasksDir)
@@ -131,8 +181,11 @@ func Prepare(tasksDir, taskFileName string) (Context, error) {
 		return Context{}, fmt.Errorf("bootstrap workflow memory: %w", err)
 	}
 
-	taskPath := TaskPath(tasksDir, taskBase)
-	if err := writeIfMissing(taskPath, taskTemplate(taskBase)); err != nil {
+	taskPath := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(taskPath), 0o755); err != nil {
+		return Context{}, fmt.Errorf("prepare task memory dir: %w", err)
+	}
+	if err := writeIfMissing(taskPath, taskTemplate(filepath.Base(rel))); err != nil {
 		return Context{}, fmt.Errorf("bootstrap task memory: %w", err)
 	}
 

--- a/internal/core/memory/store.go
+++ b/internal/core/memory/store.go
@@ -71,6 +71,12 @@ func ResolveDocumentPath(tasksDir, taskFileName string) string {
 	return TaskPath(tasksDir, taskFileName)
 }
 
+// sanitizeTaskMemoryRelpath normalizes a task file name into a forward-slash
+// relative path for nested workflow memory layouts. It trims surrounding
+// whitespace, converts backslashes to forward slashes, and silently drops
+// empty, ".", and ".." segments. Callers needing strict validation (with
+// errors on traversal attempts or missing basenames) should use
+// validateTaskMemoryRelpath instead.
 func sanitizeTaskMemoryRelpath(taskFileName string) string {
 	trimmed := strings.TrimSpace(taskFileName)
 	if trimmed == "" {

--- a/internal/core/memory/store.go
+++ b/internal/core/memory/store.go
@@ -71,12 +71,6 @@ func ResolveDocumentPath(tasksDir, taskFileName string) string {
 	return TaskPath(tasksDir, taskFileName)
 }
 
-// sanitizeTaskMemoryRelpath normalizes a task file name into a forward-slash
-// relative path for nested workflow memory layouts. It trims surrounding
-// whitespace, converts backslashes to forward slashes, and silently drops
-// empty, ".", and ".." segments. Callers needing strict validation (with
-// errors on traversal attempts or missing basenames) should use
-// validateTaskMemoryRelpath instead.
 func sanitizeTaskMemoryRelpath(taskFileName string) string {
 	trimmed := strings.TrimSpace(taskFileName)
 	if trimmed == "" {

--- a/internal/core/memory/store_test.go
+++ b/internal/core/memory/store_test.go
@@ -114,3 +114,114 @@ func TestPrepareFlagsCompactionForOversizedFiles(t *testing.T) {
 		t.Fatalf("expected task memory to require compaction")
 	}
 }
+
+func TestPrepareCreatesDistinctMemoryFilesForNestedRelpath(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+
+	authCtx, err := Prepare(tasksDir, "features/auth/task_01.md")
+	if err != nil {
+		t.Fatalf("prepare auth memory: %v", err)
+	}
+	payCtx, err := Prepare(tasksDir, "features/payment/task_01.md")
+	if err != nil {
+		t.Fatalf("prepare payment memory: %v", err)
+	}
+	rootCtx, err := Prepare(tasksDir, "task_01.md")
+	if err != nil {
+		t.Fatalf("prepare root memory: %v", err)
+	}
+
+	wantAuth := filepath.Join(tasksDir, DirName, "features", "auth", "task_01.md")
+	wantPay := filepath.Join(tasksDir, DirName, "features", "payment", "task_01.md")
+	wantRoot := filepath.Join(tasksDir, DirName, "task_01.md")
+	if authCtx.Task.Path != wantAuth {
+		t.Fatalf("auth memory path = %q, want %q", authCtx.Task.Path, wantAuth)
+	}
+	if payCtx.Task.Path != wantPay {
+		t.Fatalf("payment memory path = %q, want %q", payCtx.Task.Path, wantPay)
+	}
+	if rootCtx.Task.Path != wantRoot {
+		t.Fatalf("root memory path = %q, want %q", rootCtx.Task.Path, wantRoot)
+	}
+
+	if authCtx.Task.Path == payCtx.Task.Path {
+		t.Fatal("expected nested tasks with the same basename to use distinct memory files")
+	}
+	if authCtx.Task.Path == rootCtx.Task.Path {
+		t.Fatal("expected nested and root tasks to use distinct memory files")
+	}
+
+	authBody, err := os.ReadFile(authCtx.Task.Path)
+	if err != nil {
+		t.Fatalf("read auth memory: %v", err)
+	}
+	if !strings.Contains(string(authBody), taskHeaderPrefix+"task_01.md") {
+		t.Fatalf("expected auth memory header to use basename, got %q", string(authBody))
+	}
+}
+
+func TestPrepareNormalizesBackslashRelpath(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	ctx, err := Prepare(tasksDir, `features\auth\task_01.md`)
+	if err != nil {
+		t.Fatalf("prepare memory: %v", err)
+	}
+	want := filepath.Join(tasksDir, DirName, "features", "auth", "task_01.md")
+	if ctx.Task.Path != want {
+		t.Fatalf("task memory path = %q, want %q", ctx.Task.Path, want)
+	}
+}
+
+func TestPrepareRejectsUnsafeRelpaths(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input  string
+		needle string
+	}{
+		{"", "task file name is required"},
+		{"   ", "task file name is required"},
+		{"/task_01.md", "leading slash not allowed"},
+		{"../task_01.md", `".." segment not allowed`},
+		{"features/../task_01.md", `".." segment not allowed`},
+		{"features//task_01.md", "empty path segment"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			_, err := Prepare(t.TempDir(), tc.input)
+			if err == nil {
+				t.Fatalf("expected error for input %q", tc.input)
+			}
+			if !strings.Contains(err.Error(), tc.needle) {
+				t.Fatalf("error %v should contain %q", err, tc.needle)
+			}
+		})
+	}
+}
+
+func TestWriteDocumentCreatesNestedDirectories(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	doc, _, err := WriteDocument(tasksDir, "features/auth/task_01.md", "hello\n", WriteModeReplace)
+	if err != nil {
+		t.Fatalf("write document: %v", err)
+	}
+	want := filepath.Join(tasksDir, DirName, "features", "auth", "task_01.md")
+	if doc.Path != want {
+		t.Fatalf("document path = %q, want %q", doc.Path, want)
+	}
+	body, err := os.ReadFile(want)
+	if err != nil {
+		t.Fatalf("read nested memory: %v", err)
+	}
+	if string(body) != "hello\n" {
+		t.Fatalf("unexpected body: %q", string(body))
+	}
+}

--- a/internal/core/model/runtime_config.go
+++ b/internal/core/model/runtime_config.go
@@ -50,6 +50,7 @@ type RuntimeConfig struct {
 	ReadPromptStdin            bool
 	ResolvedPromptText         string
 	IncludeCompleted           bool
+	Recursive                  bool
 	IncludeResolved            bool
 	Timeout                    time.Duration
 	MaxRetries                 int

--- a/internal/core/plan/input.go
+++ b/internal/core/plan/input.go
@@ -215,14 +215,18 @@ func readIssueEntries(
 	resolvedInputDir string,
 	mode model.ExecutionMode,
 	includeCompleted bool,
+	recursive bool,
 ) ([]model.IssueEntry, error) {
 	if mode == model.ExecutionModePRDTasks {
-		return readTaskEntries(resolvedInputDir, includeCompleted)
+		return readTaskEntries(resolvedInputDir, includeCompleted, recursive)
 	}
 	return reviews.ReadReviewEntries(resolvedInputDir)
 }
 
-func readTaskEntries(tasksDir string, includeCompleted bool) ([]model.IssueEntry, error) {
+func readTaskEntries(tasksDir string, includeCompleted, recursive bool) ([]model.IssueEntry, error) {
+	if recursive {
+		return tasks.ReadTaskEntriesRecursive(tasksDir, includeCompleted)
+	}
 	return tasks.ReadTaskEntries(tasksDir, includeCompleted)
 }
 

--- a/internal/core/plan/prepare.go
+++ b/internal/core/plan/prepare.go
@@ -223,7 +223,7 @@ func resolvePreparedEntries(
 		return nil, err
 	}
 
-	entries, err := readIssueEntries(prep.InputDirPath, cfg.Mode, cfg.IncludeCompleted)
+	entries, err := readIssueEntries(prep.InputDirPath, cfg.Mode, cfg.IncludeCompleted, cfg.Recursive)
 	if err != nil {
 		return nil, err
 	}
@@ -1079,7 +1079,7 @@ func readExtraIssueEntries(
 		if err != nil {
 			return nil, fmt.Errorf("resolve extra issue source %q: %w", source, err)
 		}
-		items, err := readIssueEntriesFromSource(resolvedSource, cfg.Mode, cfg.IncludeCompleted)
+		items, err := readIssueEntriesFromSource(resolvedSource, cfg.Mode, cfg.IncludeCompleted, cfg.Recursive)
 		if err != nil {
 			return nil, fmt.Errorf("read extra issue source %q: %w", source, err)
 		}
@@ -1106,17 +1106,18 @@ func readIssueEntriesFromSource(
 	resolvedSource string,
 	mode model.ExecutionMode,
 	includeCompleted bool,
+	recursive bool,
 ) ([]model.IssueEntry, error) {
 	info, err := os.Stat(resolvedSource)
 	if err != nil {
 		return nil, err
 	}
 	if info.IsDir() {
-		return readIssueEntries(resolvedSource, mode, includeCompleted)
+		return readIssueEntries(resolvedSource, mode, includeCompleted, recursive)
 	}
 
 	parent := filepath.Dir(resolvedSource)
-	entries, err := readIssueEntries(parent, mode, includeCompleted)
+	entries, err := readIssueEntries(parent, mode, includeCompleted, recursive)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/core/plan/prepare_test.go
+++ b/internal/core/plan/prepare_test.go
@@ -38,7 +38,7 @@ func TestReadTaskEntriesSortsNumericallyAndFiltersCompleted(t *testing.T) {
 		}
 	}
 
-	entries, err := readTaskEntries(dir, false)
+	entries, err := readTaskEntries(dir, false, false)
 	if err != nil {
 		t.Fatalf("readTaskEntries: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestValidateAndFilterEntriesReportsCompletedTaskWorkflowsSeparately(t *test
 		t.Fatalf("refresh task meta: %v", err)
 	}
 
-	entries, err := readTaskEntries(dir, false)
+	entries, err := readTaskEntries(dir, false, false)
 	if err != nil {
 		t.Fatalf("readTaskEntries: %v", err)
 	}
@@ -157,7 +157,7 @@ func TestValidateAndFilterEntriesKeepsEmptyTaskDirectoriesDistinct(t *testing.T)
 		t.Fatalf("refresh task meta: %v", err)
 	}
 
-	entries, err := readTaskEntries(dir, false)
+	entries, err := readTaskEntries(dir, false, false)
 	if err != nil {
 		t.Fatalf("readTaskEntries: %v", err)
 	}
@@ -227,7 +227,7 @@ complexity: low
 		t.Fatalf("write v1 task: %v", err)
 	}
 
-	_, err := readTaskEntries(dir, false)
+	_, err := readTaskEntries(dir, false, false)
 	if err == nil {
 		t.Fatal("expected readTaskEntries to fail for v1 task metadata")
 	}
@@ -1908,4 +1908,183 @@ func filterHooksByPrefix(hooks []string, prefix string) []string {
 		}
 	}
 	return filtered
+}
+
+func writeRecursiveTaskFixture(t *testing.T, tasksDir string) {
+	t.Helper()
+	body := "---\nstatus: pending\ntitle: %s\ntype: backend\ncomplexity: low\n---\n\n# %s\n"
+	files := map[string]string{
+		filepath.Join(tasksDir, "task_01.md"):                        "root",
+		filepath.Join(tasksDir, "features", "auth", "task_01.md"):    "auth",
+		filepath.Join(tasksDir, "features", "payment", "task_01.md"): "payment",
+	}
+	for path, label := range files {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		content := fmt.Sprintf(body, label, label)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+}
+
+func TestReadIssueEntriesBranchesOnRecursive(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	writeRecursiveTaskFixture(t, tasksDir)
+
+	cases := []struct {
+		name      string
+		recursive bool
+		wantNames []string
+	}{
+		{
+			name:      "flat ignores nested directories",
+			recursive: false,
+			wantNames: []string{"task_01.md"},
+		},
+		{
+			name:      "recursive discovers nested directories",
+			recursive: true,
+			wantNames: []string{
+				"task_01.md",
+				"features/auth/task_01.md",
+				"features/payment/task_01.md",
+			},
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			entries, err := readIssueEntries(tasksDir, model.ExecutionModePRDTasks, false, tc.recursive)
+			if err != nil {
+				t.Fatalf("readIssueEntries: %v", err)
+			}
+			gotNames := make([]string, 0, len(entries))
+			for _, entry := range entries {
+				gotNames = append(gotNames, entry.Name)
+			}
+			if !reflect.DeepEqual(gotNames, tc.wantNames) {
+				t.Fatalf("unexpected entry order\nwant: %#v\ngot:  %#v", tc.wantNames, gotNames)
+			}
+		})
+	}
+}
+
+func resolvePreparedEntriesForTest(
+	t *testing.T,
+	cfg *model.RuntimeConfig,
+) ([]model.IssueEntry, *model.SolvePreparation) {
+	t.Helper()
+	scope := openRunScopeForTest(t, cfg)
+	prep := &model.SolvePreparation{}
+	prep.RunArtifacts = scope.RunArtifacts()
+	prep.SetRunScope(scope)
+	entries, err := resolvePreparedEntries(context.Background(), prep, cfg)
+	if err != nil {
+		closePreparedJournalForTest(t, prep)
+		t.Fatalf("resolvePreparedEntries: %v", err)
+	}
+	t.Cleanup(func() { closePreparedJournalForTest(t, prep) })
+	return entries, prep
+}
+
+func TestResolvePreparedEntriesDiscoversNestedTasksWhenRecursive(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	tasksDir := filepath.Join(workspaceRoot, model.TasksBaseDir(), "demo")
+	writeRecursiveTaskFixture(t, tasksDir)
+
+	cfg := &model.RuntimeConfig{
+		Name:          "demo",
+		WorkspaceRoot: workspaceRoot,
+		DryRun:        true,
+		IDE:           model.IDECodex,
+		Mode:          model.ExecutionModePRDTasks,
+		Recursive:     true,
+	}
+	entries, _ := resolvePreparedEntriesForTest(t, cfg)
+
+	wantNames := []string{
+		"task_01.md",
+		"features/auth/task_01.md",
+		"features/payment/task_01.md",
+	}
+	gotNames := make([]string, 0, len(entries))
+	codeFiles := make(map[string]struct{}, len(entries))
+	for _, entry := range entries {
+		gotNames = append(gotNames, entry.Name)
+		codeFiles[entry.CodeFile] = struct{}{}
+	}
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("unexpected entry order\nwant: %#v\ngot:  %#v", wantNames, gotNames)
+	}
+	if len(codeFiles) != len(entries) {
+		t.Fatalf("expected unique CodeFile per nested task, got %d unique for %d entries", len(codeFiles), len(entries))
+	}
+}
+
+func TestPreparePRDTasksRecursivePreservesDirectoryGroupedOrder(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	tasksDir := filepath.Join(workspaceRoot, model.TasksBaseDir(), "demo")
+	writeRecursiveTaskFixture(t, tasksDir)
+
+	cfg := &model.RuntimeConfig{
+		Name:          "demo",
+		WorkspaceRoot: workspaceRoot,
+		DryRun:        true,
+		IDE:           model.IDECodex,
+		Mode:          model.ExecutionModePRDTasks,
+		Recursive:     true,
+	}
+	scope := openRunScopeForTest(t, cfg)
+	prep, err := Prepare(context.Background(), cfg, scope)
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	defer closePreparedJournalForTest(t, prep)
+
+	gotCodeFiles := make([][]string, 0, len(prep.Jobs))
+	for _, job := range prep.Jobs {
+		gotCodeFiles = append(gotCodeFiles, job.CodeFiles)
+	}
+	wantCodeFiles := [][]string{
+		{"task_01"},
+		{"features/auth/task_01"},
+		{"features/payment/task_01"},
+	}
+	if !reflect.DeepEqual(gotCodeFiles, wantCodeFiles) {
+		t.Fatalf("unexpected recursive job order\nwant: %#v\ngot:  %#v", wantCodeFiles, gotCodeFiles)
+	}
+}
+
+func TestResolvePreparedEntriesIgnoresSubdirsWhenFlat(t *testing.T) {
+	t.Parallel()
+
+	workspaceRoot := t.TempDir()
+	tasksDir := filepath.Join(workspaceRoot, model.TasksBaseDir(), "demo")
+	writeRecursiveTaskFixture(t, tasksDir)
+
+	cfg := &model.RuntimeConfig{
+		Name:          "demo",
+		WorkspaceRoot: workspaceRoot,
+		DryRun:        true,
+		IDE:           model.IDECodex,
+		Mode:          model.ExecutionModePRDTasks,
+		Recursive:     false,
+	}
+	entries, _ := resolvePreparedEntriesForTest(t, cfg)
+
+	if len(entries) != 1 {
+		t.Fatalf("expected only the root task in flat mode, got %d entries", len(entries))
+	}
+	if got, want := entries[0].Name, "task_01.md"; got != want {
+		t.Fatalf("unexpected entry name\nwant: %q\ngot:  %q", want, got)
+	}
 }

--- a/internal/core/prompt/common.go
+++ b/internal/core/prompt/common.go
@@ -163,6 +163,11 @@ func FlattenAndSortIssues(groups map[string][]model.IssueEntry, mode model.Execu
 
 	if mode == model.ExecutionModePRDTasks {
 		sort.SliceStable(allIssues, func(i, j int) bool {
+			dirI := taskDirectorySortKey(allIssues[i].Name)
+			dirJ := taskDirectorySortKey(allIssues[j].Name)
+			if dirI != dirJ {
+				return dirI < dirJ
+			}
 			numI := tasks.ExtractTaskNumber(allIssues[i].Name)
 			numJ := tasks.ExtractTaskNumber(allIssues[j].Name)
 			if numI != numJ {
@@ -182,6 +187,14 @@ func FlattenAndSortIssues(groups map[string][]model.IssueEntry, mode model.Execu
 		return allIssues[i].Name < allIssues[j].Name
 	})
 	return allIssues
+}
+
+func taskDirectorySortKey(name string) string {
+	dir := filepath.ToSlash(filepath.Dir(filepath.FromSlash(name)))
+	if dir == "." {
+		return ""
+	}
+	return dir
 }
 
 func SafeFileName(path string) string {

--- a/internal/core/prompt/prompt_test.go
+++ b/internal/core/prompt/prompt_test.go
@@ -564,16 +564,18 @@ func TestFlattenAndSortIssues(t *testing.T) {
 	t.Parallel()
 
 	prdGroups := map[string][]model.IssueEntry{
-		"b": {{Name: "task_10.md"}},
-		"a": {{Name: "task_2.md"}},
+		"nested-a": {{Name: "features/auth/task_01.md"}},
+		"root-a":   {{Name: "task_01.md"}},
+		"root-b":   {{Name: "task_10.md"}},
 	}
 	prdIssues := FlattenAndSortIssues(prdGroups, model.ExecutionModePRDTasks)
 	if got := []string{
 		prdIssues[0].Name,
 		prdIssues[1].Name,
+		prdIssues[2].Name,
 	}; !reflect.DeepEqual(
 		got,
-		[]string{"task_2.md", "task_10.md"},
+		[]string{"task_01.md", "task_10.md", "features/auth/task_01.md"},
 	) {
 		t.Fatalf("unexpected prd ordering: %#v", got)
 	}

--- a/internal/core/run/preflight/preflight.go
+++ b/internal/core/run/preflight/preflight.go
@@ -28,6 +28,7 @@ type Config struct {
 	IsInteractive  func() bool
 	Force          bool
 	SkipValidation bool
+	Recursive      bool
 	Stderr         io.Writer
 	FormInput      io.Reader
 	FormOutput     io.Writer
@@ -60,7 +61,11 @@ func CheckConfig(ctx context.Context, cfg Config) (Decision, error) {
 
 	validate := cfg.ValidationFn
 	if validate == nil {
-		validate = tasks.Validate
+		validate = func(ctx context.Context, tasksDir string, registry *tasks.TypeRegistry) (tasks.Report, error) {
+			return tasks.ValidateWithOptions(ctx, tasksDir, registry, tasks.ValidateOptions{
+				Recursive: cfg.Recursive,
+			})
+		}
 	}
 	form := cfg.ValidationForm
 	report, err := validate(ctx, cfg.TasksDir, cfg.Registry)

--- a/internal/core/run/preflight/preflight_test.go
+++ b/internal/core/run/preflight/preflight_test.go
@@ -181,6 +181,69 @@ func TestPreflightCheckWrapperUsesActualValidator(t *testing.T) {
 	}
 }
 
+func TestPreflightCheckScopesValidationToRecursiveMode(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	writePreflightTask(t, tasksDir, "task_01.md", strings.Join([]string{
+		"---",
+		"status: pending",
+		"title: Root",
+		"type: backend",
+		"complexity: low",
+		"---",
+		"",
+		"# Root",
+		"",
+		"Body.",
+		"",
+	}, "\n"))
+	nestedDir := filepath.Join(tasksDir, "features", "auth")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writePreflightTask(t, nestedDir, "task_01.md", strings.Join([]string{
+		"---",
+		"status: pending",
+		"type: backend",
+		"complexity: low",
+		"---",
+		"",
+		"# Nested Draft",
+		"",
+		"Body.",
+		"",
+	}, "\n"))
+
+	flatDecision, err := CheckConfig(context.Background(), Config{
+		TasksDir: tasksDir,
+		Registry: testValidationRegistry(t),
+	})
+	if err != nil {
+		t.Fatalf("flat preflight: %v", err)
+	}
+	if flatDecision != OK {
+		t.Fatalf("expected flat preflight to ignore nested draft, got %q", flatDecision)
+	}
+
+	var stderr bytes.Buffer
+	recursiveDecision, err := CheckConfig(context.Background(), Config{
+		TasksDir:  tasksDir,
+		Registry:  testValidationRegistry(t),
+		Recursive: true,
+		Stderr:    &stderr,
+	})
+	if err != nil {
+		t.Fatalf("recursive preflight: %v", err)
+	}
+	if recursiveDecision != Aborted {
+		t.Fatalf("expected recursive preflight to abort, got %q", recursiveDecision)
+	}
+	if got := stderr.String(); !strings.Contains(got, "title is required") {
+		t.Fatalf("expected recursive validation failure in stderr, got %q", got)
+	}
+}
+
 func TestRunValidationFormUsesInjectedInputAndOutput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/run/preflight/preflight_test.go
+++ b/internal/core/run/preflight/preflight_test.go
@@ -215,33 +215,39 @@ func TestPreflightCheckScopesValidationToRecursiveMode(t *testing.T) {
 		"",
 	}, "\n"))
 
-	flatDecision, err := CheckConfig(context.Background(), Config{
-		TasksDir: tasksDir,
-		Registry: testValidationRegistry(t),
+	t.Run("Should ignore nested draft in flat mode", func(t *testing.T) {
+		t.Parallel()
+		decision, err := CheckConfig(context.Background(), Config{
+			TasksDir: tasksDir,
+			Registry: testValidationRegistry(t),
+		})
+		if err != nil {
+			t.Fatalf("flat preflight: %v", err)
+		}
+		if decision != OK {
+			t.Fatalf("expected flat preflight to ignore nested draft, got %q", decision)
+		}
 	})
-	if err != nil {
-		t.Fatalf("flat preflight: %v", err)
-	}
-	if flatDecision != OK {
-		t.Fatalf("expected flat preflight to ignore nested draft, got %q", flatDecision)
-	}
 
-	var stderr bytes.Buffer
-	recursiveDecision, err := CheckConfig(context.Background(), Config{
-		TasksDir:  tasksDir,
-		Registry:  testValidationRegistry(t),
-		Recursive: true,
-		Stderr:    &stderr,
+	t.Run("Should abort on nested draft in recursive mode", func(t *testing.T) {
+		t.Parallel()
+		var stderr bytes.Buffer
+		decision, err := CheckConfig(context.Background(), Config{
+			TasksDir:  tasksDir,
+			Registry:  testValidationRegistry(t),
+			Recursive: true,
+			Stderr:    &stderr,
+		})
+		if err != nil {
+			t.Fatalf("recursive preflight: %v", err)
+		}
+		if decision != Aborted {
+			t.Fatalf("expected recursive preflight to abort, got %q", decision)
+		}
+		if got := stderr.String(); !strings.Contains(got, "title is required") {
+			t.Fatalf("expected recursive validation failure in stderr, got %q", got)
+		}
 	})
-	if err != nil {
-		t.Fatalf("recursive preflight: %v", err)
-	}
-	if recursiveDecision != Aborted {
-		t.Fatalf("expected recursive preflight to abort, got %q", recursiveDecision)
-	}
-	if got := stderr.String(); !strings.Contains(got, "title is required") {
-		t.Fatalf("expected recursive validation failure in stderr, got %q", got)
-	}
 }
 
 func TestRunValidationFormUsesInjectedInputAndOutput(t *testing.T) {

--- a/internal/core/tasks/store.go
+++ b/internal/core/tasks/store.go
@@ -117,7 +117,7 @@ func MarkTaskCompleted(tasksDir, taskFileName string) error {
 
 func CompleteNonTerminalTasks(tasksDir string) (int, error) {
 	taskNames := make([]string, 0)
-	if err := walkTaskFiles(tasksDir, func(entry model.IssueEntry, task model.TaskEntry) error {
+	if err := walkTaskFiles(tasksDir, true, func(entry model.IssueEntry, task model.TaskEntry) error {
 		if IsTaskCompleted(task) {
 			return nil
 		}
@@ -141,11 +141,27 @@ func CompleteNonTerminalTasks(tasksDir string) (int, error) {
 }
 
 func resolveTaskName(taskFileName string) (string, error) {
-	name := filepath.Base(strings.TrimSpace(taskFileName))
-	if ExtractTaskNumber(name) == 0 {
-		return "", fmt.Errorf("invalid task file name %q", taskFileName)
+	trimmed := strings.TrimSpace(taskFileName)
+	if trimmed == "" {
+		return "", fmt.Errorf("invalid task file name %q: empty input", taskFileName)
 	}
-	return name, nil
+	clean := filepath.ToSlash(strings.ReplaceAll(trimmed, `\`, "/"))
+	if strings.HasPrefix(clean, "/") {
+		return "", fmt.Errorf("invalid task file name %q: leading slash not allowed", taskFileName)
+	}
+	for _, segment := range strings.Split(clean, "/") {
+		if segment == "" {
+			return "", fmt.Errorf("invalid task file name %q: empty path segment", taskFileName)
+		}
+		if segment == ".." {
+			return "", fmt.Errorf("invalid task file name %q: %q segment not allowed", taskFileName, "..")
+		}
+	}
+	base := filepath.Base(clean)
+	if ExtractTaskNumber(base) == 0 {
+		return "", fmt.Errorf("invalid task file name %q: basename %q does not match task pattern", taskFileName, base)
+	}
+	return clean, nil
 }
 
 func formatTaskMeta(meta model.TaskMeta) (string, error) {
@@ -223,7 +239,7 @@ func parseTaskMetaSummary(lines []string, meta *model.TaskMeta) error {
 func countTasks(tasksDir string) (int, int, error) {
 	total := 0
 	completed := 0
-	err := walkTaskFiles(tasksDir, func(_ model.IssueEntry, task model.TaskEntry) error {
+	err := walkTaskFiles(tasksDir, true, func(_ model.IssueEntry, task model.TaskEntry) error {
 		total++
 		if IsTaskCompleted(task) {
 			completed++

--- a/internal/core/tasks/store_test.go
+++ b/internal/core/tasks/store_test.go
@@ -265,6 +265,235 @@ func TestCompleteNonTerminalTasksRewritesWorkflowAndRefreshesMeta(t *testing.T) 
 	}
 }
 
+func TestCountTasksRecursesAndCountsNested(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	files := map[string]string{
+		"task_01.md":                  pendingTaskBody("Root 01"),
+		"features/auth/task_01.md":    pendingTaskBody("Auth 01"),
+		"features/auth/task_02.md":    completedTaskBody("Auth 02"),
+		"features/payment/task_01.md": pendingTaskBody("Payment 01"),
+		".cache/task_01.md":           pendingTaskBody("Hidden"),
+		"reviews-001/task_01.md":      pendingTaskBody("Reviews"),
+	}
+	writeNestedFiles(t, tasksDir, files)
+
+	total, completed, err := countTasks(tasksDir)
+	if err != nil {
+		t.Fatalf("countTasks: %v", err)
+	}
+	if total != 4 {
+		t.Fatalf("total = %d, want 4", total)
+	}
+	if completed != 1 {
+		t.Fatalf("completed = %d, want 1", completed)
+	}
+}
+
+func TestMarkTaskCompletedAcceptsRelativeSubpath(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	rel := "features/auth/task_01.md"
+	writeNestedFiles(t, tasksDir, map[string]string{
+		rel: pendingTaskBody("Auth 01"),
+	})
+
+	if err := MarkTaskCompleted(tasksDir, rel); err != nil {
+		t.Fatalf("mark task completed: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(tasksDir, filepath.FromSlash(rel)))
+	if err != nil {
+		t.Fatalf("read %s: %v", rel, err)
+	}
+	if !strings.Contains(string(body), "status: completed") {
+		t.Fatalf("expected nested task to be completed, got:\n%s", string(body))
+	}
+}
+
+func TestMarkTaskCompletedNormalizesBackslashes(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	writeNestedFiles(t, tasksDir, map[string]string{
+		"features/auth/task_01.md": pendingTaskBody("Auth 01"),
+	})
+
+	if err := MarkTaskCompleted(tasksDir, `features\auth\task_01.md`); err != nil {
+		t.Fatalf("mark task completed with backslash input: %v", err)
+	}
+
+	body, err := os.ReadFile(filepath.Join(tasksDir, "features", "auth", "task_01.md"))
+	if err != nil {
+		t.Fatalf("read nested task: %v", err)
+	}
+	if !strings.Contains(string(body), "status: completed") {
+		t.Fatalf("expected backslash input to resolve to nested task, got:\n%s", string(body))
+	}
+}
+
+func TestResolveTaskNameRejectsEmpty(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"", "   ", "\t\n"}
+	for _, input := range cases {
+		input := input
+		t.Run(strings.TrimSpace(input)+"|raw="+input, func(t *testing.T) {
+			t.Parallel()
+			_, err := resolveTaskName(input)
+			if err == nil {
+				t.Fatalf("expected error for empty input %q", input)
+			}
+			if !strings.Contains(err.Error(), "empty input") {
+				t.Fatalf("error should mention empty input, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestResolveTaskNameRejectsLeadingSlash(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{"/task_01.md", "/features/auth/task_01.md", "//features/task_01.md"}
+	for _, input := range cases {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			_, err := resolveTaskName(input)
+			if err == nil {
+				t.Fatalf("expected error for leading-slash input %q", input)
+			}
+			if !strings.Contains(err.Error(), input) {
+				t.Fatalf("error should reference offending input %q, got: %v", input, err)
+			}
+		})
+	}
+}
+
+func TestResolveTaskNameRejectsParentSegment(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"../task_01.md",
+		"features/../task_01.md",
+		"features/auth/../task_01.md",
+		"..",
+	}
+	for _, input := range cases {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			_, err := resolveTaskName(input)
+			if err == nil {
+				t.Fatalf("expected error for parent-segment input %q", input)
+			}
+			if !strings.Contains(err.Error(), "..") {
+				t.Fatalf("error should reference \"..\" segment, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), input) {
+				t.Fatalf("error should reference offending input %q, got: %v", input, err)
+			}
+		})
+	}
+}
+
+func TestResolveTaskNameRejectsNonTaskBasename(t *testing.T) {
+	t.Parallel()
+
+	cases := []string{
+		"features/auth/notes.md",
+		"task_bad.md",
+		"task_01.txt",
+		"features/auth/task_01",
+	}
+	for _, input := range cases {
+		input := input
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			_, err := resolveTaskName(input)
+			if err == nil {
+				t.Fatalf("expected error for non-task basename %q", input)
+			}
+			if !strings.Contains(err.Error(), filepath.Base(input)) {
+				t.Fatalf("error should reference invalid basename %q, got: %v", filepath.Base(input), err)
+			}
+		})
+	}
+}
+
+func TestResolveTaskNameAcceptsValidRelpath(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{"task_01.md", "task_01.md"},
+		{"features/auth/task_01.md", "features/auth/task_01.md"},
+		{"  features/auth/task_02.md  ", "features/auth/task_02.md"},
+		{`features\auth\task_03.md`, "features/auth/task_03.md"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveTaskName(tc.input)
+			if err != nil {
+				t.Fatalf("resolveTaskName(%q): %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("resolveTaskName(%q) = %q; want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompleteNonTerminalTasksHandlesNestedFixture(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	pending := []string{
+		"task_01.md",
+		"features/auth/task_01.md",
+		"features/payment/task_01.md",
+	}
+	files := map[string]string{
+		"features/auth/task_02.md": completedTaskBody("Auth 02"),
+	}
+	for _, rel := range pending {
+		files[rel] = pendingTaskBody(rel)
+	}
+	writeNestedFiles(t, tasksDir, files)
+
+	completed, err := CompleteNonTerminalTasks(tasksDir)
+	if err != nil {
+		t.Fatalf("CompleteNonTerminalTasks: %v", err)
+	}
+	if completed != len(pending) {
+		t.Fatalf("completed = %d, want %d", completed, len(pending))
+	}
+
+	for rel := range files {
+		body, err := os.ReadFile(filepath.Join(tasksDir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+		if !strings.Contains(string(body), "status: completed") {
+			t.Fatalf("expected %s to be completed, got:\n%s", rel, string(body))
+		}
+	}
+
+	meta, err := ReadTaskMeta(tasksDir)
+	if err != nil {
+		t.Fatalf("read task meta: %v", err)
+	}
+	if meta.Total != len(files) || meta.Completed != len(files) || meta.Pending != 0 {
+		t.Fatalf("unexpected task meta after nested completion: %#v", meta)
+	}
+}
+
 func writeTaskFile(t *testing.T, tasksDir, name, status string) {
 	t.Helper()
 

--- a/internal/core/tasks/validate.go
+++ b/internal/core/tasks/validate.go
@@ -18,27 +18,36 @@ var validTaskStatuses = []string{"pending", "in_progress", "completed", "blocked
 
 var validTaskComplexities = []string{"low", "medium", "high", "critical"}
 
-// Issue describes one validation problem found in a task file.
 type Issue struct {
 	Path    string `json:"path"`
 	Field   string `json:"field"`
 	Message string `json:"message"`
 }
 
-// Report captures the outcome of validating a tasks directory.
 type Report struct {
 	TasksDir string  `json:"tasks_dir"`
 	Scanned  int     `json:"scanned"`
 	Issues   []Issue `json:"issues"`
 }
 
-// OK reports whether the validation pass found no issues.
+type ValidateOptions struct {
+	Recursive bool
+}
+
 func (r Report) OK() bool {
 	return len(r.Issues) == 0
 }
 
-// Validate scans task markdown files and reports schema violations without mutating the filesystem.
 func Validate(ctx context.Context, tasksDir string, registry *TypeRegistry) (Report, error) {
+	return ValidateWithOptions(ctx, tasksDir, registry, ValidateOptions{Recursive: true})
+}
+
+func ValidateWithOptions(
+	ctx context.Context,
+	tasksDir string,
+	registry *TypeRegistry,
+	options ValidateOptions,
+) (Report, error) {
 	if registry == nil {
 		return Report{}, errors.New("task type registry is required")
 	}
@@ -52,28 +61,30 @@ func Validate(ctx context.Context, tasksDir string, registry *TypeRegistry) (Rep
 	}
 
 	report := Report{TasksDir: resolvedDir}
-	entries, err := os.ReadDir(resolvedDir)
-	if err != nil {
-		return report, fmt.Errorf("read tasks directory: %w", err)
+	if _, statErr := os.Stat(resolvedDir); statErr != nil {
+		return report, fmt.Errorf("read tasks directory %s: %w", resolvedDir, statErr)
 	}
-
-	taskNames := collectTaskFileNames(entries)
-	report.Scanned = len(taskNames)
-	if len(taskNames) == 0 {
+	names, err := taskFileNames(resolvedDir, options.Recursive)
+	if err != nil {
+		return report, err
+	}
+	report.Scanned = len(names)
+	if len(names) == 0 {
 		return report, nil
 	}
 
-	existingTasks := make(map[string]struct{}, len(taskNames))
-	for _, name := range taskNames {
+	existingTasks := make(map[string]struct{}, len(names))
+	for _, name := range names {
 		existingTasks[strings.TrimSuffix(name, filepath.Ext(name))] = struct{}{}
+		existingTasks[strings.TrimSuffix(filepath.Base(name), filepath.Ext(name))] = struct{}{}
 	}
 
-	for _, name := range taskNames {
+	for _, name := range names {
 		if err := context.Cause(ctx); err != nil {
 			return report, fmt.Errorf("validate tasks: %w", err)
 		}
 
-		path := filepath.Join(resolvedDir, name)
+		path := filepath.Join(resolvedDir, filepath.FromSlash(name))
 		content, err := os.ReadFile(path)
 		if err != nil {
 			return report, fmt.Errorf("read %s: %w", name, err)
@@ -88,25 +99,14 @@ func Validate(ctx context.Context, tasksDir string, registry *TypeRegistry) (Rep
 			report.Issues,
 			validateTaskFile(path, task, body, legacyKeys, registry, existingTasks)...)
 	}
+	slices.SortStableFunc(report.Issues, func(a, b Issue) int {
+		if cmp := strings.Compare(a.Path, b.Path); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Field, b.Field)
+	})
 
 	return report, nil
-}
-
-func collectTaskFileNames(entries []os.DirEntry) []string {
-	names := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if !entry.Type().IsRegular() || ExtractTaskNumber(entry.Name()) == 0 {
-			continue
-		}
-		names = append(names, entry.Name())
-	}
-	slices.SortStableFunc(names, func(a, b string) int {
-		if numA, numB := ExtractTaskNumber(a), ExtractTaskNumber(b); numA != numB {
-			return numA - numB
-		}
-		return strings.Compare(a, b)
-	})
-	return names
 }
 
 func parseTaskForValidation(content string) (model.TaskEntry, string, []string, error) {

--- a/internal/core/tasks/validate_test.go
+++ b/internal/core/tasks/validate_test.go
@@ -281,6 +281,108 @@ func TestValidateRequiresRegistry(t *testing.T) {
 	}
 }
 
+func TestValidateRecursesIntoNestedDirectories(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	writeRawTaskFile(t, tasksDir, "task_01.md", taskMarkdown(
+		[]string{"status: pending", "title: Root", "type: backend", "complexity: low"},
+		"# Root",
+	))
+	nestedDir := filepath.Join(tasksDir, "features", "auth")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writeRawTaskFile(t, nestedDir, "task_01.md", taskMarkdown(
+		[]string{"status: pending", "type: backend", "complexity: low"},
+		"# Nested",
+	))
+
+	report, err := Validate(context.Background(), tasksDir, mustTaskRegistry(t))
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if report.Scanned != 2 {
+		t.Fatalf("expected recursive scan to find 2 files, got %d", report.Scanned)
+	}
+	if report.OK() {
+		t.Fatalf("expected nested file to surface a title issue, got clean report")
+	}
+	nestedPath := filepath.Join(nestedDir, "task_01.md")
+	found := false
+	for _, issue := range report.Issues {
+		if issue.Path == nestedPath && issue.Field == "title" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected nested title issue at %q, got %#v", nestedPath, report.Issues)
+	}
+}
+
+func TestValidateWithOptionsFlatIgnoresNestedTasks(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	writeRawTaskFile(t, tasksDir, "task_01.md", taskMarkdown(
+		[]string{"status: pending", "title: Root", "type: backend", "complexity: low"},
+		"# Root",
+	))
+	nestedDir := filepath.Join(tasksDir, "features", "auth")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir nested: %v", err)
+	}
+	writeRawTaskFile(t, nestedDir, "task_01.md", taskMarkdown(
+		[]string{"status: pending", "type: backend", "complexity: low"},
+		"# Nested",
+	))
+
+	report, err := ValidateWithOptions(
+		context.Background(),
+		tasksDir,
+		mustTaskRegistry(t),
+		ValidateOptions{Recursive: false},
+	)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if report.Scanned != 1 {
+		t.Fatalf("expected flat scan to find 1 file, got %d", report.Scanned)
+	}
+	if !report.OK() {
+		t.Fatalf("expected flat scan to ignore nested draft, got %#v", report.Issues)
+	}
+}
+
+func TestValidateSkipsHiddenAndReviewDirectories(t *testing.T) {
+	t.Parallel()
+
+	tasksDir := t.TempDir()
+	writeRawTaskFile(t, tasksDir, "task_01.md", taskMarkdown(
+		[]string{"status: pending", "title: Root", "type: backend", "complexity: low"},
+		"# Root",
+	))
+	for _, sub := range []string{".cache", "_drafts", "reviews-001", "adrs", "memory"} {
+		dir := filepath.Join(tasksDir, sub)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", sub, err)
+		}
+		writeRawTaskFile(t, dir, "task_01.md", "garbage")
+	}
+
+	report, err := Validate(context.Background(), tasksDir, mustTaskRegistry(t))
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if report.Scanned != 1 {
+		t.Fatalf("expected validator to skip hidden dirs; got scanned=%d", report.Scanned)
+	}
+	if !report.OK() {
+		t.Fatalf("expected clean report, got %#v", report.Issues)
+	}
+}
+
 func TestValidateRejectsLegacyTaskMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/tasks/walker.go
+++ b/internal/core/tasks/walker.go
@@ -2,6 +2,8 @@ package tasks
 
 import (
 	"fmt"
+	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sort"
@@ -11,8 +13,16 @@ import (
 )
 
 func ReadTaskEntries(tasksDir string, includeCompleted bool) ([]model.IssueEntry, error) {
+	return readTaskEntriesWithMode(tasksDir, includeCompleted, false)
+}
+
+func ReadTaskEntriesRecursive(tasksDir string, includeCompleted bool) ([]model.IssueEntry, error) {
+	return readTaskEntriesWithMode(tasksDir, includeCompleted, true)
+}
+
+func readTaskEntriesWithMode(tasksDir string, includeCompleted, recursive bool) ([]model.IssueEntry, error) {
 	entries := make([]model.IssueEntry, 0)
-	if err := walkTaskFiles(tasksDir, func(entry model.IssueEntry, task model.TaskEntry) error {
+	if err := walkTaskFiles(tasksDir, recursive, func(entry model.IssueEntry, task model.TaskEntry) error {
 		if !includeCompleted && IsTaskCompleted(task) {
 			return nil
 		}
@@ -21,11 +31,20 @@ func ReadTaskEntries(tasksDir string, includeCompleted bool) ([]model.IssueEntry
 	}); err != nil {
 		return nil, err
 	}
+	slog.Debug(
+		"recursive task discovery resolved entries",
+		"count", len(entries),
+		"recursive", recursive,
+	)
 	return entries, nil
 }
 
-func walkTaskFiles(tasksDir string, visit func(model.IssueEntry, model.TaskEntry) error) error {
-	names, err := taskFileNames(tasksDir)
+func walkTaskFiles(
+	tasksDir string,
+	recursive bool,
+	visit func(model.IssueEntry, model.TaskEntry) error,
+) error {
+	names, err := taskFileNames(tasksDir, recursive)
 	if err != nil {
 		return err
 	}
@@ -42,7 +61,14 @@ func walkTaskFiles(tasksDir string, visit func(model.IssueEntry, model.TaskEntry
 	return nil
 }
 
-func taskFileNames(tasksDir string) ([]string, error) {
+func taskFileNames(tasksDir string, recursive bool) ([]string, error) {
+	if recursive {
+		return taskFileNamesRecursive(tasksDir)
+	}
+	return taskFileNamesFlat(tasksDir)
+}
+
+func taskFileNamesFlat(tasksDir string) ([]string, error) {
 	files, err := os.ReadDir(tasksDir)
 	if err != nil {
 		return nil, fmt.Errorf("read tasks directory: %w", err)
@@ -59,14 +85,112 @@ func taskFileNames(tasksDir string) ([]string, error) {
 		names = append(names, file.Name())
 	}
 
-	sort.SliceStable(names, func(i, j int) bool {
-		return ExtractTaskNumber(names[i]) < ExtractTaskNumber(names[j])
-	})
+	sortTaskNames(names)
 	return names, nil
 }
 
+func taskFileNamesRecursive(tasksDir string) ([]string, error) {
+	names := make([]string, 0)
+	walkErr := filepath.WalkDir(tasksDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if d != nil && d.IsDir() && path != tasksDir {
+				slog.Debug(
+					"recursive task discovery skipped directory",
+					"dir", relForLog(tasksDir, path),
+					"reason", "walk-error",
+					"error", err,
+				)
+				return filepath.SkipDir
+			}
+			return err
+		}
+		if d.IsDir() {
+			if path == tasksDir {
+				return nil
+			}
+			if shouldSkipDir(d.Name()) {
+				slog.Debug(
+					"recursive task discovery skipped directory",
+					"dir", relForLog(tasksDir, path),
+					"reason", "skip-list",
+				)
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !d.Type().IsRegular() || !strings.HasSuffix(d.Name(), ".md") {
+			return nil
+		}
+		if ExtractTaskNumber(d.Name()) == 0 {
+			return nil
+		}
+		rel, relErr := filepath.Rel(tasksDir, path)
+		if relErr != nil {
+			return fmt.Errorf("relpath %s: %w", path, relErr)
+		}
+		names = append(names, filepath.ToSlash(rel))
+		return nil
+	})
+	if walkErr != nil {
+		return nil, fmt.Errorf("walk tasks directory: %w", walkErr)
+	}
+	sortTaskNames(names)
+	return names, nil
+}
+
+func sortTaskNames(names []string) {
+	sort.SliceStable(names, func(i, j int) bool {
+		di, dj := dirKey(names[i]), dirKey(names[j])
+		if di != dj {
+			return di < dj
+		}
+		ni := ExtractTaskNumber(filepath.Base(names[i]))
+		nj := ExtractTaskNumber(filepath.Base(names[j]))
+		if ni != nj {
+			return ni < nj
+		}
+		return names[i] < names[j]
+	})
+}
+
+func dirKey(rel string) string {
+	dir := filepath.ToSlash(filepath.Dir(filepath.FromSlash(rel)))
+	if dir == "." {
+		return ""
+	}
+	return dir
+}
+
+func shouldSkipDir(name string) bool {
+	if name == "" {
+		return false
+	}
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+	if strings.HasPrefix(name, "_") {
+		return true
+	}
+	if strings.HasPrefix(name, "reviews-") {
+		return true
+	}
+	switch name {
+	case "adrs", "memory":
+		return true
+	}
+	return false
+}
+
+func relForLog(tasksDir, path string) string {
+	rel, err := filepath.Rel(tasksDir, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}
+
 func readTaskEntry(tasksDir, name string) (model.IssueEntry, model.TaskEntry, error) {
-	absPath := filepath.Join(tasksDir, name)
+	absPath := filepath.Join(tasksDir, filepath.FromSlash(name))
 	body, err := os.ReadFile(absPath)
 	if err != nil {
 		return model.IssueEntry{}, model.TaskEntry{}, fmt.Errorf("read %s: %w", name, err)

--- a/internal/core/tasks/walker.go
+++ b/internal/core/tasks/walker.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -32,7 +33,7 @@ func readTaskEntriesWithMode(tasksDir string, includeCompleted, recursive bool) 
 		return nil, err
 	}
 	slog.Debug(
-		"recursive task discovery resolved entries",
+		"task discovery resolved entries",
 		"count", len(entries),
 		"recursive", recursive,
 	)
@@ -91,27 +92,18 @@ func taskFileNamesFlat(tasksDir string) ([]string, error) {
 
 func taskFileNamesRecursive(tasksDir string) ([]string, error) {
 	names := make([]string, 0)
-	walkErr := filepath.WalkDir(tasksDir, func(path string, d fs.DirEntry, err error) error {
+	walkErr := filepath.WalkDir(tasksDir, func(entryPath string, d fs.DirEntry, err error) error {
 		if err != nil {
-			if d != nil && d.IsDir() && path != tasksDir {
-				slog.Debug(
-					"recursive task discovery skipped directory",
-					"dir", relForLog(tasksDir, path),
-					"reason", "walk-error",
-					"error", err,
-				)
-				return filepath.SkipDir
-			}
-			return err
+			return fmt.Errorf("walk %s: %w", relForLog(tasksDir, entryPath), err)
 		}
 		if d.IsDir() {
-			if path == tasksDir {
+			if entryPath == tasksDir {
 				return nil
 			}
 			if shouldSkipDir(d.Name()) {
 				slog.Debug(
 					"recursive task discovery skipped directory",
-					"dir", relForLog(tasksDir, path),
+					"dir", relForLog(tasksDir, entryPath),
 					"reason", "skip-list",
 				)
 				return filepath.SkipDir
@@ -124,9 +116,9 @@ func taskFileNamesRecursive(tasksDir string) ([]string, error) {
 		if ExtractTaskNumber(d.Name()) == 0 {
 			return nil
 		}
-		rel, relErr := filepath.Rel(tasksDir, path)
+		rel, relErr := filepath.Rel(tasksDir, entryPath)
 		if relErr != nil {
-			return fmt.Errorf("relpath %s: %w", path, relErr)
+			return fmt.Errorf("relpath %s: %w", entryPath, relErr)
 		}
 		names = append(names, filepath.ToSlash(rel))
 		return nil
@@ -154,7 +146,7 @@ func sortTaskNames(names []string) {
 }
 
 func dirKey(rel string) string {
-	dir := filepath.ToSlash(filepath.Dir(filepath.FromSlash(rel)))
+	dir := path.Dir(rel)
 	if dir == "." {
 		return ""
 	}
@@ -181,10 +173,10 @@ func shouldSkipDir(name string) bool {
 	return false
 }
 
-func relForLog(tasksDir, path string) string {
-	rel, err := filepath.Rel(tasksDir, path)
+func relForLog(tasksDir, entryPath string) string {
+	rel, err := filepath.Rel(tasksDir, entryPath)
 	if err != nil {
-		return filepath.ToSlash(path)
+		return filepath.ToSlash(entryPath)
 	}
 	return filepath.ToSlash(rel)
 }

--- a/internal/core/tasks/walker_test.go
+++ b/internal/core/tasks/walker_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -35,5 +36,201 @@ func TestReadTaskEntriesSortsNumericallyAndFiltersCompleted(t *testing.T) {
 	wantNames := []string{"task_2.md", "task_10.md"}
 	if !reflect.DeepEqual(gotNames, wantNames) {
 		t.Fatalf("unexpected task order\nwant: %#v\ngot:  %#v", wantNames, gotNames)
+	}
+}
+
+func TestReadTaskEntriesRecursiveDiscoversNestedAndSortsByDir(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	files := map[string]string{
+		"task_01.md":                  pendingTaskBody("Root 01"),
+		"features/auth/task_01.md":    pendingTaskBody("Auth 01"),
+		"features/auth/task_02.md":    pendingTaskBody("Auth 02"),
+		"features/payment/task_01.md": pendingTaskBody("Payment 01"),
+	}
+	writeNestedFiles(t, dir, files)
+
+	entries, err := ReadTaskEntriesRecursive(dir, false)
+	if err != nil {
+		t.Fatalf("ReadTaskEntriesRecursive: %v", err)
+	}
+
+	gotNames := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		gotNames = append(gotNames, entry.Name)
+	}
+	wantNames := []string{
+		"task_01.md",
+		"features/auth/task_01.md",
+		"features/auth/task_02.md",
+		"features/payment/task_01.md",
+	}
+	if !reflect.DeepEqual(gotNames, wantNames) {
+		t.Fatalf("unexpected entry order\nwant: %#v\ngot:  %#v", wantNames, gotNames)
+	}
+
+	for _, entry := range entries {
+		if strings.Contains(entry.Name, "\\") {
+			t.Fatalf("entry name uses native separator: %q", entry.Name)
+		}
+		wantCodeFile := strings.TrimSuffix(entry.Name, ".md")
+		if entry.CodeFile != wantCodeFile {
+			t.Fatalf("entry %q has CodeFile %q; want %q", entry.Name, entry.CodeFile, wantCodeFile)
+		}
+		wantAbs := filepath.Join(dir, filepath.FromSlash(entry.Name))
+		if entry.AbsPath != wantAbs {
+			t.Fatalf("entry %q has AbsPath %q; want %q", entry.Name, entry.AbsPath, wantAbs)
+		}
+	}
+}
+
+func TestReadTaskEntriesRecursiveSkipsHiddenAndReviewDirs(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	files := map[string]string{
+		".cache/task_01.md":      pendingTaskBody("Cache"),
+		"_drafts/task_01.md":     pendingTaskBody("Drafts"),
+		"reviews-001/task_01.md": pendingTaskBody("Reviews"),
+		"adrs/task_01.md":        pendingTaskBody("Adrs"),
+		"memory/task_01.md":      pendingTaskBody("Memory"),
+	}
+	writeNestedFiles(t, dir, files)
+
+	entries, err := ReadTaskEntriesRecursive(dir, false)
+	if err != nil {
+		t.Fatalf("ReadTaskEntriesRecursive: %v", err)
+	}
+	if len(entries) != 0 {
+		got := make([]string, 0, len(entries))
+		for _, entry := range entries {
+			got = append(got, entry.Name)
+		}
+		t.Fatalf("expected no entries; got %#v", got)
+	}
+}
+
+func TestReadTaskEntriesRecursiveIgnoresNonMatchingFilenames(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "notes.md"), []byte("ignored\n"), 0o600); err != nil {
+		t.Fatalf("write notes.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "task_bad.md"), []byte("ignored\n"), 0o600); err != nil {
+		t.Fatalf("write task_bad.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "task_01.txt"), []byte("ignored\n"), 0o600); err != nil {
+		t.Fatalf("write task_01.txt: %v", err)
+	}
+
+	entries, err := ReadTaskEntriesRecursive(dir, false)
+	if err != nil {
+		t.Fatalf("ReadTaskEntriesRecursive: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected empty result; got %d entries", len(entries))
+	}
+}
+
+func TestReadTaskEntriesNonRecursiveUnchanged(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	files := map[string]string{
+		"task_01.md":               pendingTaskBody("Root 01"),
+		"task_02.md":               pendingTaskBody("Root 02"),
+		"features/auth/task_01.md": pendingTaskBody("Auth 01"),
+	}
+	writeNestedFiles(t, dir, files)
+
+	entries, err := ReadTaskEntries(dir, false)
+	if err != nil {
+		t.Fatalf("ReadTaskEntries: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected flat mode to ignore nested files; got %d entries", len(entries))
+	}
+	got := []string{entries[0].Name, entries[1].Name}
+	want := []string{"task_01.md", "task_02.md"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("flat mode names changed\nwant: %#v\ngot:  %#v", want, got)
+	}
+	for _, entry := range entries {
+		if entry.Name != entry.CodeFile+".md" {
+			t.Fatalf("expected basename CodeFile in flat mode, got entry %#v", entry)
+		}
+	}
+}
+
+func TestShouldSkipDirMatchesAdr002Predicate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		skip bool
+	}{
+		{".cache", true},
+		{".git", true},
+		{"_archived", true},
+		{"_meta", true},
+		{"reviews-001", true},
+		{"reviews-", true},
+		{"adrs", true},
+		{"memory", true},
+		{"features", false},
+		{"auth", false},
+		{"payment", false},
+		{"adrs-extras", false},
+		{"reviews", false},
+		{"memories", false},
+	}
+	for _, tc := range cases {
+		got := shouldSkipDir(tc.name)
+		if got != tc.skip {
+			t.Errorf("shouldSkipDir(%q) = %v; want %v", tc.name, got, tc.skip)
+		}
+	}
+}
+
+func pendingTaskBody(title string) string {
+	return strings.Join([]string{
+		"---",
+		"status: pending",
+		"title: " + title,
+		"type: backend",
+		"complexity: low",
+		"---",
+		"",
+		"# " + title,
+		"",
+	}, "\n")
+}
+
+func completedTaskBody(title string) string {
+	return strings.Join([]string{
+		"---",
+		"status: completed",
+		"title: " + title,
+		"type: backend",
+		"complexity: low",
+		"---",
+		"",
+		"# " + title,
+		"",
+	}, "\n")
+}
+
+func writeNestedFiles(t *testing.T, root string, files map[string]string) {
+	t.Helper()
+	for rel, content := range files {
+		path := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
 	}
 }

--- a/internal/core/tasks/walker_test.go
+++ b/internal/core/tasks/walker_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -161,6 +162,38 @@ func TestReadTaskEntriesNonRecursiveUnchanged(t *testing.T) {
 		if entry.Name != entry.CodeFile+".md" {
 			t.Fatalf("expected basename CodeFile in flat mode, got entry %#v", entry)
 		}
+	}
+}
+
+func TestReadTaskEntriesRecursivePropagatesUnreadableDirectoryError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission semantics do not apply on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses POSIX permission checks; permission gate cannot trigger")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	writeNestedFiles(t, dir, map[string]string{
+		"task_01.md":          pendingTaskBody("Root"),
+		"features/task_01.md": pendingTaskBody("Feature"),
+	})
+
+	blocked := filepath.Join(dir, "features")
+	if err := os.Chmod(blocked, 0o000); err != nil {
+		t.Fatalf("chmod %s: %v", blocked, err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(blocked, 0o755)
+	})
+
+	_, err := ReadTaskEntriesRecursive(dir, false)
+	if err == nil {
+		t.Fatal("expected ReadTaskEntriesRecursive to fail when subdirectory is unreadable")
+	}
+	if !strings.Contains(err.Error(), "features") {
+		t.Fatalf("expected error to reference unreadable subdirectory, got %v", err)
 	}
 }
 

--- a/internal/core/workspace/config_merge.go
+++ b/internal/core/workspace/config_merge.go
@@ -76,6 +76,7 @@ func buildEffectiveTaskRunConfig(
 ) TaskRunConfig {
 	return TaskRunConfig{
 		IncludeCompleted: cloneOptionalValue(preferOverlay(global.IncludeCompleted, workspace.IncludeCompleted)),
+		Recursive:        cloneOptionalValue(preferOverlay(global.Recursive, workspace.Recursive)),
 		OutputFormat: effectiveCommandOverride(
 			globalDefaults.OutputFormat,
 			global.OutputFormat,

--- a/internal/core/workspace/config_test.go
+++ b/internal/core/workspace/config_test.go
@@ -375,6 +375,72 @@ output_format = "json"
 	}
 }
 
+func TestWorkspaceConfigRoundTripsTasksRunRecursive(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{
+			name: "true",
+			content: `
+[tasks.run]
+recursive = true
+`,
+			want: true,
+		},
+		{
+			name: "false",
+			content: `
+[tasks.run]
+recursive = false
+`,
+			want: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			writeWorkspaceConfig(t, root, tc.content)
+
+			cfg, _, err := LoadConfig(context.Background(), root)
+			if err != nil {
+				t.Fatalf("load config: %v", err)
+			}
+			if cfg.Tasks.Run.Recursive == nil {
+				t.Fatalf("expected tasks.run.recursive to be parsed, got nil")
+			}
+			if *cfg.Tasks.Run.Recursive != tc.want {
+				t.Fatalf("tasks.run.recursive = %v, want %v", *cfg.Tasks.Run.Recursive, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceConfigOmitsRecursiveWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	writeWorkspaceConfig(t, root, `
+[tasks.run]
+include_completed = true
+`)
+
+	cfg, _, err := LoadConfig(context.Background(), root)
+	if err != nil {
+		t.Fatalf("load config: %v", err)
+	}
+	if cfg.Tasks.Run.Recursive != nil {
+		t.Fatalf("expected tasks.run.recursive to remain nil when unset, got %#v", cfg.Tasks.Run.Recursive)
+	}
+}
+
 func TestLoadConfigAcceptsRawJSONExecOutputFormat(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/workspace/config_types.go
+++ b/internal/core/workspace/config_types.go
@@ -40,6 +40,7 @@ type DefaultsConfig RuntimeOverrides
 
 type TaskRunConfig struct {
 	IncludeCompleted *bool                    `toml:"include_completed"`
+	Recursive        *bool                    `toml:"recursive"`
 	OutputFormat     *string                  `toml:"output_format"`
 	TUI              *bool                    `toml:"tui"`
 	TaskRuntimeRules *[]model.TaskRuntimeRule `toml:"task_runtime_rules"`

--- a/internal/daemon/run_manager.go
+++ b/internal/daemon/run_manager.go
@@ -155,6 +155,7 @@ type runtimeOverrideInput struct {
 	Verbose                    *bool                       `json:"verbose"`
 	Persist                    *bool                       `json:"persist"`
 	IncludeCompleted           *bool                       `json:"include_completed"`
+	Recursive                  *bool                       `json:"recursive"`
 	IncludeResolved            *bool                       `json:"include_resolved"`
 	TaskRuntimeRules           *[]model.TaskRuntimeRule    `json:"task_runtime_rules"`
 	TUI                        *bool                       `json:"tui"`
@@ -2424,6 +2425,9 @@ func applyTaskProjectConfig(cfg *model.RuntimeConfig, projectCfg workspacecfg.Ta
 	if projectCfg.IncludeCompleted != nil {
 		cfg.IncludeCompleted = *projectCfg.IncludeCompleted
 	}
+	if projectCfg.Recursive != nil {
+		cfg.Recursive = *projectCfg.Recursive
+	}
 	cfg.TaskRuntimeRules = model.CloneTaskRuntimeRules(derefTaskRuntimeRules(projectCfg.TaskRuntimeRules))
 }
 
@@ -2565,6 +2569,9 @@ func applyRuntimeOverrideWorkflowScalars(cfg *model.RuntimeConfig, overrides run
 	}
 	if overrides.IncludeCompleted != nil {
 		cfg.IncludeCompleted = *overrides.IncludeCompleted
+	}
+	if overrides.Recursive != nil {
+		cfg.Recursive = *overrides.Recursive
 	}
 	if overrides.IncludeResolved != nil {
 		cfg.IncludeResolved = *overrides.IncludeResolved

--- a/sdk/extension/types.go
+++ b/sdk/extension/types.go
@@ -543,6 +543,7 @@ type RuntimeConfig struct {
 	ReadPromptStdin            bool
 	ResolvedPromptText         string
 	IncludeCompleted           bool
+	Recursive                  bool
 	IncludeResolved            bool
 	Timeout                    time.Duration
 	MaxRetries                 int

--- a/skills/compozy/SKILL.md
+++ b/skills/compozy/SKILL.md
@@ -73,7 +73,7 @@ For a detailed step-by-step walkthrough of each phase, read `references/workflow
 | **Workflow Execution** | | |
 | `compozy daemon` | Manage the home-scoped daemon lifecycle | `start`, `status`, `stop` |
 | `compozy workspaces` | Inspect and manage daemon workspace registrations | `list`, `show`, `register`, `unregister`, `resolve` |
-| `compozy tasks run` | Execute PRD task files through the daemon | `--name`, `--attach`, `--ui`, `--stream`, `--detach`, `--task-runtime` |
+| `compozy tasks run` | Execute PRD task files through the daemon | `--name`, `--recursive` / `-r`, `--attach`, `--ui`, `--stream`, `--detach`, `--task-runtime` |
 | `compozy exec` | Execute an ad hoc prompt | `--agent`, `--format`, `--prompt-file`, `--tui`, `--persist`, `--run-id` |
 | `compozy runs` | Attach, watch, and purge daemon-managed runs | `attach`, `watch`, `purge` |
 | **Review** | | |
@@ -172,6 +172,7 @@ types = ["frontend", "backend", "docs", "test", "infra", "refactor", "chore", "b
 
 [tasks.run]
 include_completed = false
+recursive = false
 
 [fix_reviews]
 concurrent = 2

--- a/skills/compozy/references/cli-reference.md
+++ b/skills/compozy/references/cli-reference.md
@@ -57,6 +57,7 @@ Execute PRD task files sequentially from a workflow directory through the shared
 | --- | --- | --- | --- |
 | `--name` | string | | Task workflow name (resolves to `.compozy/tasks/<name>`) |
 | `--include-completed` | bool | false | Include tasks already marked as completed |
+| `--recursive`, `-r` | bool | false | Discover `task_NNN.md` files in nested subdirectories of the workflow root |
 | `--skip-validation` | bool | false | Skip task metadata preflight check |
 | `--force` | bool | false | Continue after validation fails in non-interactive mode |
 | `--attach` | string | auto | Attach mode: auto, ui, stream, detach |

--- a/skills/compozy/references/config-reference.md
+++ b/skills/compozy/references/config-reference.md
@@ -33,6 +33,7 @@ Options specific to `compozy tasks run`.
 | Field | Type | Description |
 | --- | --- | --- |
 | `include_completed` | bool | Include tasks already marked as completed |
+| `recursive` | bool | Discover `task_NNN.md` files in nested subdirectories. Equivalent to `--recursive` on the CLI |
 | `task_runtime_rules` | `array<table>` | Type-scoped runtime overrides applied after `[defaults]` for `compozy tasks run` |
 
 #### `[[tasks.run.task_runtime_rules]]`
@@ -226,6 +227,7 @@ types = ["frontend", "backend", "docs", "test", "infra", "refactor", "chore", "b
 
 [tasks.run]
 include_completed = false
+recursive = false
 
 [fix_reviews]
 concurrent = 2

--- a/skills/compozy/references/workflow-guide.md
+++ b/skills/compozy/references/workflow-guide.md
@@ -83,6 +83,7 @@ Install flow: `compozy ext install --yes compozy/compozy --remote github --ref <
 - `--auto-commit` -- create a local commit after each task completes cleanly.
 - `--dry-run` -- generate prompts without running the IDE tool.
 - `--include-completed` -- re-process tasks already marked as completed.
+- `--recursive` / `-r` -- discover `task_NNN.md` files in nested subdirectories (e.g., `features/auth/task_01.md`). Root tasks run first, then each subdirectory alphabetically, numerically within. Dot- and underscore-prefixed directories, `reviews-*`, `adrs/`, and `memory/` are skipped.
 
 **Interactive mode:** In interactive terminals, `tasks run` attaches to the TUI by default; use `--ui`, `--stream`, `--detach`, or `--attach` to override that behavior.
 


### PR DESCRIPTION
## Summary

- Adds opt-in `--recursive` / `-r` flag (default `false`) to `compozy tasks run` so workflows can keep `task_NNN.md` under nested feature subdirectories instead of flattening every task into the slug root. Flat (non-`--recursive`) runs are byte-identical to today's behavior on every code path I traced.
- Walker swaps `os.ReadDir` for `filepath.WalkDir` with a hardcoded skip predicate (`.`-prefix, `_`-prefix, `reviews-*`, `adrs/`, `memory/`). Results are emitted as forward-slash relative paths, sorted root-first then per-subdir alphabetical, numeric within each group.
- `tasks/store` accepts validated forward-slash relpaths via `*os.Root` subpath resolution; `_meta.md` totals (`countTasks`, `SnapshotTaskMeta`) and `CompleteNonTerminalTasks` are always recursion-aware so a flat run never under-reports stray nested files.
- Workflow memory is scoped per-subdir: tasks at `features/auth/task_01.md` write to `memory/features/auth/MEMORY.md`. Reads use closest-ancestor inheritance; writes always target the task's immediate scope so a sub-feature note never silently bleeds into an ancestor. Keeps any one `MEMORY.md` well below the 12 KB / 150-line soft cap on deep recursive runs.
- Surfaces wired across `--recursive` flag, runtime-override DTO, `[tasks.run] recursive` TOML key, and interactive task-runtime form.

### Design decisions

- **Opt-in flag + sibling Go function**: a new `ReadTaskEntriesRecursive` lives next to `ReadTaskEntries` instead of widening the existing signature. Avoids forcing a coordinated extension SDK release.
- **Directory-grouped numeric ordering**: root tasks first, then each subdirectory alphabetically, numerically within each group. Skip predicate is hardcoded (dot-prefix, underscore-prefix, `reviews-*`, `adrs/`, `memory/`).
- **Recursion-agnostic meta + bulk completion**: `countTasks` / `SnapshotTaskMeta` / `CompleteNonTerminalTasks` always recurse so `_meta.md` totals stay reliable across flat and recursive runs. `MarkTaskCompleted` accepts validated relative paths via `os.OpenRoot` for defense-in-depth.

### Always-recursive behavior to call out in release notes

Two surfaces intentionally ignore the flag and always scan recursively:

- `tasks.countTasks` / `tasks.SnapshotTaskMeta` / `tasks.CompleteNonTerminalTasks`
- `tasks.Validate` (preflight)

For users who already have stray nested `task_*.md` files under a slug but don't pass `--recursive` to runs, `_meta.md` totals and preflight validation will now surface those files. Users with no nested files see zero behavior change.

## Test plan

- [x] `make verify` (fmt + lint + test + build): 0 issues, 3140 tests pass, build OK
- [x] `internal/core/memory/store_test.go` — 8 new tests for per-subdir bootstrap, root fallback, ancestor isolation on writes, closest-ancestor on reads, append-bootstraps-template
- [x] `internal/core/tasks/walker_test.go` — recursive discovery + skip predicate + nested-memory regression
- [x] `internal/core/tasks/store_test.go` — `MarkTaskCompleted` accepts relpaths; rejects path escape
- [x] `internal/core/plan/prepare_test.go` — nested task flows through planner with scoped workflow memory
- [x] `internal/core/extension/host_reads_test.go` / `host_writes_test.go` — extension SDK semantics widened additively (bare `MEMORY.md` still targets root)
- [x] `internal/cli/root_test.go::TestRunPreparedStartFlatValidationIgnoresNestedDrafts` — flat-mode regression guard
- [x] `internal/core/workspace/config_test.go` — TOML `[tasks.run] recursive = true` round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --recursive (-r) option for task discovery so "tasks run" can include task files in subdirectories; configurable via CLI or workspace config.
  * CLI help updated to document recursive discovery and how it interacts with other sync/scopes.

* **Behavior Changes**
  * Preflight validation and task selection now respect the recursive setting, affecting which nested tasks are discovered and validated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compozy/compozy/pull/153)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->