### PR TITLE
fix: preserve worktree binding during reconciliation

### DIFF
--- a/docs/qa/reports/2026-08-23-session-worktree-reconcile.md
+++ b/docs/qa/reports/2026-08-23-session-worktree-reconcile.md
@@ -1,0 +1,73 @@
+# QA Run Report — 2026-08-23 — session-worktree-reconcile
+
+- **Scope:** Daemon boot reconciliation preserves the worktree binding of an existing session.
+- **Cadence tier:** targeted
+- **Build:** `df7e80e4-dirty` · **Environment:** isolated local runtime lab
+- **Started:** 2026-08-23T00:24:43-03:00 · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Ada | isolated CLI workspace | local CLI / local network / pt-BR | CH-worktree-binding-containment |
+
+## Flows in Scope
+
+- `J-worktree-management` — create and resume a session bound to a ready worktree (`../journeys/J-worktree-management.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-worktree-binding-containment | J-worktree-management / RT-session-worktree-lifecycle | Ada | targeted CLI/runtime restart | Pass | [#455](https://github.com/compozy/compozy/issues/455) | uncommitted |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-worktree-binding-containment — Ada
+
+- **Ran:** 2026-08-23T00:26:19-03:00 → 2026-08-23T00:27:52-03:00 (box respected: yes)
+- **Findings:** The daemon restarted with one recovered session and no reconciliation error.
+- **Bugs filed/updated:** [#455](https://github.com/compozy/compozy/issues/455)
+- **Scenarios settled:** RT-session-worktree-lifecycle → pass
+- **Paper cuts:** None.
+- **Surprises:** The first explicit worktree path overlapped the registered workspace and was correctly rejected; the default managed path succeeded.
+- **Suggested next charter:** No adjacent journey is required for this narrow reconstruction fix.
+
+## What Was Fixed
+
+### #455: Daemon boot fails while reconciling a worktree-bound session
+
+- **Symptom:** The daemon refuses to start with a session participation mismatch.
+- **Root cause:** Boot reconciliation rebuilt the durable session projection without its persisted worktree ID.
+- **Fix:** Preserve the worktree ID when reconstructing `SessionInfo` from `meta.json`.
+- **Regression test:** `internal/observe/reconcile_test.go` — failed before the fix and passes after it.
+- **Retested:** A fresh isolated CLI/runtime walk stopped the bound session, restarted the daemon, then confirmed the same session and worktree ID through filtered list and independent status reads.
+
+## Paper Cuts
+
+None observed.
+
+## Runtime Errors Observed
+
+The initial explicit worktree path was rejected with `worktree_path_exists` because it overlapped the workspace root. This was expected containment behavior and the managed worktree path was used.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- Durable session metadata and the global projection must preserve immutable ownership fields through every reconstruction path.
+
+## Final Status
+
+- **Exit gate evidence:** The fingerprint-matched record in `.cache/gate/full.json` is authoritative. Historical failed runs are preserved at `.cache/gate/logs/full-1787455830.log` and `.cache/gate/logs/full-1787458643.log`; they identified Btrfs temporary-file semantics, an invalid external `/tmp/.git`, and stale extension rollback assertions after lifecycle ownership tokens were introduced. The changed `internal/observe` package passed in both runs.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1/1 journeys walked; isolated CLI and runtime surfaces passed. Strict QA audit passed with zero blockers and zero warnings.
+- **Verdict:** the targeted fix and runtime walk pass, and teardown evidence reports `clean: true` with no survivors. Repository merge readiness follows the current fingerprint-matched full-gate record.

--- a/docs/qa/scenarios/RT-session-worktree-lifecycle.md
+++ b/docs/qa/scenarios/RT-session-worktree-lifecycle.md
@@ -11,8 +11,8 @@ bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-worktree-support-20260813-083057-155448-lab/qa-artifacts/qa/native-handoff-fixed-task.json; /Users/pedronauck/dev/qa-labs/compozy-worktree-support-20260813-083057-155448-lab/qa-artifacts/qa/browser-worktree-bound-context.png; internal/daemon/daemon_worktree_e2e_integration_test.go
-last_report: docs/qa/reports/2026-08-13-worktree-support.md
+evidence: /Users/pedronauck/dev/qa-labs/compozy-worktree-support-20260813-083057-155448-lab/qa-artifacts/qa/native-handoff-fixed-task.json; /Users/pedronauck/dev/qa-labs/compozy-worktree-support-20260813-083057-155448-lab/qa-artifacts/qa/browser-worktree-bound-context.png; internal/daemon/daemon_worktree_e2e_integration_test.go; /home/francisross/dev/qa-labs/compozy-session-worktree-reconcile-20260823-032508-181632-lab/qa-artifacts/qa/cli-runtime-evidence.json; internal/observe/reconcile_test.go
+last_report: docs/qa/reports/2026-08-23-session-worktree-reconcile.md
 overlaps: RT-worktree-api-surface-parity; RT-worktree-cli-lifecycle
 ---
 

--- a/internal/observe/reconcile.go
+++ b/internal/observe/reconcile.go
@@ -172,6 +172,7 @@ func recoveredSessionFromMeta(meta *store.SessionMeta) recoveredSession {
 		RuntimeTransition: meta.RuntimeTransition,
 		RuntimeFailure:    store.SessionRuntimeFailureValue(meta.RuntimeFailure),
 		WorkspaceID:       meta.WorkspaceID,
+		WorktreeID:        meta.WorktreeIDValue(),
 		SessionType:       meta.SessionType,
 		Lineage:           store.CloneSessionLineage(meta.Lineage),
 		State:             meta.State,

--- a/internal/observe/reconcile_test.go
+++ b/internal/observe/reconcile_test.go
@@ -459,12 +459,20 @@ func TestReconciliationPreservesWorktreeBinding(t *testing.T) {
 			t.Fatalf("WriteSessionMeta() error = %v", err)
 		}
 
-		result, err := h.observer.Reconcile(ctx)
+		firstResult, err := h.observer.Reconcile(ctx)
 		if err != nil {
-			t.Fatalf("Reconcile() error = %v", err)
+			t.Fatalf("first Reconcile() error = %v", err)
 		}
-		if len(result.Indexed) != 0 {
-			t.Fatalf("Indexed = %#v, want empty for an existing session", result.Indexed)
+		if len(firstResult.Indexed) != 0 {
+			t.Fatalf("first Indexed = %#v, want empty for an existing session", firstResult.Indexed)
+		}
+
+		secondResult, err := h.observer.Reconcile(ctx)
+		if err != nil {
+			t.Fatalf("second Reconcile() error = %v", err)
+		}
+		if len(secondResult.Indexed) != 0 {
+			t.Fatalf("second Indexed = %#v, want empty for an existing session", secondResult.Indexed)
 		}
 		sessions, err := h.registry.ListSessions(ctx, store.SessionListQuery{})
 		if err != nil {

--- a/internal/observe/reconcile_test.go
+++ b/internal/observe/reconcile_test.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/compozy/compozy/internal/network/participation"
 	"github.com/compozy/compozy/internal/soul"
-	"github.com/compozy/compozy/internal/testutil"
-
 	"github.com/compozy/compozy/internal/store"
+	"github.com/compozy/compozy/internal/testutil"
+	worktreepkg "github.com/compozy/compozy/internal/worktree"
 )
 
 func TestReconciliationIndexesSessionDirNotInDB(t *testing.T) {
@@ -354,6 +354,127 @@ func TestReconciliationPreservesDurableSessionProjectionMetadata(t *testing.T) {
 			recent.FailureKind != store.FailureProcess ||
 			recent.Summary != "agent exited with status 1" {
 			t.Fatalf("Health().Failures.Recent[0] = %#v, want reconstructed failure", recent)
+		}
+	})
+}
+
+func TestReconciliationPreservesWorktreeBinding(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Should refresh an identity-bound session without losing its worktree", func(t *testing.T) {
+		t.Parallel()
+
+		h := newHarness(t)
+		ctx := testutil.Context(t)
+		now := h.now.Add(40 * time.Minute)
+		sessionID := "sess-worktree-bound"
+		worktreeID := "wt-session-reconcile"
+		worktreePath := filepath.Join(h.workspace, ".worktrees", "session-reconcile")
+		if err := h.registry.Worktrees.Insert(ctx, worktreepkg.Worktree{
+			ID:          worktreeID,
+			WorkspaceID: h.workspaceID,
+			Name:        "session-reconcile",
+			Branch:      "fix/session-reconcile",
+			Path:        worktreePath,
+			State:       worktreepkg.StateReady,
+			Origin:      worktreepkg.OriginManual,
+			SetupState:  worktreepkg.SetupNone,
+			CreatedAt:   now,
+			UpdatedAt:   now,
+		}); err != nil {
+			t.Fatalf("Insert(worktree) error = %v", err)
+		}
+
+		creationProfile := store.SessionCreationProfile{
+			Version: store.SessionCreationProfileVersion, AgentName: "coder", Provider: "claude",
+			WorkspaceID: h.workspaceID, CWD: worktreePath, WorktreeRef: worktreeID,
+			SandboxMode: store.SessionCreationSandboxNone, Permissions: "approve-reads",
+		}
+		creationOptions := store.SessionCreationOptions{
+			SessionID:            sessionID,
+			Name:                 "Worktree-bound session",
+			NetworkOwnerKey:      "session:" + sessionID,
+			NetworkParticipation: participation.LocalSpec(),
+			SessionType:          "user",
+		}
+		creationProfileRef, err := h.registry.PutSessionCreationProfile(ctx, creationProfile)
+		if err != nil {
+			t.Fatalf("PutSessionCreationProfile() error = %v", err)
+		}
+		policySpecDigest, err := creationProfile.PolicySpecDigest()
+		if err != nil {
+			t.Fatalf("SessionCreationProfile.PolicySpecDigest() error = %v", err)
+		}
+		creationDigest, err := creationProfile.CreationDigest(creationOptions)
+		if err != nil {
+			t.Fatalf("SessionCreationProfile.CreationDigest() error = %v", err)
+		}
+		creationIdentity := store.SessionCreationIdentity{
+			CreationProfileRef: creationProfileRef,
+			PolicySpecDigest:   policySpecDigest,
+			CreationDigest:     creationDigest,
+		}
+		info := store.SessionInfo{
+			ID:            sessionID,
+			Name:          creationOptions.Name,
+			AgentName:     creationProfile.AgentName,
+			Provider:      creationProfile.Provider,
+			RuntimeStatus: store.SessionRuntimeUnbound,
+			WorkspaceID:   h.workspaceID,
+			WorktreeID:    worktreeID,
+			SessionType:   creationOptions.SessionType,
+			State:         "stopped",
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		}
+		info.SetNetworkSpec(creationOptions.NetworkParticipation)
+		if _, err := h.registry.RegisterSessionWithCreationIdentity(ctx, info, creationIdentity); err != nil {
+			t.Fatalf("RegisterSessionWithCreationIdentity() error = %v", err)
+		}
+
+		meta := store.SessionMeta{
+			ID:                   sessionID,
+			Name:                 creationOptions.Name,
+			AgentName:            creationProfile.AgentName,
+			Provider:             creationProfile.Provider,
+			RuntimeStatus:        store.SessionRuntimeUnbound,
+			WorkspaceID:          h.workspaceID,
+			CWD:                  worktreePath,
+			NetworkParticipation: participation.CloneSpec(creationOptions.NetworkParticipation),
+			SessionType:          creationOptions.SessionType,
+			State:                "stopped",
+			CreationProfile:      &creationProfile,
+			CreationOptions:      &creationOptions,
+			CreationProfileRef:   creationIdentity.CreationProfileRef,
+			PolicySpecDigest:     creationIdentity.PolicySpecDigest,
+			CreationDigest:       creationIdentity.CreationDigest,
+			CreatedAt:            now,
+			UpdatedAt:            now,
+		}
+		meta.SetWorktreeID(worktreeID)
+		if err := store.WriteSessionMeta(
+			store.SessionMetaFile(filepath.Join(h.home.SessionsDir, sessionID)),
+			meta,
+		); err != nil {
+			t.Fatalf("WriteSessionMeta() error = %v", err)
+		}
+
+		result, err := h.observer.Reconcile(ctx)
+		if err != nil {
+			t.Fatalf("Reconcile() error = %v", err)
+		}
+		if len(result.Indexed) != 0 {
+			t.Fatalf("Indexed = %#v, want empty for an existing session", result.Indexed)
+		}
+		sessions, err := h.registry.ListSessions(ctx, store.SessionListQuery{})
+		if err != nil {
+			t.Fatalf("ListSessions() error = %v", err)
+		}
+		if got, want := len(sessions), 1; got != want {
+			t.Fatalf("len(sessions) = %d, want %d", got, want)
+		}
+		if got, want := sessions[0].WorktreeID, worktreeID; got != want {
+			t.Fatalf("sessions[0].WorktreeID = %q, want %q", got, want)
 		}
 	})
 }

--- a/internal/observe/reconcile_test.go
+++ b/internal/observe/reconcile_test.go
@@ -371,6 +371,7 @@ func TestReconciliationPreservesWorktreeBinding(t *testing.T) {
 		worktreeID := "wt-session-reconcile"
 		worktreePath := filepath.Join(h.workspace, ".worktrees", "session-reconcile")
 		if err := h.registry.Worktrees.Insert(ctx, worktreepkg.Worktree{
+			ProfileID:   store.DefaultProfileID,
 			ID:          worktreeID,
 			WorkspaceID: h.workspaceID,
 			Name:        "session-reconcile",
@@ -387,6 +388,7 @@ func TestReconciliationPreservesWorktreeBinding(t *testing.T) {
 
 		creationProfile := store.SessionCreationProfile{
 			Version: store.SessionCreationProfileVersion, AgentName: "coder", Provider: "claude",
+			ProfileID:   store.DefaultProfileID,
 			WorkspaceID: h.workspaceID, CWD: worktreePath, WorktreeRef: worktreeID,
 			SandboxMode: store.SessionCreationSandboxNone, Permissions: "approve-reads",
 		}
@@ -415,6 +417,7 @@ func TestReconciliationPreservesWorktreeBinding(t *testing.T) {
 			CreationDigest:     creationDigest,
 		}
 		info := store.SessionInfo{
+			ProfileID:     store.DefaultProfileID,
 			ID:            sessionID,
 			Name:          creationOptions.Name,
 			AgentName:     creationProfile.AgentName,
@@ -433,13 +436,13 @@ func TestReconciliationPreservesWorktreeBinding(t *testing.T) {
 		}
 
 		meta := store.SessionMeta{
+			ProfileID:            store.DefaultProfileID,
 			ID:                   sessionID,
 			Name:                 creationOptions.Name,
 			AgentName:            creationProfile.AgentName,
 			Provider:             creationProfile.Provider,
 			RuntimeStatus:        store.SessionRuntimeUnbound,
 			WorkspaceID:          h.workspaceID,
-			CWD:                  worktreePath,
 			NetworkParticipation: participation.CloneSpec(creationOptions.NetworkParticipation),
 			SessionType:          creationOptions.SessionType,
 			State:                "stopped",
@@ -451,6 +454,7 @@ func TestReconciliationPreservesWorktreeBinding(t *testing.T) {
 			CreatedAt:            now,
 			UpdatedAt:            now,
 		}
+		meta.SetCWD(worktreePath)
 		meta.SetWorktreeID(worktreeID)
 		if err := store.WriteSessionMeta(
 			store.SessionMetaFile(filepath.Join(h.home.SessionsDir, sessionID)),
@@ -474,7 +478,9 @@ func TestReconciliationPreservesWorktreeBinding(t *testing.T) {
 		if len(secondResult.Indexed) != 0 {
 			t.Fatalf("second Indexed = %#v, want empty for an existing session", secondResult.Indexed)
 		}
-		sessions, err := h.registry.ListSessions(ctx, store.SessionListQuery{})
+		sessions, err := h.registry.ListSessions(ctx, store.SessionListQuery{
+			ReadScope: store.ReadScope{ProfileID: store.DefaultProfileID},
+		})
 		if err != nil {
 			t.Fatalf("ListSessions() error = %v", err)
 		}


### PR DESCRIPTION
## Summary

- preserve the persisted worktree ID when boot reconciliation rebuilds an existing session projection
- add regression coverage for identity-bound sessions so immutable participation does not mismatch at daemon startup
- update extension rollback assertions to ignore the intentionally volatile internal lifecycle ownership token introduced on main
- record the isolated runtime QA walk and teardown evidence

## Verification

- `make gate-full`
- `CGO_ENABLED=1 go test -race ./internal/daemon/... ./internal/extension/... ./internal/cli/... ./internal/worktree/... ./internal/observe/...`
- isolated daemon restart with a stopped worktree-bound session

## Compozy Impact Audit

- Native tools: no tool IDs, descriptors, schemas, digests, risk flags, or capability gates changed
- Extensibility and hooks: no extension, hook, skill, capability, resource, registry, bridge SDK, MCP, or config lifecycle contract changed
- Workspace data isolation: existing workspace-scoped session data now preserves its worktree binding during boot reconciliation; no new data scope was introduced
- Official Compozy skill: no public behavior, CLI path, native tool ID, hook event, or capability changed

Fixes #455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved worktree associations when recovering sessions.
  * Prevented duplicate session indexing during reconciliation.
* **Tests**
  * Added coverage confirming repeated reconciliation retains a single session and its worktree binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->