### PR TITLE
fix: restore reliable session message copy

### DIFF
--- a/desktop/e2e/_electron/__tests__/shell.spec.ts
+++ b/desktop/e2e/_electron/__tests__/shell.spec.ts
@@ -935,19 +935,65 @@ test("E2E-024: status, healthy retry, diagnose, and diagnostic bundle remain age
   }
 });
 
-test("E2E-034: packaged product and boot windows enforce their security boundaries", async ({
+test("E2E-034: packaged windows enforce security boundaries and intentional debugging", async ({
   launchDesktop,
 }) => {
-  const desktop = await launchDesktop();
+  const desktop = await launchDesktop({
+    environment: { COMPOZY_DESKTOP_E2E_FOREGROUND: "1" },
+  });
   const product = await desktop.product();
   expect(await product.evaluate(async () => await Notification.requestPermission())).toBe("denied");
+
+  const clipboardValue = "Copied through the packaged Electron product window";
+  expect(
+    await product.evaluate(async value => {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }, clipboardValue)
+  ).toBe(true);
+  expect(await desktop.app.evaluate(({ clipboard }) => clipboard.readText())).toBe(clipboardValue);
+
+  // Playwright's page keyboard does not enter Electron's native input path on macOS;
+  // sendInputEvent supplies the exact Control+Option+I chord that a physical keypress emits.
   await desktop.app.evaluate(({ BrowserWindow }) => {
-    const window = BrowserWindow.getAllWindows().find(candidate => {
-      const url = candidate.webContents.getURL();
-      return url.startsWith("http://") || url.startsWith("https://");
+    const productWindow = BrowserWindow.getAllWindows().find(window =>
+      /^https?:/u.test(window.webContents.getURL())
+    );
+    if (!productWindow) throw new Error("Product window missing before shortcut probe.");
+    productWindow.webContents.sendInputEvent({
+      type: "keyDown",
+      keyCode: "I",
+      modifiers: ["control", "alt"],
     });
-    if (!window) throw new Error("The product window is missing.");
-    window.webContents.openDevTools();
+    productWindow.webContents.sendInputEvent({
+      type: "keyUp",
+      keyCode: "I",
+      modifiers: ["control", "alt"],
+    });
+  });
+  await expect
+    .poll(
+      async () =>
+        await desktop.app.evaluate(({ BrowserWindow }) =>
+          BrowserWindow.getAllWindows().some(window => window.webContents.isDevToolsOpened())
+        )
+    )
+    .toBe(true);
+  await desktop.app.evaluate(({ BrowserWindow }) => {
+    const productWindow = BrowserWindow.getAllWindows().find(window =>
+      /^https?:/u.test(window.webContents.getURL())
+    );
+    if (!productWindow) throw new Error("Product window missing before shortcut close.");
+    productWindow.webContents.sendInputEvent({
+      type: "keyDown",
+      keyCode: "I",
+      modifiers: ["control", "alt"],
+    });
+    productWindow.webContents.sendInputEvent({
+      type: "keyUp",
+      keyCode: "I",
+      modifiers: ["control", "alt"],
+    });
   });
   await expect
     .poll(

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -264,6 +264,7 @@ async function start(): Promise<void> {
       const runtime = await runner.run(async event => {
         await statePublisher.publish(bootstrapSnapshot(event, paths.bootstrapLog));
       });
+      applyDefaultDenyPermissions(session.defaultSession, runtime.origin);
       await statePublisher.setRuntime(runtime.version, runtime.owned);
       startUpdateConsumer(statePublisher);
       runtimeMonitor?.stop();

--- a/desktop/src/window/application-menu.ts
+++ b/desktop/src/window/application-menu.ts
@@ -31,6 +31,12 @@ export function installApplicationMenu(product: () => ProductWindow | null): voi
       },
       { type: "separator" },
       { role: "reload" },
+      { type: "separator" },
+      {
+        label: "Developer Tools",
+        accelerator: "Control+Alt+I",
+        click: () => product()?.toggleDevTools(),
+      },
     ],
   });
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));

--- a/desktop/src/window/product-window.ts
+++ b/desktop/src/window/product-window.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, screen } from "electron";
+import { BrowserWindow, dialog, screen } from "electron";
 
 import { productDeepLink, productNavigationURL, type DeepLinkQueue } from "../deep-links/deep-link";
 import { writeWindowState, readWindowState, type StoredWindowState } from "./window-state-store";
@@ -83,7 +83,7 @@ export class ProductWindow {
         sandbox: true,
         nodeIntegration: false,
         webviewTag: false,
-        devTools: !app.isPackaged,
+        devTools: true,
       },
     });
     this.#window = window;
@@ -130,6 +130,16 @@ export class ProductWindow {
     this.#scheduleSave();
   }
 
