### PR TITLE
fix: emit one task slug per compozy completion candidate

### DIFF
--- a/zsh/compozy-completion/compozy-completion.plugin.zsh
+++ b/zsh/compozy-completion/compozy-completion.plugin.zsh
@@ -1,7 +1,7 @@
 #!/usr/bin/env zsh
 
-# Finds the nearest .compozy/tasks directory by walking up from the current
-# working directory.
+# Finds the nearest workspace `.compozy/tasks` directory by walking up from the
+# current working directory and returns the first match.
 _compozy_tasks_workspace() {
   local dir="$PWD"
 
@@ -18,6 +18,8 @@ _compozy_tasks_workspace() {
   return 1
 }
 
+# Returns a newline-separated list of task slugs found in the discovered
+# `.compozy/tasks` directory, one slug per line.
 _compozy_task_slugs() {
   local tasks_path
   local -a task_slugs
@@ -40,10 +42,8 @@ _compozy_task_slugs() {
   print -l -- "${task_slugs[@]}"
 }
 
-# Provides zsh completion for:
-# - `compozy tasks`
-# - `compozy tasks run`
-# - task slugs found under the discovered .compozy/tasks directory
+# Provides zsh completion for `compozy` command flows and returns task slugs for
+# completion of `compozy tasks run`.
 _compozy() {
   local -a comps
   local tasks_path

--- a/zsh/compozy-completion/compozy-completion.plugin.zsh
+++ b/zsh/compozy-completion/compozy-completion.plugin.zsh
@@ -18,6 +18,28 @@ _compozy_tasks_workspace() {
   return 1
 }
 
+_compozy_task_slugs() {
+  local tasks_path
+  local -a task_slugs
+  local task_path
+
+  tasks_path="$(_compozy_tasks_workspace)"
+  if [[ -z "$tasks_path" || ! -d "$tasks_path" ]]; then
+    return 1
+  fi
+
+  task_slugs=()
+  for task_path in "$tasks_path"/*(N/); do
+    task_slugs+=("${task_path:t}")
+  done
+
+  if (( ${#task_slugs[@]} == 0 )); then
+    return 1
+  fi
+
+  print -l -- "${task_slugs[@]}"
+}
+
 # Provides zsh completion for:
 # - `compozy tasks`
 # - `compozy tasks run`
@@ -41,18 +63,10 @@ _compozy() {
   fi
 
   if (( CURRENT >= 4 )) && [[ $words[2] == "tasks" ]] && [[ $words[3] == "run" ]]; then
-    tasks_path="$(_compozy_tasks_workspace)"
-
-    if [[ -n "$tasks_path" && -d "$tasks_path" ]]; then
-      task_slugs=()
-      for task_path in "$tasks_path"/*(N/); do
-        task_slugs+=("${task_path:t}")
-      done
-
-      if (( ${#task_slugs} > 0 )); then
-        compadd -Q -a task_slugs
-        return 0
-      fi
+    task_slugs=("${(@f)$(_compozy_task_slugs)}")
+    if (( ${#task_slugs[@]} > 0 )); then
+      compadd -Q -a task_slugs
+      return 0
     fi
   fi
 


### PR DESCRIPTION
## Summary
- Adjust compozy completion plugin in `zsh/compozy-completion/compozy-completion.plugin.zsh` to emit task slugs as separate completion candidates.
- Keep behavior unchanged for other completion paths.

## Testing
- Reloaded zsh and confirmed completion generation is fed with per-task lines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved zsh completion by extracting task discovery into a dedicated helper, simplifying completion logic and comments. End users benefit from cleaner, more reliable task name completion when using the shell.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compozy/compozy/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->