### PR TITLE
build: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 - 2026-08-21
+## 0.3.0 - 2026-08-22
 
 ### ♻️ Refactoring
 
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Complete Loop graph engineering and typed inputs (#427)
 - Simplify the interface for everyday users (#440)
 - Deliver the command palette operating surface (#441)
+- Make loop runs legible and task lists calm (#452)
 
 ### 🐛 Bug Fixes
 
@@ -131,6 +132,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve agent runtime recovery regressions (#447)
 - Preserve run-agent session lifecycle (#446)
 - Use migration timeout for tail replay
+- Recover ACP sessions after provider disconnects (#454)
 
 ### 🔧 Miscellaneous Tasks
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 - 2026-08-21
+## 0.3.0 - 2026-08-24
 
 ### ♻️ Refactoring
 
@@ -54,6 +54,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Complete Loop graph engineering and typed inputs (#427)
 - Simplify the interface for everyday users (#440)
 - Deliver the command palette operating surface (#441)
+- Make loop runs legible and task lists calm (#452)
+- Complete production demo seed (#453)
 
 ### 🐛 Bug Fixes
 
@@ -131,6 +133,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve agent runtime recovery regressions (#447)
 - Preserve run-agent session lifecycle (#446)
 - Use migration timeout for tail replay
+- Recover ACP sessions after provider disconnects (#454)
 
 ### 🔧 Miscellaneous Tasks
 

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,4 +1,4 @@
-## 0.3.0 - 2026-08-21
+## 0.3.0 - 2026-08-24
 
 ### ♻️ Refactoring
 
@@ -47,6 +47,8 @@
 - Complete Loop graph engineering and typed inputs (#427)
 - Simplify the interface for everyday users (#440)
 - Deliver the command palette operating surface (#441)
+- Make loop runs legible and task lists calm (#452)
+- Complete production demo seed (#453)
 
 ### 🐛 Bug Fixes
 
@@ -124,6 +126,7 @@
 - Resolve agent runtime recovery regressions (#447)
 - Preserve run-agent session lifecycle (#446)
 - Use migration timeout for tail replay
+- Recover ACP sessions after provider disconnects (#454)
 
 ### 🔧 Miscellaneous Tasks
 

--- a/RELEASE_BODY.md
+++ b/RELEASE_BODY.md
@@ -1,4 +1,4 @@
-## 0.3.0 - 2026-08-21
+## 0.3.0 - 2026-08-22
 
 ### ♻️ Refactoring
 
@@ -47,6 +47,7 @@
 - Complete Loop graph engineering and typed inputs (#427)
 - Simplify the interface for everyday users (#440)
 - Deliver the command palette operating surface (#441)
+- Make loop runs legible and task lists calm (#452)
 
 ### 🐛 Bug Fixes
 
@@ -124,6 +125,7 @@
 - Resolve agent runtime recovery regressions (#447)
 - Preserve run-agent session lifecycle (#446)
 - Use migration timeout for tail replay
+- Recover ACP sessions after provider disconnects (#454)
 
 ### 🔧 Miscellaneous Tasks
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-## 0.3.0 - 2026-08-21
+## 0.3.0 - 2026-08-24
 
 ### ♻️ Refactoring
 
@@ -47,6 +47,8 @@
 - Complete Loop graph engineering and typed inputs (#427)
 - Simplify the interface for everyday users (#440)
 - Deliver the command palette operating surface (#441)
+- Make loop runs legible and task lists calm (#452)
+- Complete production demo seed (#453)
 
 ### 🐛 Bug Fixes
 
@@ -124,6 +126,7 @@
 - Resolve agent runtime recovery regressions (#447)
 - Preserve run-agent session lifecycle (#446)
 - Use migration timeout for tail replay
+- Recover ACP sessions after provider disconnects (#454)
 
 ### 🔧 Miscellaneous Tasks
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-## 0.3.0 - 2026-08-21
+## 0.3.0 - 2026-08-22
 
 ### ♻️ Refactoring
 
@@ -47,6 +47,7 @@
 - Complete Loop graph engineering and typed inputs (#427)
 - Simplify the interface for everyday users (#440)
 - Deliver the command palette operating surface (#441)
+- Make loop runs legible and task lists calm (#452)
 
 ### 🐛 Bug Fixes
 
@@ -124,6 +125,7 @@
 - Resolve agent runtime recovery regressions (#447)
 - Preserve run-agent session lifecycle (#446)
 - Use migration timeout for tail replay
+- Recover ACP sessions after provider disconnects (#454)
 
 ### 🔧 Miscellaneous Tasks
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/compozy/compozy-web-assets v0.0.167
+	github.com/compozy/compozy-web-assets v0.0.173
 	github.com/compozy/compozy/sdk/go v0.0.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/dave/jennifer v1.7.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/coder/acp-go-sdk v0.13.5
-	github.com/compozy/compozy-web-assets v0.0.167
+	github.com/compozy/compozy-web-assets v0.0.170
 	github.com/compozy/compozy/sdk/go v0.0.0
 	github.com/creativeprojects/go-selfupdate v1.5.2
 	github.com/dave/jennifer v1.7.1

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/compozy/acp-go-sdk v0.13.5-compozy.2 h1:jrgwxoL6DBHrjzQPVs8LO6rUAyJFiTT3u1qdxcOlbMk=
 github.com/compozy/acp-go-sdk v0.13.5-compozy.2/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
-github.com/compozy/compozy-web-assets v0.0.167 h1:XpYc8/kUDHF9/4ibrN/oL4kmnDUch/wqUFcd1BVDjnA=
-github.com/compozy/compozy-web-assets v0.0.167/go.mod h1:+vAAEpoIVLAjo8/BbhgSB7IMWX+SG7uS/S5edn+suBo=
+github.com/compozy/compozy-web-assets v0.0.170 h1:mCD1HdlNSJP376B8cj/R7lpsA0o/ii1m7KEQ3iziQig=
+github.com/compozy/compozy-web-assets v0.0.170/go.mod h1:+vAAEpoIVLAjo8/BbhgSB7IMWX+SG7uS/S5edn+suBo=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6 h1:8h5+bWd7R6AYUslN6c6iuZWTKsKxUFDlpnmilO6R2n0=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/compozy/acp-go-sdk v0.13.5-compozy.2 h1:jrgwxoL6DBHrjzQPVs8LO6rUAyJFiTT3u1qdxcOlbMk=
 github.com/compozy/acp-go-sdk v0.13.5-compozy.2/go.mod h1:yKzM/3R9uELp4+nBAwwtkS0aN1FOFjo11CNPy37yFko=
-github.com/compozy/compozy-web-assets v0.0.167 h1:XpYc8/kUDHF9/4ibrN/oL4kmnDUch/wqUFcd1BVDjnA=
-github.com/compozy/compozy-web-assets v0.0.167/go.mod h1:+vAAEpoIVLAjo8/BbhgSB7IMWX+SG7uS/S5edn+suBo=
+github.com/compozy/compozy-web-assets v0.0.173 h1:J3IRGxW3Wn+oyFuy2wcNVNB4vhv841IpyU4fBA84uyI=
+github.com/compozy/compozy-web-assets v0.0.173/go.mod h1:+vAAEpoIVLAjo8/BbhgSB7IMWX+SG7uS/S5edn+suBo=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6 h1:8h5+bWd7R6AYUslN6c6iuZWTKsKxUFDlpnmilO6R2n0=
 github.com/coreos/go-iptables v0.7.1-0.20240112124308-65c67c9f46e6/go.mod h1:Qe8Bv2Xik5FyTXwgIbLAnv2sWSBmvWdFETJConOQ//Q=
 github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNvehc=


### PR DESCRIPTION

## Release v0.3.0

This PR prepares the release of version v0.3.0.

### Changelog

## 0.3.0 - 2026-08-24



### ♻️ Refactoring

- State management with xstate-store (#268)
- Site improvements (#277)
- Replace bundles with extension kits (#291)
- Modernize Go runtime packages (#293)
- Use geist instead of inter (#334)
- Add global workspace toggle (#368)
- Unify PRD and TechSpec into a single spec pipeline (#397)



### 🎉 Features

- Introducing CompozyOS beta
- **BREAKING:** introducing CompozyOS beta
- Add provider-neutral ACP speed control (#267)
- Support grouped skill directories (#270)
- Session transcript calm-surface redesign (#271)
- Add permission-aware cross-workspace access (#275)
- Extensions improvements (#278)
- Select and switch runtime per session prompt (#283)
- Adopt MCP 2026 and expand the curated catalog (#284)
- **BREAKING:** MCP catalogs now require manifest_version 2 and public
MCP transport no longer accepts SSE.
- Add support for window tabs (#287)
- Adopt feedback semantics for durable Loops (#290)
- Add complete Loop node lifecycle (#305)
- Rewind sessions to durable conversation checkpoints (#310)
- Add session-aware slash skill commands (#311)
- Add reversible session archiving and list actions (#309)
- Replace software-delivery with implement-tasks (#325)
- **BREAKING:** remove software-delivery; use implement-tasks without gate inputs.
- Parent and child sessions (#327)
- Add secure remote gateway access (#331)
- Ship CompozyOS desktop app (#336)
- Add first-class worktree support (#388)
- Close the loops UI visual-contract parity gap (#406)
- Unify zero-inventory empty states for jobs, triggers, and tasks (#409)
- Redesign workspaces overview as command-tab switcher (#410)
- Redesign trigger detail into the When/If/Then rule page (#411)
- Session attachments — paste, drop, and picker to multimodal agents end to end (#412)
- Add Agent Plugins ingestion to extensions (#419)
- Add session attention and orchestration parity (#422)
- Replace Tauri with Electron and unify updates (#424)
- Add Batuta to marketplace (#432)
- Complete Loop graph engineering and typed inputs (#427)
- Simplify the interface for everyday users (#440)
- Deliver the command palette operating surface (#441)
- Make loop runs legible and task lists calm (#452)
- Complete production demo seed (#453)



### 🐛 Bug Fixes

- Align release and process test contracts
- Workspace params (#266)
- Onboarding workspace selection
- Restore Windows daemon support (PR #163 regression + new fixes) (#274)
- Untested cases from qa (#276)
- Remaining untested qa (#279)
- Durable session messaging (#288)
- Assistant-ui version
- Changelog generation (#292)
- Make busy-session inputs durable (#304)
- Restore durable ACP session continuity (#307)
- Preserve Loop template manifests across hydration (#317)
- Preserve ACP stream disconnect recovery (#319)
- Discover Cursor model catalog before sessions (#320)
- Keep managed skill loading on native seam (#323)
- Loop run bugs (#324)
- Enforce bundled agent and Loop ownership (#326)
- Session native tools and extensions details (#330)
- Judge gate on goal loops
- Restore minimum-age dependencies
- Stabilize release runtime startup
- Start absent SSH daemon
- Make loop goals converge reliably (#335)
- Desktop issues
- Ship the full desktop icon set required by Windows tauri-build
- Pause the Windows desktop lane and ship macOS + Linux only
- Adjust project copy
- Publish staged GitHub release drafts
- Repair release integration contracts
- Harden desktop startup and diagnostics (#343)
- Resolve desktop and session usability issues (#351)
- Recover canceled Loop coordinators on restart (#353)
- Resolve extension-published agents for session command catalogs (#350)
- Eliminate persistent performance bottlenecks (#354)
- Reject automation trigger events no producer emits (#358)
- Read loop watch-events with a stream-global cursor (#356)
- Prevent session timeline render loops (#361)
- Align update artifacts with release policy (#363)
- Canonicalize desktop runtime manifests (#364)
- Validate desktop bundles before release
- Make release publication atomic
- Defer npm publication safely
- Harden release recovery
- Isolate release publishers
- Make release artifacts reproducible
- Align release automation contracts
- Reject invalid agent names (#367)
- Resolve extension agent skills and missing config paths (#372)
- Include extension tools in hosted MCP bootstrap (#373)
- Use conventional release triggers
- Resolve main lint regressions
- Parse nanosecond daemon timestamps
- Validate release workflow tools by type
- Preserve awaited child loop state (#391)
- Use exact Cursor ACP model values (#392)
- Preserve dead session history (#393)
- Validate desktop release smoke wiring
- Validate public CLI version command
- Clarify missing config path errors (#401)
- Guard autonomous memory extractor writes (#396)
- Write $ENV interpolation in pi runtime models.json apiKey (#404)
- Authorize daemon-owned loop effects (#407)
- Retain terminal loop effect results in web (#408)
- Bound desktop runtime health checks (#414)
- Preserve loop goal session lineage (#420)
- Support resource-only extension development (#423)
- Daemon path resolution
- Website font style
- Harden Loop runtime and graph execution (#438)
- Use candidate version in release dry-run
- Coalesce redundant ACP tool updates (#442)
- Resolve agent runtime recovery regressions (#447)
- Preserve run-agent session lifecycle (#446)
- Use migration timeout for tail replay
- Recover ACP sessions after provider disconnects (#454)



### 🔧 Miscellaneous Tasks

- *(mise)* Pin Go 1.26.6 (#433)



### 🧪 Testing

- Guard ACP initialize protocol version (#318)
- Align nightly runtime fixtures
- Align dead session recovery coverage
- Preserve loop claim tokens in daemon fixtures (#418)
- Fix cases failing

### Release notes included

- Extension kits replace Bundles
- Runtime hardening and secret-safe provider login
- implement-tasks replaces the software-delivery Loop
- The desktop app is now Electron
- The OS Release
- Agent Plugins install as extensions
- Agents operate commands without the UI
- Ask the agent when nothing matches
- Attention: know which session needs you
- Batuta in the Marketplace
- Bundled Tailscale connectivity extension
- Complete Loop node lifecycle
- Correct one output, repair one lane
- Cursor models come from your account
- Every domain opens inside the palette
- Extensions contribute commands and views
- Fan-out settles with an honest count
- First-class Git worktrees
- Grouped skill directories
- Feedback semantics for durable Loops
- Loop inputs that know what they point at
- Loops can stop and ask you a question
- Loops take one path and tell you why
- Loops UI and empty catalogs match their design contract
- Pin, rename, and bind any command
- Remote gateway: reach your daemon from anywhere
- Reversible session archiving and list actions
- Rewind a session to an earlier checkpoint
- Runtime speed is part of the runtime
- Session attachments: paste, drop, or pick
- Session-aware slash commands
- The command palette runs CompozyOS
- The interface speaks plain words at a legible size
- The workspace switcher works like Command-Tab
- Time travel — compare, rerun, and fork a Loop run
- Trigger detail is a rule page
- Unified docs and Marketplace
- Window tabs in the OS shell
- A burst of tool updates no longer drops the provider
- A crashed agent no longer looks like a finished one
- A finished Loop leaves nothing running
- A guarded history reference no longer crashes generation 1
- Autonomous extraction stays out of curated memory
- Dry-run proves the run you are about to submit
- Restart a stopped session and keep its runtime
- Durable inputs for busy sessions
- Durable session messaging
- Fan-out filters actually filter
- Four runtime regressions around prompts, permissions, and settlement
- Live changelog and composer fixes
- Loop runs keep their lineage, permissions, and results
- Loop runs you can debug from the run page
- Managed run-agent workers keep their lineage and let go
- Skills load through the native seam inside managed sessions
- One owner per Loop run, and cancellation that sticks
- Pi providers receive the secret, not its variable name
- Recover a Loop-owned task run without losing its place
- Removing the suggested Home folder no longer breaks the desktop
- Resource-only extensions need no toolchain
- The daemon owns a managed worker's outcome
- The desktop stays responsive with a large session catalog
- Gateway docs: zero to GitHub webhooks
- MCP catalog, session runtime, and extension management

### Full release details

The complete changelog and unabridged release notes are in [`RELEASE_BODY.md`](./RELEASE_BODY.md) and [`RELEASE_NOTES.md`](./RELEASE_NOTES.md) in this pull request.