+  toggleDevTools(): void {
+    const window = this.#window;
+    if (!window || window.isDestroyed()) return;
+    if (window.webContents.isDevToolsOpened()) {
+      window.webContents.closeDevTools();
+      return;
+    }
+    window.webContents.openDevTools({ mode: "detach" });
+  }
+
   async flushState(): Promise<void> {
     if (this.#saveTimer) clearTimeout(this.#saveTimer);
     this.#saveTimer = null;
@@ -155,6 +165,16 @@ export class ProductWindow {
       this.#navigatePending();
     });
     window.webContents.on("before-input-event", (event, input) => {
+      if (
+        input.type === "keyDown" &&
+        input.alt &&
+        (input.control || input.meta) &&
+        input.key.toLowerCase() === "i"
+      ) {
+        event.preventDefault();
+        this.toggleDevTools();
+        return;
+      }
       if (!input.control && !input.meta) return;
       const direction =
         input.key === "0"

--- a/desktop/src/window/security.ts
+++ b/desktop/src/window/security.ts
@@ -1,10 +1,44 @@
-import { app, type BrowserWindow, type Session, shell } from "electron";
+import { type BrowserWindow, type Session, shell } from "electron";
 
 import { classifyNavigation, safeExternalURL } from "./navigation-policy";
 
-export function applyDefaultDenyPermissions(session: Session): void {
-  session.setPermissionCheckHandler(() => false);
-  session.setPermissionRequestHandler((_webContents, _permission, callback) => callback(false));
+function normalizedOrigin(raw: string | undefined): string | null {
+  if (!raw) return null;
+  try {
+    return new URL(raw).origin;
+  } catch {
+    return null;
+  }
+}
+
+function allowsProductClipboardWrite(
+  permission: string,
+  requestingURL: string,
+  isMainFrame: boolean,
+  productOrigin: string | undefined
+): boolean {
+  return (
+    isMainFrame &&
+    permission === "clipboard-sanitized-write" &&
+    normalizedOrigin(requestingURL) !== null &&
+    normalizedOrigin(requestingURL) === normalizedOrigin(productOrigin)
+  );
+}
+
+export function applyDefaultDenyPermissions(session: Session, productOrigin?: string): void {
+  session.setPermissionCheckHandler((_webContents, permission, requestingOrigin, details) =>
+    allowsProductClipboardWrite(permission, requestingOrigin, details.isMainFrame, productOrigin)
+  );
+  session.setPermissionRequestHandler((_webContents, permission, callback, details) =>
+    callback(
+      allowsProductClipboardWrite(
+        permission,
+        details.requestingUrl,
+        details.isMainFrame,
+        productOrigin
+      )
+    )
+  );
 }
 
 export function guardWindowNavigation(
@@ -26,7 +60,4 @@ export function guardWindowNavigation(
     openExternal(details.url);
     return { action: "deny" };
   });
-  if (app.isPackaged) {
-    window.webContents.on("devtools-opened", () => window.webContents.closeDevTools());
-  }
 }

--- a/docs/qa/reports/2026-08-24-eng-145-session-copy.md
+++ b/docs/qa/reports/2026-08-24-eng-145-session-copy.md
@@ -1,0 +1,68 @@
+# QA Run Report — 2026-08-24 — eng-145-session-copy
+
+- **Scope:** ENG-145 Session message copy visibility and Clipboard API outcome feedback
+- **Cadence tier:** targeted
+- **Build:** working tree before review · **Environment:** local Storybook story with MSW transcript fixtures; production-parity daemon/auth not available in this worktree
+- **Started:** 2026-08-24T21:20:00-03:00 · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Rafa | Casual User | desktop / wifi-fast / en-US | CH-message-actions-copy-timestamp |
+
+## Flows in Scope
+
+- `J-14` — Read a finished transcript (`../journeys/J-14-read-a-finished-transcript.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-message-actions-copy-timestamp | J-14 / RT-053 | Rafa | Feature Tour | Blocked (needs human verify) | Production-parity daemon/auth unavailable; Storybook preview stalled before the transcript rendered | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-message-actions-copy-timestamp — Rafa
+
+- **Ran:** 2026-08-24T21:20:00-03:00 → 2026-08-24T21:24:00-03:00 (box respected: yes)
+- **Findings:**
+  - The Storybook manager loaded and exposed the `Hover Toolbar` story entry. Opening the isolated preview did not reach a stable rendered transcript within the browser command timeout; the story uses MSW fixtures and cannot prove production parity.
+- **Bugs filed/updated:** []
+- **Scenarios settled:** RT-053 → blocked-verify
+- **Paper cuts:** None observed before the preview stall.
+- **Surprises:** The existing charter still describes hover-only and hidden streaming behavior; the implementation and scenario contract now intentionally supersede those stale instructions.
+- **Suggested next charter:** Re-run this same charter from an isolated authenticated Session daemon, not Storybook.
+
+## What Was Fixed
+
+### ENG-145: Session copy action visibility and reliability
+
+- **Symptom:** Session copy actions were hidden behind hover and clipboard failures were silent.
+- **Root cause:** MessageActions applied opacity/pointer-event gating; the shared primitive had no user-facing outcome notification; action derivation hid streaming text.
+- **Fix:** Persistent action row, settled-so-far streaming copy, guarded Clipboard API write, and success/failure toast feedback.
+- **Regression test:** `web/src/components/assistant-ui/__tests__/session-thread.test.tsx`; `packages/ui/src/components/custom/__tests__/code-block.test.tsx` — focused suites pass.
+- **Retested:** Automated component and primitive suites pass; browser parity walk remains pending the isolated daemon/auth environment.
+
+## Paper Cuts
+
+| Persona | Where (journey/step) | Felt | Sharpness | Outcome |
+|---|---|---|---|---|
+| Rafa | J-14 step 3 | "The action should not disappear while I move the pointer." | sharp | fixed in ENG-145 |
+
+## Runtime Errors Observed
+
+- None in the focused automated suites. Storybook/MSW parity is not an independent production read path.
+
+## Human Verifications Needed
+
+- [ ] From a production-parity authenticated Session, walk `CH-message-actions-copy-timestamp` on desktop: verify plain user text, user text with attachments, long clamped user text, settled assistant markdown, streaming assistant partial text, and tool-only turns. Confirm actions are visible without hover, copy exact text, success/failure feedback is announced, timestamp/rewind placement is unchanged, and the result survives reload. Record screenshots in `docs/qa/evidence/2026-08-24-eng-145-session-copy/` and update `RT-053` to `pass` with the report path. (row #1)
+
+## Final Status
+
+- **Exit gate (full automated suite):** Not run by instruction; focused Turbo tests and typecheck passed.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 1 · Friction 0 · Cosmetic 0
+- **Coverage:** 0/1 production-parity journeys walked; Storybook manager smoke attempted, preview stall and parity gap disclosed.
+- **Verdict:** ready with blocked items — merge the implementation only with the targeted production-parity Session walk completed by a human or isolated QA lab.

--- a/docs/qa/reports/2026-08-25-eng-145-electron.md
+++ b/docs/qa/reports/2026-08-25-eng-145-electron.md
@@ -1,0 +1,40 @@
+# QA Run Report — 2026-08-25 — eng-145-electron
+
+- **Scope:** ENG-145 packaged Electron clipboard permission and product DevTools shortcut
+- **Cadence tier:** targeted
+- **Build:** local packaged macOS arm64 fixture from the current worktree · **Environment:** Electron 43.4.0, fixture daemon, generated `web/dist`
+- **Started:** 2026-08-25T01:22:00Z · **Status:** closed
+
+## Matrix
+
+| # | Scenario | Persona | Result | Evidence |
+|---|---|---|---|---|
+| 1 | ET-electron-session-copy-debug | Bruno | Blocked (needs human verify) | `desktop/e2e/_electron/__tests__/shell.spec.ts` E2E-034 passed; physical OS walk pending |
+
+## What was verified
+
+- The packaged product's `navigator.clipboard.writeText` resolved and the Electron main-process clipboard contained the exact text.
+- Notification permission remained denied while the product-origin clipboard write succeeded.
+- The exact `Control+Alt+I` native input event opened the product DevTools and the second chord closed it.
+- The existing packaged security probe still found no remote-debugging endpoint; the boot window remains `devTools: false`.
+- The Playwright fixture completed its application and daemon teardown after the passing run.
+
+## Commands
+
+- `make desktop-test` — 137/137 tests passed.
+- `make desktop-lint` — format, lint, and typecheck passed.
+- `make desktop-build` — packaged macOS arm64 app built.
+- `make web-build` — generated the daemon-served `web/dist` bundle required by the fixture.
+- `cd desktop && ./node_modules/.bin/playwright test --config playwright.config.ts --grep "E2E-034"` — 1/1 passed.
+
+## Human verification still required
+
+- Launch a production-parity authenticated packaged Electron app on macOS.
+- Copy a user message and an assistant markdown answer, then confirm the exact OS clipboard contents and success/failure feedback.
+- Press physical `Control+Option+I` (`Ctrl+Opt+I`) while the product window is focused; confirm the DevTools console opens and the second press closes it.
+- Confirm the boot window does not expose DevTools and `http://127.0.0.1:<port>/json/version` remains unavailable.
+- Capture evidence under `docs/qa/evidence/2026-08-25-eng-145-electron/` and update `ET-electron-session-copy-debug` and `RT-053` to `pass`.
+
+## Verdict
+
+The Electron implementation and packaged regression gate pass. The scenario remains `blocked-verify` because this environment cannot supply the required production-parity authenticated session and a real physical macOS keyboard/clipboard walk.

--- a/docs/qa/scenarios/ET-electron-session-copy-debug.md
+++ b/docs/qa/scenarios/ET-electron-session-copy-debug.md
@@ -1,0 +1,21 @@
+---
+id: ET-electron-session-copy-debug
+area: ET
+title: Copy Session text and open Electron diagnostics
+persona: Bruno
+journey: J-operate-desktop-shell
+expected: The packaged product window can copy the visible Session message through the OS clipboard because the exact daemon origin is allowed `clipboard-sanitized-write`; unrelated permission requests remain denied. `Ctrl+Opt+I` toggles DevTools for the product window, boot remains non-debuggable, and no remote-debugging endpoint is exposed.
+entry_points: packaged Electron product window; SessionThread copy action; `Ctrl+Opt+I`
+qa_status: blocked-verify
+bug_ids:
+fix_status: fixed
+retest_status: blocked-verify
+fix_commits:
+evidence: docs/qa/reports/2026-08-25-eng-145-electron.md
+last_report: docs/qa/reports/2026-08-25-eng-145-electron.md
+overlaps: RT-053; APP-desktop-native-edit-shortcuts; ET-web-desktop-shell-lifecycle
+---
+
+story: As a desktop operator, I can copy a Session answer and intentionally open the product diagnostics console without weakening the shell's other security boundaries.
+
+QA impact 2026-08-25: ENG-145 now covers the Electron permission seam and the product-only `Ctrl+Opt+I` debugging path. The focused packaged E2E passed; a physical macOS walk is still required before this scenario can become `pass`.

--- a/docs/qa/scenarios/RT-053.md
+++ b/docs/qa/scenarios/RT-053.md
@@ -1,18 +1,18 @@
 ---
 id: RT-053
 area: RT
-title: Message hover toolbar (copy + timestamp)
+title: Persistent message toolbar (copy + timestamp)
 persona: Rafa
 journey: J-14
-expected: Hovering or keyboard-focusing (focus-within) a settled assistant message reveals only a copy affordance (whole markdown source) plus the turn timestamp, with no Goal action; copy is hidden while the turn streams and on pure tool-work turns with no text answer. User messages reveal a copy affordance too. Copy flips to a check on success.
+expected: Every user or assistant message with copyable text keeps only a copy affordance (whole markdown source) plus the turn timestamp visible and keyboard reachable without hover, with no Goal action; a streaming turn copies the text settled so far, while pure tool-work turns with no text answer have no dead copy button. Copy flips to a check on success and reports failures explicitly.
 entry_points: web SessionThread; Storybook components-assistant-ui-sessionthread--hover-toolbar
-qa_status: pass
+qa_status: blocked-verify
 bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence: docs/qa/reports/2026-07-08-session-improvements.md;/Users/pedronauck/dev/qa-labs/compozy-durable-acp-sessions-20260804-164200-701355-lab/qa-artifacts/qa/evidence/message-actions.txt
-last_report: docs/qa/reports/2026-08-04-durable-acp-sessions.md
+evidence: docs/qa/reports/2026-07-08-session-improvements.md;/Users/pedronauck/dev/qa-labs/compozy-durable-acp-sessions-20260804-164200-701355-lab/qa-artifacts/qa/evidence/message-actions.txt;docs/qa/reports/2026-08-24-eng-145-session-copy.md
+last_report: docs/qa/reports/2026-08-24-eng-145-session-copy.md
 overlaps: RT-043; RT-049
 ---
 
@@ -25,5 +25,9 @@ src: .compozy/tasks/session-improvements/task_29.md
 Task43 QA 2026-07-08: scenario covered by persona charter plus required E2E lanes; no open truthful-UI blocker observed.
 
 QA impact 2026-08-04: the assistant-response Goal shortcut was removed. Reset to verify that the settled toolbar contains only copy and timestamp while `/goal` remains composer-owned.
+
+QA impact 2026-08-24: ENG-145 makes the Session copy action persistently visible, keeps partial streaming text copyable, and adds explicit Clipboard API failure feedback. Reset for a focused re-walk of settled, streaming, attachment, tool-only, and failure states.
+
+QA 2026-08-24 ENG-145: Automated SessionThread and CopyIconButton suites passed. The production-parity browser walk is blocked because this worktree has no isolated authenticated daemon/session, and the Storybook MSW preview stalled before rendering a stable transcript. Re-run from a real Session entry point and update this row to `pass` with screenshots covering the focused states.
 
 QA 2026-08-04: interactive accessibility inspection showed only `Copy message` controls on settled messages and no Goal action. Entering `/goal status` still used the intended composer command path.

--- a/docs/qa/scenarios/RT-053.md
+++ b/docs/qa/scenarios/RT-053.md
@@ -5,7 +5,7 @@ title: Persistent message toolbar (copy + timestamp)
 persona: Rafa
 journey: J-14
 expected: Every user or assistant message with copyable text keeps only a copy affordance (whole markdown source) plus the turn timestamp visible and keyboard reachable without hover, with no Goal action; a streaming turn copies the text settled so far, while pure tool-work turns with no text answer have no dead copy button. Copy flips to a check on success and reports failures explicitly.
-entry_points: web SessionThread; Storybook components-assistant-ui-sessionthread--hover-toolbar
+entry_points: web SessionThread; packaged Electron SessionThread; Storybook components-assistant-ui-sessionthread--hover-toolbar
 qa_status: blocked-verify
 bug_ids:
 fix_status:
@@ -27,6 +27,8 @@ Task43 QA 2026-07-08: scenario covered by persona charter plus required E2E lane
 QA impact 2026-08-04: the assistant-response Goal shortcut was removed. Reset to verify that the settled toolbar contains only copy and timestamp while `/goal` remains composer-owned.
 
 QA impact 2026-08-24: ENG-145 makes the Session copy action persistently visible, keeps partial streaming text copyable, and adds explicit Clipboard API failure feedback. Reset for a focused re-walk of settled, streaming, attachment, tool-only, and failure states.
+
+QA impact 2026-08-25: the packaged Electron product now grants only the exact daemon-origin clipboard write needed by Session copy and keeps the product-only `Ctrl+Opt+I` DevTools toggle available while boot and remote debugging remain closed. Reset for a production-parity Electron walk.
 
 QA 2026-08-24 ENG-145: Automated SessionThread and CopyIconButton suites passed. The production-parity browser walk is blocked because this worktree has no isolated authenticated daemon/session, and the Storybook MSW preview stalled before rendering a stable transcript. Re-run from a real Session entry point and update this row to `pass` with screenshots covering the focused states.
 

--- a/packages/site/app/layout.tsx
+++ b/packages/site/app/layout.tsx
@@ -5,7 +5,7 @@ import type { Metadata, Viewport } from "next";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { RootProvider } from "fumadocs-ui/provider/next";
-import { UIProvider } from "@compozy/ui";
+import { Toaster, UIProvider } from "@compozy/ui";
 import { SiteFooter } from "@/components/site/site-footer";
 import { SiteSearchDialog, SiteSearchProvider } from "@/components/site/site-search";
 import { siteConfig } from "@/lib/site-config";
@@ -94,6 +94,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           Skip to content
         </a>
         <UIProvider>
+          <Toaster />
           <SiteSearchProvider>
             <RootProvider
               search={{

--- a/packages/ui/src/components/custom/__tests__/code-block.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/code-block.test.tsx
@@ -238,6 +238,33 @@ describe("CodeBlock", () => {
     expect(button.getAttribute("data-copied")).toBeNull();
   });
 
+  it("Should keep feedback from the newest overlapping copy request", async () => {
+    let releaseFirstRequest = () => {};
+    const firstRequest = new Promise<void>(resolve => {
+      releaseFirstRequest = resolve;
+    });
+    clipboard.writeText
+      .mockImplementationOnce(() => firstRequest)
+      .mockRejectedValueOnce(new Error("newer request blocked"));
+    const { container } = render(<CodeBlock code="compozy start" />);
+    const button = container.querySelector<HTMLButtonElement>('[data-slot="code-block-copy"]')!;
+
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toHaveAttribute("data-copy-state", "failed");
+      expect(toastMocks.error).toHaveBeenCalledWith("Couldn't copy to clipboard");
+    });
+
+    await act(async () => {
+      releaseFirstRequest();
+      await Promise.resolve();
+    });
+    expect(button).toHaveAttribute("data-copy-state", "failed");
+    expect(toastMocks.success).not.toHaveBeenCalled();
+  });
+
   it("Should apply line truncation attributes", () => {
     const { container } = render(
       <CodeBlock code={"one\ntwo\nthree\nfour"} showPrompt={false} truncateLines={2} />

--- a/packages/ui/src/components/custom/__tests__/code-block.test.tsx
+++ b/packages/ui/src/components/custom/__tests__/code-block.test.tsx
@@ -3,6 +3,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CodeBlock, CopyIconButton } from "../code-block";
 
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ toast: toastMocks }));
+
 function installClipboard() {
   const writeText = vi.fn<(value: string) => Promise<void>>().mockResolvedValue(undefined);
   const descriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
@@ -25,6 +32,8 @@ describe("CodeBlock", () => {
 
   beforeEach(() => {
     clipboard = installClipboard();
+    toastMocks.error.mockClear();
+    toastMocks.success.mockClear();
   });
 
   afterEach(() => {
@@ -141,6 +150,7 @@ describe("CodeBlock", () => {
     fireEvent.click(button);
     await waitFor(() => {
       expect(clipboard.writeText).toHaveBeenCalledWith("compozy network status");
+      expect(toastMocks.success).toHaveBeenCalledWith("Copied to clipboard");
     });
   });
 
@@ -151,9 +161,27 @@ describe("CodeBlock", () => {
     fireEvent.click(button);
     await waitFor(() => {
       expect(button).toHaveAttribute("data-copy-state", "failed");
+      expect(toastMocks.error).toHaveBeenCalledWith("Couldn't copy to clipboard");
     });
     expect(button.getAttribute("aria-label")).toBe("Copy failed");
     expect(button.querySelector("svg.lucide-triangle-alert")).not.toBeNull();
+  });
+
+  it("Should expose copy failure when the Clipboard API is unavailable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+    const { container } = render(<CodeBlock code="compozy start" />);
+    const button = container.querySelector<HTMLButtonElement>('[data-slot="code-block-copy"]')!;
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(button).toHaveAttribute("data-copy-state", "failed");
+      expect(toastMocks.error).toHaveBeenCalledWith("Couldn't copy to clipboard");
+    });
+    expect(button).toHaveAttribute("aria-label", "Copy failed");
   });
 
   it("Should swap to the check icon for 1.5s on copy success, then revert", async () => {

--- a/packages/ui/src/components/custom/code-block.tsx
+++ b/packages/ui/src/components/custom/code-block.tsx
@@ -2,6 +2,7 @@
 
 import { AlertTriangleIcon, CheckIcon, CopyIcon } from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 
 import type { CodeBlockThemeMode } from "../../lib/code-theme";
 import type { HighlightedCodeToken } from "../../lib/shiki-highlighter";
@@ -33,7 +34,9 @@ export type CodeBlockDensity = "default" | "compact";
 
 export interface CopyIconButtonProps extends Omit<React.ComponentProps<typeof Button>, "children"> {
   copiedLabel?: string;
+  copiedToastLabel?: string;
   copyFailedLabel?: string;
+  copyFailedToastLabel?: string;
   copyLabel?: string;
   value: string;
 }
@@ -42,6 +45,23 @@ type CopyState = "idle" | "copied" | "failed";
 
 const COPY_FEEDBACK_MS = 1500;
 const EMPTY_LINE = "\u00A0";
+
+async function writeClipboard(value: string): Promise<boolean> {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  try {
+    const clipboard = navigator.clipboard;
+    if (!clipboard || typeof clipboard.writeText !== "function") {
+      return false;
+    }
+    await clipboard.writeText(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Code block per DESIGN.md §4. Canvas-deep container, JetBrains Mono body on
@@ -190,7 +210,9 @@ function CodeBlock({
 function CopyIconButton({
   className,
   copiedLabel = "Copied",
+  copiedToastLabel = "Copied to clipboard",
   copyFailedLabel = "Copy failed",
+  copyFailedToastLabel = "Couldn't copy to clipboard",
   copyLabel = "Copy to clipboard",
   onClick,
   value,
@@ -219,17 +241,13 @@ function CopyIconButton({
   };
 
   const handleCopy = async () => {
-    if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) {
-      setCopyState("failed");
-      scheduleReset();
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(value);
-      setCopyState("copied");
-    } catch {
-      setCopyState("failed");
+    const copied = await writeClipboard(value);
+    const nextState: CopyState = copied ? "copied" : "failed";
+    setCopyState(nextState);
+    if (copied) {
+      toast.success(copiedToastLabel);
+    } else {
+      toast.error(copyFailedToastLabel);
     }
     scheduleReset();
   };

--- a/packages/ui/src/components/custom/code-block.tsx
+++ b/packages/ui/src/components/custom/code-block.tsx
@@ -223,6 +223,7 @@ function CopyIconButton({
 }: CopyIconButtonProps) {
   const [copyState, setCopyState] = React.useState<CopyState>("idle");
   const copyFeedbackTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const copyRequestRef = React.useRef(0);
 
   React.useEffect(
     () => () => {
@@ -241,7 +242,14 @@ function CopyIconButton({
   };
 
   const handleCopy = async () => {
+    const requestID = copyRequestRef.current + 1;
+    copyRequestRef.current = requestID;
+    if (copyFeedbackTimerRef.current) {
+      clearTimeout(copyFeedbackTimerRef.current);
+      copyFeedbackTimerRef.current = null;
+    }
     const copied = await writeClipboard(value);
+    if (requestID !== copyRequestRef.current) return;
     const nextState: CopyState = copied ? "copied" : "failed";
     setCopyState(nextState);
     if (copied) {

--- a/web/src/components/assistant-ui/__tests__/session-thread.test.tsx
+++ b/web/src/components/assistant-ui/__tests__/session-thread.test.tsx
@@ -432,6 +432,9 @@ describe("SessionThread transcript states", () => {
     attachmentUploadSequence = 0;
     resetSessionDebugTelemetry();
     vi.stubGlobal("fetch", createFetchMock());
+    vi.mocked(toast.error).mockClear();
+    vi.mocked(toast.success).mockClear();
+    vi.mocked(toast.warning).mockClear();
   });
 
   afterEach(() => {
@@ -979,6 +982,7 @@ describe("SessionThread transcript states", () => {
       await waitFor(() => {
         expect(writeText).toHaveBeenCalledWith("Flatten both.");
       });
+      expect(vi.mocked(toast.success)).toHaveBeenCalledWith("Message copied");
     } finally {
       if (clipboardDescriptor) {
         Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
@@ -986,6 +990,87 @@ describe("SessionThread transcript states", () => {
         Reflect.deleteProperty(navigator as unknown as { clipboard?: unknown }, "clipboard");
       }
     }
+  });
+
+  it("Should keep the message action visible without hover and report clipboard rejection", async () => {
+    const writeText = vi
+      .fn<(value: string) => Promise<void>>()
+      .mockRejectedValue(new Error("blocked"));
+    const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    const transcript = [
+      {
+        id: "assistant-copy-rejected",
+        role: "assistant",
+        parts: [
+          {
+            type: "text",
+            text: "The clipboard permission is blocked.",
+            state: "done",
+          },
+        ] as unknown as SessionMessage["parts"],
+      } as SessionMessage,
+    ];
+
+    try {
+      renderThreadState({ status: "success", messages: toReadonlyThreadMessages(transcript) });
+
+      const toolbar = await screen.findByTestId("assistant-message-actions");
+      const copy = within(toolbar).getByTestId("assistant-message-actions-copy");
+      expect(toolbar).toBeVisible();
+      expect(copy).toBeVisible();
+      expect(toolbar).not.toHaveClass("opacity-0", "pointer-events-none");
+
+      fireEvent.click(copy);
+
+      await waitFor(() => {
+        expect(copy).toHaveAttribute("data-copy-state", "failed");
+        expect(copy).toHaveAttribute("aria-label", "Copy failed");
+        expect(vi.mocked(toast.error)).toHaveBeenCalledWith("Couldn't copy message");
+      });
+    } finally {
+      if (clipboardDescriptor) {
+        Object.defineProperty(navigator, "clipboard", clipboardDescriptor);
+      } else {
+        Reflect.deleteProperty(navigator as unknown as { clipboard?: unknown }, "clipboard");
+      }
+    }
+  });
+
+  it("Should reserve a disabled copy row before a streaming answer has text", async () => {
+    const transcript = [
+      {
+        id: "assistant-streaming-reasoning",
+        role: "assistant",
+        parts: [
+          {
+            type: "reasoning",
+            text: "Checking the tool output before answering.",
+            state: "streaming",
+          },
+        ] as unknown as SessionMessage["parts"],
+      } as SessionMessage,
+      {
+        id: "assistant-settled-tool-only",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-Bash",
+            toolCallId: "tool-settled-only",
+            state: "output-available",
+            input: { command: "true" },
+            output: { type: "tool_result", title: "Bash", raw: { content: "ok" } },
+          },
+        ] as unknown as SessionMessage["parts"],
+      } as SessionMessage,
+    ];
+
+    renderThreadState({ status: "success", messages: toReadonlyThreadMessages(transcript) });
+
+    const toolbar = await screen.findByTestId("assistant-message-actions");
+    const copy = within(toolbar).getByTestId("assistant-message-actions-copy");
+    expect(copy).toBeDisabled();
+    expect(screen.getAllByTestId("assistant-message-actions")).toHaveLength(1);
   });
 
   it.each([
@@ -1642,12 +1727,11 @@ describe("SessionThread transcript states", () => {
     expect(
       await screen.findByText("The launch note is ready and the checks are green.")
     ).toBeInTheDocument();
-    // Settled, incomplete, and persisted-failure text remain copyable. The
-    // streaming turn renders no toolbar.
+    // Settled, streaming, incomplete, and persisted-failure text remain copyable.
     const assistantToolbars = screen.getAllByTestId("assistant-message-actions");
-    expect(assistantToolbars).toHaveLength(5);
+    expect(assistantToolbars).toHaveLength(6);
     expect(screen.queryByRole("button", { name: "Use as Goal" })).not.toBeInTheDocument();
-    expect(screen.getAllByTestId("assistant-message-actions-copy")).toHaveLength(5);
+    expect(screen.getAllByTestId("assistant-message-actions-copy")).toHaveLength(6);
     const successfulToolbar = assistantToolbars[0]!;
     expect(
       within(successfulToolbar).getByTestId("assistant-message-actions-timestamp")
@@ -1693,6 +1777,7 @@ describe("SessionThread transcript states", () => {
       await waitFor(() => {
         expect(copy).toHaveAttribute("data-copied", "true");
       });
+      expect(vi.mocked(toast.success)).toHaveBeenCalledWith("Message copied");
       expect(copy.querySelector("svg.lucide-check")).not.toBeNull();
       expect(copy.querySelector("svg.lucide-copy")).toBeNull();
     } finally {

--- a/web/src/components/assistant-ui/message-actions.logic.ts
+++ b/web/src/components/assistant-ui/message-actions.logic.ts
@@ -1,10 +1,10 @@
 interface MessageActionsState {
-  /** The message's markdown text answer, joined and trimmed (empty for a pure tool turn). */
+  /** The message's copyable text, joined and trimmed (empty for a pure tool turn). */
   source: string;
   /** Latest real event time across the message's parts, or null when none is recorded. */
   timestampMs: number | null;
   streaming: boolean;
-  /** Copy is offered for non-streaming message text, including inspectable failure output. */
+  /** Copy stays in the row while streaming, including before the first text token arrives. */
   visible: boolean;
 }
 
@@ -19,6 +19,28 @@ function stringField(record: Record<string, unknown>, key: string): string | und
 
 function isStreamingState(state: string | undefined): boolean {
   return state === "streaming" || state === "running";
+}
+
+function copyableTextSegments(content: unknown): string[] {
+  if (typeof content === "string") {
+    return [content];
+  }
+
+  if (!Array.isArray(content)) {
+    return [];
+  }
+
+  return content.flatMap(part => {
+    if (typeof part === "string") {
+      return [part];
+    }
+    if (!isRecord(part) || stringField(part, "type") !== "text") {
+      return [];
+    }
+
+    const text = stringField(part, "text");
+    return text ? [text] : [];
+  });
 }
 
 function partTimestampMs(part: Record<string, unknown>): number | null {
@@ -38,7 +60,7 @@ export function deriveMessageActions(message: {
   status?: { type?: string };
 }): MessageActionsState {
   const parts = Array.isArray(message.content) ? message.content : [];
-  const textSegments: string[] = [];
+  const textSegments = copyableTextSegments(message.content);
   let streaming = message.status?.type === "running";
   let timestampMs: number | null = null;
 
@@ -48,10 +70,6 @@ export function deriveMessageActions(message: {
     if ((type === "text" || type === "reasoning") && isStreamingState(stringField(part, "state"))) {
       streaming = true;
     }
-    if (type === "text") {
-      const text = stringField(part, "text");
-      if (text) textSegments.push(text);
-    }
     const timestamp = partTimestampMs(part);
     if (timestamp !== null && (timestampMs === null || timestamp > timestampMs)) {
       timestampMs = timestamp;
@@ -59,6 +77,9 @@ export function deriveMessageActions(message: {
   }
 
   const source = textSegments.join("\n\n").trim();
-  const visible = source.length > 0 && !streaming;
+  // Streaming messages copy the text settled so far. Keeping the action in the
+  // row prevents it from appearing only after generation finishes and shifting
+  // the transcript layout.
+  const visible = source.length > 0 || streaming;
   return { source, timestampMs, streaming, visible };
 }

--- a/web/src/components/assistant-ui/message-actions.tsx
+++ b/web/src/components/assistant-ui/message-actions.tsx
@@ -12,13 +12,6 @@ import { useSessionThreadReadOnly } from "./hooks/use-session-thread-read-only";
 
 const ACTIONS_CLASS_NAME = "flex items-center gap-2 text-small-body text-muted tabular-nums";
 
-const REVEAL_CLASS_NAME = cn(
-  ACTIONS_CLASS_NAME,
-  "opacity-0 pointer-events-none transition-opacity duration-slow motion-reduce:transition-none",
-  "group-hover/message:opacity-100 group-hover/message:pointer-events-auto",
-  "focus-within:opacity-100 focus-within:pointer-events-auto"
-);
-
 export interface MessageActionsProps {
   /** `start` aligns the row under a flat assistant message; `end` under the right-aligned user bubble. */
   align: "start" | "end";
@@ -30,7 +23,7 @@ export function MessageActions({ align, copyLabel, testId }: MessageActionsProps
   const message = useAuiState(
     state => state.message as { content?: unknown; status?: { type?: string } }
   );
-  const { source, timestampMs, visible } = deriveMessageActions(message);
+  const { source, timestampMs, streaming, visible } = deriveMessageActions(message);
   const readOnly = useSessionThreadReadOnly();
 
   if (!visible) {
@@ -54,6 +47,9 @@ export function MessageActions({ align, copyLabel, testId }: MessageActionsProps
       value={source}
       copyLabel={copyLabel}
       copiedLabel="Copied"
+      copiedToastLabel="Message copied"
+      copyFailedToastLabel="Couldn't copy message"
+      disabled={streaming && source.length === 0}
       className="text-muted hover:text-fg"
       data-testid={`${testId}-copy`}
     />
@@ -61,7 +57,7 @@ export function MessageActions({ align, copyLabel, testId }: MessageActionsProps
   return (
     <div
       data-testid={testId}
-      className={cn(REVEAL_CLASS_NAME, align === "end" ? "justify-end" : "justify-start")}
+      className={cn(ACTIONS_CLASS_NAME, align === "end" ? "justify-end" : "justify-start")}
     >
       {align === "end" ? (
         <>


### PR DESCRIPTION
## Summary

Resolves ENG-145: restore a dependable copy-to-clipboard action for Session messages in both the browser and packaged Electron shell.

The Session toolbar previously hid its actions behind hover-only opacity and pointer-event gating. Moving from the message toward the action could cancel the click target, and streaming messages removed the row entirely. Clipboard rejection or an unavailable Clipboard API only changed internal icon state, so the user received no explicit feedback. The packaged Electron shell additionally rejected the permission needed by Chromium's sanitized clipboard write, and it disabled the intentional developer-console shortcut.

## Root cause

- `MessageActions` used `opacity-0` plus `pointer-events-none` until hover/focus, making a pointer transition fragile and creating an interaction that was not consistently discoverable or keyboard-stable.
- `deriveMessageActions` only handled one array-shaped text-part representation and hid all streaming rows, so string content, settled-so-far streaming text, and layout stability were not covered.
- The shared `CopyIconButton` had no user-facing success/error notification and did not expose a distinct error outcome when `navigator.clipboard` was unavailable or rejected a write.
- The Electron session permission policy denied every permission, including `clipboard-sanitized-write` for the product's own daemon origin.
- Packaged product windows set `devTools: false` and forcibly closed any DevTools instance, so `Ctrl+Opt+I` could not be used for intentional local debugging even though remote debugging remained disabled.

## Implementation

### Web and shared UI

- Keep copy/timestamp actions persistently visible and keyboard reachable for user and assistant text; remove hover-only opacity and pointer-event gating.
- Normalize copyable message content from string, string-array, and text-part forms while excluding attachments, reasoning, tool, file, and data parts from the single whole-message answer action.
- Keep the action row reserved for every streaming message to prevent layout shift. Copy is disabled only before the first copyable token, then copies settled-so-far text while generation continues. Settled pure tool-only messages have no dead copy button.
- Add guarded Clipboard API handling with explicit success and failure states, accessible labels, and Sonner success/error notifications. Preserve the existing icon transition and reset timing.
- Serialize overlapping copy requests by ignoring stale completions, so a slower earlier write cannot overwrite the newest state or emit duplicate feedback.
- Mount one `Toaster` in the site root so the shared primitive behaves consistently in both web and site consumers.

### Electron shell

- Allow only main-frame `clipboard-sanitized-write` requests whose normalized origin exactly matches the active daemon origin; keep all other permission checks/requests denied.
- Reapply the permission policy when the runtime origin becomes available, while the boot window remains deny-by-default.
- Enable DevTools only for the product window and add an explicit `Control+Alt+I` (`Ctrl+Opt+I` on macOS) toggle, including a hidden View-menu accelerator. Boot DevTools remain disabled and packaged remote-debugging switches remain removed.
- Extend the canonical packaged Electron security test to verify actual OS clipboard contents, notification denial, DevTools open/close, and the absence of a remote-debugging endpoint.

### QA and documentation

- Update the canonical RT-053 copy scenario for packaged Electron coverage.
- Add content-addressed scenario `ET-electron-session-copy-debug` and its targeted report. The automated packaged walk passed; the required physical production-parity macOS walk remains explicitly `blocked-verify`.

## Tests and verification

Passing focused checks:

- `rtk bunx turbo run test --filter=@compozy/ui` — 705/705 (including the canonical CodeBlock suite, now 19 tests).
- `rtk bunx turbo run test --filter=compozy-web -- --run src/components/assistant-ui/__tests__/session-thread.test.tsx` — 87/87.
- `rtk make bun-lint` — passed with zero warnings/errors.
- `rtk make bun-typecheck` — passed.
- `rtk bunx turbo run typecheck --filter=@compozy/site` — passed.
- `rtk make desktop-test` — 137/137.
- `rtk make desktop-lint` — desktop format, lint, and typecheck passed.
- `rtk make desktop-build` — packaged macOS arm64 app built.
- `rtk make web-build` — generated the daemon-served bundle needed by the Electron fixture.
- `cd desktop && ./node_modules/.bin/playwright test --config playwright.config.ts --grep "E2E-034"` — 1/1 passed; verified OS clipboard contents, product DevTools toggle, boot hardening, and no remote-debugging endpoint.
- `rtk git diff --check` and changed-file `oxfmt --check` — passed.

The required scoped `rtk make gate` was run for the first web change and twice-focused suites passed. After the Electron follow-up, `rtk make gate` correctly classified unclassified desktop paths and escalated automatically to its full lane; that lane stopped at two pre-existing source-size violations (`web/src/systems/marketplace/routes/marketplace-detail.stories.tsx` 508 lines and `web/src/systems/session/index.ts` 504 lines). No changed file violated the cap and no ENG-145 test failed. `make gate-full` and `make verify` were not invoked directly, per task instructions.

GitHub CI run `32798616834` was watched to completion. The ENG-145 Desktop, Preflight, Darwin peer, React Doctor, Vercel, and PR-title checks passed. The required aggregate check is red only because unrelated baseline work fails: Frontend has one existing `use-window-manager-stream.test.tsx:322` failure; Go source-size repeats the two files above; Go build/race reports the pre-existing `internal/demoseed/seed.go:79` `ListPresets` compile error plus unrelated profile/SQLite timeout failures (race shard 1 timed out with 331 failures, shard 2 had 12 failures). Those files are outside this PR and were not modified.

The first PR CodeRabbit round completed with approval and no actionable comments. The required second GraphQL fetch was also run after the Electron commit; it returned no review threads, while the service reported `Review rate limited`. Artifacts are `.codex/artifacts/coderabbit/pr-460-review.json` and `.codex/artifacts/coderabbit/pr-460-review-round2.json`; both were fetched with `.codex/scripts/coderabbit-review-graphql.sh 460`.

## QA status

The existing tracker scenario `RT-053` remains `blocked-verify` because the production-parity authenticated Session walk is unavailable in this worktree. The Electron-specific `ET-electron-session-copy-debug` report records the passing packaged E2E plus the remaining physical macOS walk: copy a user message and assistant markdown answer, verify the OS clipboard and toast outcomes, press physical `Control+Option+I`, confirm boot DevTools stay closed, and confirm `/json/version` remains unavailable. Evidence belongs under `docs/qa/evidence/2026-08-25-eng-145-electron/`.

## Risks and rollback

- The shared `CopyIconButton` now emits Sonner feedback for every consumer and ignores stale overlapping writes. This is intentionally the common behavior; the site root now provides the required host. Consumers can override copy/failure labels where domain language differs.
- Clipboard permissions are narrowly scoped to the active product origin and write-only; unsupported or blocked environments still produce a clear failure state rather than a silent no-op.
- DevTools are intentionally available only in the product window through the explicit shortcut/menu path. Remote debugging remains unavailable in packaged production builds.
- Rollback is a single commit revert of `e6e961b`, `178399829`, plus the earlier web implementation commit `b6392e897`.

## Compozy Impact Audit

- **Native tools:** no impact. No `compozy__*` tool IDs, toolsets, descriptors, schemas, digests, risk flags, availability diagnostics, or capability gates changed.
- **Extensibility and hooks:** no impact. No extensions, hooks, skills/capabilities, tools/resources, registries, bridge SDKs, MCP sidecars, or `config.toml` keys/defaults/docs changed.
- **Workspace data isolation:** no impact. The action copies only text already rendered in the current Session message; it adds no data read, cache, SSE, event, or workspace propagation path and cannot introduce cross-workspace reads.
- **Official Compozy skill:** no impact. No public tool ID, CLI path, hook event, capability, or memory/network/task semantic changed.

## Review notes

The implementation was reviewed by a standalone GPT-5.6-Sol reviewer with High reasoning. Both initial actionable findings were addressed before the first commit: reserve a disabled row before the first streaming token, and mount the shared toast host for site consumers. The final review also covered the Electron security/shortcut changes and the stale-completion guard. CodeRabbit's two requested review fetches returned no actionable threads; the second service request was rate-limited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added toast notifications for successful and failed copy actions across the site.
  - Copy actions now support clearer custom success and failure messages.
  - Added a Developer Tools option to the desktop app’s View menu, with keyboard shortcut support.
  - Enabled safe clipboard writing for the product’s desktop runtime.

- **Bug Fixes**
  - Improved copy behavior for streaming messages and unavailable clipboard access.
  - Prevented older copy requests from overriding the latest result.
  - Kept message actions available when content is still loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->