### PR TITLE
feat: combine settings update actions

### DIFF
--- a/docs/qa/reports/2026-08-24-eng-144.md
+++ b/docs/qa/reports/2026-08-24-eng-144.md
@@ -1,0 +1,37 @@
+# QA Run Report — 2026-08-24 — ENG-144
+
+- **Scope:** Settings → General update action consolidation, target-set contract, runtime→app ordering, one-target eligibility, managed/live no-action states, and HTTP/UDS parity.
+- **Cadence tier:** focused
+- **Build:** worktree `linear-eng-144`
+- **Started:** 2026-08-24 · **Finished:** 2026-08-24
+- **Status:** blocked-verify — browser walk deferred to CI's web E2E environment
+
+## Scenario
+
+| Area | Scenario | Verdict | Evidence summary |
+|---|---|---|---|
+| MS | `MS-settings-update-mutations` | Blocked — verify | Canonical Go API/spec/daemon suites and web unit suites pass. A focused Playwright selector run is not available through the repository's Turbo graph; the direct package runner resolves duplicate Playwright versions, while the repository lane runs the full browser suite and is outside this task-focused check budget. |
+
+## Automated evidence
+
+- `go test -race ./internal/api/core ./internal/api/spec ./internal/daemon -run 'TestSettingsUpdate|TestSettingsRoutesAndSchemas' -count=1` — passed after the final implementation (API rejection, schema exact-set, daemon forwarding, and transport parity cases).
+- `bunx turbo run test --filter=./web -- --run src/systems/settings/lib/__tests__/update-presentation.test.ts src/systems/settings/hooks/__tests__/use-settings-general-page.test.tsx src/routes/_app/settings/__tests__/-general.test.tsx` — passed (58 tests).
+- `bunx turbo run typecheck --filter=./web` — passed.
+- `bunx turbo run lint --filter=./web` — passed with zero warnings and errors.
+
+## Blocker and decision
+
+The product behavior is flagged and the focused unit/contract evidence is recorded. The focused browser walk remains explicitly `blocked-verify`, not `pass`: `turbo` has no registered `test:e2e:daemon-served` task, and invoking the web-local runner directly produced the repository's duplicate `@playwright/test` version error. The broader `make test-e2e-web` lane is intentionally deferred to CI per the task request to run only focused checks.
+
+No bug was dismissed, and no test was weakened. The existing last-known rows remain visible during refresh failure, while the shared action is hidden until a fresh update snapshot confirms eligibility.
+
+## Teardown
+
+The failed exploratory E2E processes were terminated and verified absent before continuing. No daemon, web, browser, watcher, or runner process from this worktree remains.
+
+## Compozy Impact Audit
+
+- **Native tools:** no impact; checked `compozy__*` descriptors/toolsets, schemas, digests, risk flags, capability gates, diagnostics, and CLI/API fallbacks.
+- **Extensibility and hooks:** no impact; checked extensions, hooks, skills/capabilities, tools/resources, registries, bridge SDKs, MCP sidecars, and `config.toml` settings lifecycle. The existing HTTP/UDS contract remains the agent-manageable surface.
+- **Workspace data isolation:** no impact; update state is daemon-home global, and no workspace-scoped data or propagation path changed.
+- **Official Compozy skill:** updated `skills/compozy/references/desktop.md`, `runtime-operations.md`, and `configuration.md` for the hard-cut target-set request.

--- a/docs/qa/scenarios/MS-settings-update-mutations.md
+++ b/docs/qa/scenarios/MS-settings-update-mutations.md
@@ -4,17 +4,20 @@ area: MS
 title: Apply and cancel an update through settings
 persona: Dora
 journey: J-desktop-update-moment
-expected: Settings apply returns an accepted durable operation id; cancel archives only a dormant operation with outcome `canceled` and frees acquisition; HTTP and UDS expose the same typed state and refusal results.
+expected: One shared settings action applies every eligible target in runtime→app order; one-target and managed/no-action states remain truthful; invalid or legacy target sets return 400; HTTP and UDS expose the same typed result and refusal states.
 entry_points: GET /api/settings/update; POST /api/settings/update/apply; POST /api/settings/update/cancel over HTTP and UDS
-qa_status: pass
+qa_status: blocked-verify
 bug_ids:
 fix_status: 
 retest_status: 
 fix_commits: 
-evidence: docs/qa/reports/2026-08-17-electron-shell.md
-last_report: docs/qa/reports/2026-08-17-electron-shell.md
+evidence: docs/qa/reports/2026-08-24-eng-144.md
+last_report: docs/qa/reports/2026-08-24-eng-144.md
 overlaps: MS-034; APP-cancel-dormant-update
 ---
 
-Added 2026-08-16 for the asynchronous settings update contract. Task 07 owns transport parity,
-detached execution, live-holder refusal, and final projection checks.
+Added 2026-08-16 for the asynchronous settings update contract. ENG-144 extends the walk to the
+single combined action, runtime→app ordering, one-target eligibility, managed/live no-action states,
+invalid target-set refusal, and HTTP/UDS parity. The browser walk is blocked in this worktree because
+the focused Playwright command is not registered in Turbo and the permitted web E2E lane is broader
+than this task; the canonical unit and transport-contract suites remain green.

--- a/internal/api/contract/settings_mutations.go
+++ b/internal/api/contract/settings_mutations.go
@@ -298,7 +298,7 @@ type RestartActionStatus struct {
 }
 
 type SettingsUpdateApplyRequest struct {
-	Target SettingsUpdateTarget `json:"target"`
+	Targets []SettingsUpdateTarget `json:"targets"`
 }
 
 type SettingsUpdateHolderPayload struct {
@@ -355,7 +355,7 @@ type SettingsUpdateResponse struct {
 }
 
 type SettingsUpdateApplyResponse struct {
-	Target      SettingsUpdateTarget         `json:"target"`
+	Targets     []SettingsUpdateTarget       `json:"targets"`
 	Status      SettingsUpdateApplyStatus    `json:"status"`
 	OperationID string                       `json:"operation_id,omitempty"`
 	Message     string                       `json:"message"`

--- a/internal/api/core/conversions_settings_sections.go
+++ b/internal/api/core/conversions_settings_sections.go
@@ -471,8 +471,12 @@ func settingsUpdateHolderPayload(holder *compozyupdate.Holder) *contract.Setting
 }
 
 func SettingsUpdateApplyResponseFromResult(result SettingsUpdateApply) contract.SettingsUpdateApplyResponse {
+	targets := make([]contract.SettingsUpdateTarget, 0, len(result.Targets))
+	for _, target := range result.Targets {
+		targets = append(targets, contract.SettingsUpdateTarget(target))
+	}
 	return contract.SettingsUpdateApplyResponse{
-		Target:      contract.SettingsUpdateTarget(result.Target),
+		Targets:     targets,
 		Status:      contract.SettingsUpdateApplyStatus(result.Status),
 		OperationID: strings.TrimSpace(result.OperationID),
 		Message:     strings.TrimSpace(result.Message),

--- a/internal/api/core/settings_test.go
+++ b/internal/api/core/settings_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -445,7 +446,7 @@ func (s *stubSettingsRestartController) RequestRestart(
 
 type stubSettingsUpdateController struct {
 	GetFn       func(context.Context) (compozyupdate.MultiState, error)
-	ApplyFn     func(context.Context, compozyupdate.Target) (core.SettingsUpdateApply, error)
+	ApplyFn     func(context.Context, []compozyupdate.Target) (core.SettingsUpdateApply, error)
 	CancelFn    func(context.Context) (core.SettingsUpdateCancel, error)
 	GetCalls    int
 	ApplyCalls  int
@@ -462,11 +463,11 @@ func (s *stubSettingsUpdateController) GetUpdate(ctx context.Context) (compozyup
 
 func (s *stubSettingsUpdateController) ApplyUpdate(
 	ctx context.Context,
-	target compozyupdate.Target,
+	targets []compozyupdate.Target,
 ) (core.SettingsUpdateApply, error) {
 	s.ApplyCalls++
 	if s.ApplyFn != nil {
-		return s.ApplyFn(ctx, target)
+		return s.ApplyFn(ctx, targets)
 	}
 	return core.SettingsUpdateApply{}, nil
 }
@@ -1249,12 +1250,12 @@ func TestSettingsUpdateMutationsReturnStructuredOutcomes(t *testing.T) {
 		t.Parallel()
 
 		fixture := newSettingsHandlerFixture(t, "api-core-http", &stubSettingsService{}, nil)
-		fixture.Update.ApplyFn = func(_ context.Context, target compozyupdate.Target) (core.SettingsUpdateApply, error) {
-			if target != compozyupdate.TargetRuntime {
-				t.Fatalf("ApplyUpdate() target = %q, want runtime", target)
+		fixture.Update.ApplyFn = func(_ context.Context, targets []compozyupdate.Target) (core.SettingsUpdateApply, error) {
+			if !slices.Equal(targets, []compozyupdate.Target{compozyupdate.TargetRuntime}) {
+				t.Fatalf("ApplyUpdate() targets = %v, want [runtime]", targets)
 			}
 			return core.SettingsUpdateApply{
-				Target: target, Status: compozyupdate.ApplyStatusAccepted,
+				Targets: targets, Status: compozyupdate.ApplyStatusAccepted,
 				OperationID: "operation-1", Message: "Update accepted.",
 			}, nil
 		}
@@ -1264,7 +1265,7 @@ func TestSettingsUpdateMutationsReturnStructuredOutcomes(t *testing.T) {
 			fixture.Engine,
 			http.MethodPost,
 			"/api/settings/update/apply",
-			[]byte(`{"target":"runtime"}`),
+			[]byte(`{"targets":["runtime"]}`),
 		)
 		if resp.Code != http.StatusOK {
 			t.Fatalf("POST apply status = %d, want 200; body=%s", resp.Code, resp.Body.String())
@@ -1274,40 +1275,92 @@ func TestSettingsUpdateMutationsReturnStructuredOutcomes(t *testing.T) {
 			t.Fatalf("json.Unmarshal(apply response) error = %v", err)
 		}
 		if payload.Status != contract.SettingsUpdateApplyAccepted ||
-			payload.Target != contract.SettingsUpdateTargetRuntime ||
+			!slices.Equal(payload.Targets, []contract.SettingsUpdateTarget{contract.SettingsUpdateTargetRuntime}) ||
 			payload.OperationID != "operation-1" ||
 			fixture.Update.ApplyCalls != 1 {
 			t.Fatalf("apply response = %#v calls=%d, want accepted runtime", payload, fixture.Update.ApplyCalls)
 		}
 	})
 
-	t.Run("Should reject an unknown target before invoking the controller", func(t *testing.T) {
+	t.Run("Should return an accepted operation for runtime then app", func(t *testing.T) {
 		t.Parallel()
 
 		fixture := newSettingsHandlerFixture(t, "api-core-http", &stubSettingsService{}, nil)
+		fixture.Update.ApplyFn = func(_ context.Context, targets []compozyupdate.Target) (core.SettingsUpdateApply, error) {
+			if !slices.Equal(targets, []compozyupdate.Target{compozyupdate.TargetRuntime, compozyupdate.TargetApp}) {
+				t.Fatalf("ApplyUpdate() targets = %v, want [runtime app]", targets)
+			}
+			return core.SettingsUpdateApply{
+				Targets: targets, Status: compozyupdate.ApplyStatusAccepted,
+				OperationID: "operation-both", Message: "Update accepted.",
+			}, nil
+		}
+
 		resp := performRequest(
 			t,
 			fixture.Engine,
 			http.MethodPost,
 			"/api/settings/update/apply",
-			[]byte(`{"target":"everything"}`),
+			[]byte(`{"targets":["runtime","app"]}`),
 		)
-		if resp.Code != http.StatusBadRequest || fixture.Update.ApplyCalls != 0 {
-			t.Fatalf(
-				"POST invalid apply status=%d calls=%d body=%s",
-				resp.Code,
-				fixture.Update.ApplyCalls,
-				resp.Body.String(),
-			)
+		if resp.Code != http.StatusOK {
+			t.Fatalf("POST apply status = %d, want 200; body=%s", resp.Code, resp.Body.String())
 		}
-		var payload contract.ErrorPayload
+		var payload contract.SettingsUpdateApplyResponse
 		if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
-			t.Fatalf("json.Unmarshal(error response) error = %v", err)
+			t.Fatalf("json.Unmarshal(apply response) error = %v", err)
 		}
-		if payload.Error != "settings: update target must be runtime or app" {
-			t.Fatalf("invalid target error = %#v, want stable validation message", payload)
+		if payload.Status != contract.SettingsUpdateApplyAccepted ||
+			!slices.Equal(payload.Targets, []contract.SettingsUpdateTarget{
+				contract.SettingsUpdateTargetRuntime,
+				contract.SettingsUpdateTargetApp,
+			}) || payload.OperationID != "operation-both" || fixture.Update.ApplyCalls != 1 {
+			t.Fatalf("apply response = %#v calls=%d, want accepted runtime/app", payload, fixture.Update.ApplyCalls)
 		}
 	})
+
+	for _, test := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "Should reject an empty target set before invoking the controller", body: `{"targets":[]}`, want: "settings: update targets must contain at least one target"},
+		{name: "Should reject an unknown target before invoking the controller", body: `{"targets":["everything"]}`, want: `settings: update target "everything" is invalid`},
+		{name: "Should reject a target with surrounding whitespace before invoking the controller", body: `{"targets":[" runtime "]}`, want: `settings: update target " runtime " is invalid`},
+		{name: "Should reject the removed singular target body before invoking the controller", body: `{"target":"runtime"}`, want: "settings: update targets must contain at least one target"},
+		{name: "Should reject duplicate targets before invoking the controller", body: `{"targets":["runtime","runtime"]}`, want: `settings: update targets must not contain duplicate "runtime"`},
+		{name: "Should reject app before runtime before invoking the controller", body: `{"targets":["app","runtime"]}`, want: "settings: runtime must be the first update target"},
+		{name: "Should reject more than two targets before invoking the controller", body: `{"targets":["runtime","app","runtime"]}`, want: "settings: update targets must contain at most two targets"},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newSettingsHandlerFixture(t, "api-core-http", &stubSettingsService{}, nil)
+			resp := performRequest(
+				t,
+				fixture.Engine,
+				http.MethodPost,
+				"/api/settings/update/apply",
+				[]byte(test.body),
+			)
+			if resp.Code != http.StatusBadRequest || fixture.Update.ApplyCalls != 0 {
+				t.Fatalf(
+					"POST invalid apply status=%d calls=%d body=%s",
+					resp.Code,
+					fixture.Update.ApplyCalls,
+					resp.Body.String(),
+				)
+			}
+			var payload contract.ErrorPayload
+			if err := json.Unmarshal(resp.Body.Bytes(), &payload); err != nil {
+				t.Fatalf("json.Unmarshal(error response) error = %v", err)
+			}
+			if payload.Error != test.want {
+				t.Fatalf("invalid target error = %#v, want stable validation message", payload)
+			}
+		})
+	}
 
 	t.Run("Should return a blocked cancel with its live holder", func(t *testing.T) {
 		t.Parallel()
@@ -4309,10 +4362,10 @@ func TestSettingsHandlersBehaveIdenticallyAcrossTransportShims(t *testing.T) {
 		}
 		fixture.Update.ApplyFn = func(
 			_ context.Context,
-			target compozyupdate.Target,
+			targets []compozyupdate.Target,
 		) (core.SettingsUpdateApply, error) {
 			return core.SettingsUpdateApply{
-				Target: target, Status: compozyupdate.ApplyStatusAccepted,
+				Targets: targets, Status: compozyupdate.ApplyStatusAccepted,
 				OperationID: "update-op", Message: "Update accepted.",
 			}, nil
 		}
@@ -4332,7 +4385,7 @@ func TestSettingsHandlersBehaveIdenticallyAcrossTransportShims(t *testing.T) {
 		{method: http.MethodPost, path: "/api/settings/actions/restart", body: []byte(`{}`)},
 		{method: http.MethodGet, path: "/api/settings/actions/restart/op-shared"},
 		{method: http.MethodGet, path: "/api/settings/update"},
-		{method: http.MethodPost, path: "/api/settings/update/apply", body: []byte(`{"target":"runtime"}`)},
+		{method: http.MethodPost, path: "/api/settings/update/apply", body: []byte(`{"targets":["runtime"]}`)},
 		{method: http.MethodPost, path: "/api/settings/update/cancel", body: []byte(`{}`)},
 	} {
 		httpResp := performRequest(t, httpFixture.Engine, request.method, request.path, request.body)

--- a/internal/api/core/settings_test.go
+++ b/internal/api/core/settings_test.go
@@ -1332,7 +1332,6 @@ func TestSettingsUpdateMutationsReturnStructuredOutcomes(t *testing.T) {
 		{name: "Should reject app before runtime before invoking the controller", body: `{"targets":["app","runtime"]}`, want: "settings: runtime must be the first update target"},
 		{name: "Should reject more than two targets before invoking the controller", body: `{"targets":["runtime","app","runtime"]}`, want: "settings: update targets must contain at most two targets"},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/api/core/settings_update.go
+++ b/internal/api/core/settings_update.go
@@ -2,8 +2,8 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/compozy/compozy/internal/api/contract"
 	compozyupdate "github.com/compozy/compozy/internal/update"
@@ -39,17 +39,44 @@ func (h *BaseHandlers) ApplySettingsUpdate(c *gin.Context) {
 		h.respondError(c, http.StatusBadRequest, err)
 		return
 	}
-	target := compozyupdate.Target(strings.TrimSpace(string(request.Target)))
-	if target != compozyupdate.TargetRuntime && target != compozyupdate.TargetApp {
-		h.respondError(c, http.StatusBadRequest, errors.New("settings: update target must be runtime or app"))
+	targets, err := settingsUpdateTargets(request.Targets)
+	if err != nil {
+		h.respondError(c, http.StatusBadRequest, err)
 		return
 	}
-	result, err := h.SettingsUpdate.ApplyUpdate(c.Request.Context(), target)
+	result, err := h.SettingsUpdate.ApplyUpdate(c.Request.Context(), targets)
 	if err != nil && result.Status == "" {
 		h.respondError(c, StatusForSettingsError(err), err)
 		return
 	}
 	c.JSON(http.StatusOK, SettingsUpdateApplyResponseFromResult(result))
+}
+
+func settingsUpdateTargets(rawTargets []contract.SettingsUpdateTarget) ([]compozyupdate.Target, error) {
+	if len(rawTargets) == 0 {
+		return nil, errors.New("settings: update targets must contain at least one target")
+	}
+	if len(rawTargets) > 2 {
+		return nil, errors.New("settings: update targets must contain at most two targets")
+	}
+
+	targets := make([]compozyupdate.Target, 0, len(rawTargets))
+	seen := make(map[compozyupdate.Target]struct{}, len(rawTargets))
+	for index, rawTarget := range rawTargets {
+		target := compozyupdate.Target(rawTarget)
+		if target != compozyupdate.TargetRuntime && target != compozyupdate.TargetApp {
+			return nil, fmt.Errorf("settings: update target %q is invalid", target)
+		}
+		if _, exists := seen[target]; exists {
+			return nil, fmt.Errorf("settings: update targets must not contain duplicate %q", target)
+		}
+		if target == compozyupdate.TargetRuntime && index != 0 {
+			return nil, errors.New("settings: runtime must be the first update target")
+		}
+		seen[target] = struct{}{}
+		targets = append(targets, target)
+	}
+	return targets, nil
 }
 
 // CancelSettingsUpdate cancels and archives a dormant update operation.

--- a/internal/api/core/settings_update_contract.go
+++ b/internal/api/core/settings_update_contract.go
@@ -8,7 +8,7 @@ import (
 
 // SettingsUpdateApply describes an accepted update operation.
 type SettingsUpdateApply struct {
-	Target      compozyupdate.Target
+	Targets     []compozyupdate.Target
 	Status      compozyupdate.ApplyStatus
 	OperationID string
 	Message     string
@@ -26,6 +26,6 @@ type SettingsUpdateCancel struct {
 // SettingsUpdateController exposes the daemon-owned update status surface to settings transports.
 type SettingsUpdateController interface {
 	GetUpdate(ctx context.Context) (compozyupdate.MultiState, error)
-	ApplyUpdate(ctx context.Context, target compozyupdate.Target) (SettingsUpdateApply, error)
+	ApplyUpdate(ctx context.Context, targets []compozyupdate.Target) (SettingsUpdateApply, error)
 	CancelUpdate(ctx context.Context) (SettingsUpdateCancel, error)
 }

--- a/internal/api/spec/registry_settings.go
+++ b/internal/api/spec/registry_settings.go
@@ -121,7 +121,7 @@ func applySettingsUpdateOperationSpec() OperationSpec {
 				Description: "Accepted, blocked, or acquisition-time failure",
 				Body:        contract.SettingsUpdateApplyResponse{},
 			},
-			{Status: 400, Description: "Invalid update target", Body: contract.ErrorPayload{}},
+			{Status: 400, Description: "Invalid update target set", Body: contract.ErrorPayload{}},
 			{Status: 403, Description: specForbiddenDescription, Body: contract.ErrorPayload{}},
 			{Status: 500, Description: specInternalServerErrorDescription, Body: contract.ErrorPayload{}},
 			{Status: 503, Description: settingsUpdateUnavailableDescription, Body: contract.ErrorPayload{}},

--- a/internal/api/spec/schema_customizers.go
+++ b/internal/api/spec/schema_customizers.go
@@ -74,6 +74,7 @@ var schemaCustomizers = map[reflect.Type]func(*openapi3.Schema){
 	reflect.TypeFor[contract.SettingsShellResponse]():          customizeClosedObjectSchema,
 	reflect.TypeFor[contract.SettingsShellPayload]():           customizeClosedObjectSchema,
 	reflect.TypeFor[contract.SettingsShellSessionsPayload]():   customizeClosedObjectSchema,
+	reflect.TypeFor[contract.SettingsUpdateApplyRequest]():     customizeSettingsUpdateApplyRequestSchema,
 	reflect.TypeFor[contract.SettingsMCPCatalogInputPayload](): customizeSettingsMCPCatalogInputSchema,
 	reflect.TypeFor[contract.SettingsMCPAuthExchangeRequest](): customizeSettingsMCPAuthExchangeRequestSchema,
 	reflect.TypeFor[contract.AttachSessionRequest]():           customizeAttachSessionRequestSchema,

--- a/internal/api/spec/schema_customizers.go
+++ b/internal/api/spec/schema_customizers.go
@@ -75,6 +75,7 @@ var schemaCustomizers = map[reflect.Type]func(*openapi3.Schema){
 	reflect.TypeFor[contract.SettingsShellPayload]():           customizeClosedObjectSchema,
 	reflect.TypeFor[contract.SettingsShellSessionsPayload]():   customizeClosedObjectSchema,
 	reflect.TypeFor[contract.SettingsUpdateApplyRequest]():     customizeSettingsUpdateApplyRequestSchema,
+	reflect.TypeFor[contract.SettingsUpdateApplyResponse]():    customizeSettingsUpdateApplyResponseSchema,
 	reflect.TypeFor[contract.SettingsMCPCatalogInputPayload](): customizeSettingsMCPCatalogInputSchema,
 	reflect.TypeFor[contract.SettingsMCPAuthExchangeRequest](): customizeSettingsMCPAuthExchangeRequestSchema,
 	reflect.TypeFor[contract.AttachSessionRequest]():           customizeAttachSessionRequestSchema,

--- a/internal/api/spec/settings_test.go
+++ b/internal/api/spec/settings_test.go
@@ -788,11 +788,7 @@ func TestSettingsRoutesAndSchemas(t *testing.T) {
 		applyResponseSchema := jsonResponseSchema(t, applyUpdate, 200)
 		assertRequired(t, applyResponseSchema, "targets", "status", "message")
 		applyResponseTargetsSchema := propertySchema(t, applyResponseSchema, "targets")
-		if applyResponseTargetsSchema.Type == nil || !applyResponseTargetsSchema.Type.Is("array") ||
-			applyResponseTargetsSchema.Items == nil || applyResponseTargetsSchema.Items.Value == nil {
-			t.Fatal("apply response targets schema must be an array with resolved items")
-		}
-		assertEnumValues(t, applyResponseTargetsSchema.Items.Value, "app", "runtime")
+		assertSettingsUpdateTargetSetSchema(t, applyResponseTargetsSchema)
 		assertEnumValues(t, propertySchema(t, applyResponseSchema, "status"), "accepted", "blocked", "failed")
 
 		cancelUpdate := operationFor(t, doc, "/api/settings/update/cancel", "POST")
@@ -964,6 +960,15 @@ func assertSettingsUpdateTargetSetSchema(t *testing.T, schema *openapi3.Schema) 
 	want := []string{`["app"]`, `["runtime","app"]`, `["runtime"]`}
 	if !slices.Equal(got, want) {
 		t.Fatalf("settings update target set enum = %v, want %v", got, want)
+	}
+	for _, invalid := range [][]any{
+		{"app", "runtime"},
+		{"runtime", "runtime"},
+		{},
+	} {
+		if schema.IsMatching(invalid) {
+			t.Fatalf("settings update target set schema accepts invalid targets %v", invalid)
+		}
 	}
 }
 

--- a/internal/api/spec/settings_test.go
+++ b/internal/api/spec/settings_test.go
@@ -961,14 +961,21 @@ func assertSettingsUpdateTargetSetSchema(t *testing.T, schema *openapi3.Schema) 
 	if !slices.Equal(got, want) {
 		t.Fatalf("settings update target set enum = %v, want %v", got, want)
 	}
-	for _, invalid := range [][]any{
-		{"app", "runtime"},
-		{"runtime", "runtime"},
-		{},
+	for _, test := range []struct {
+		name  string
+		value []any
+	}{
+		{name: "Should reject app before runtime", value: []any{"app", "runtime"}},
+		{name: "Should reject duplicate runtime", value: []any{"runtime", "runtime"}},
+		{name: "Should reject an empty target set", value: []any{}},
 	} {
-		if schema.IsMatching(invalid) {
-			t.Fatalf("settings update target set schema accepts invalid targets %v", invalid)
-		}
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if schema.IsMatching(test.value) {
+				t.Fatalf("settings update target set schema accepts invalid targets %v", test.value)
+			}
+		})
 	}
 }
 

--- a/internal/api/spec/settings_test.go
+++ b/internal/api/spec/settings_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
 
@@ -781,11 +782,17 @@ func TestSettingsRoutesAndSchemas(t *testing.T) {
 
 		applyUpdate := operationFor(t, doc, "/api/settings/update/apply", "POST")
 		applyRequestSchema := jsonRequestSchema(t, applyUpdate)
-		assertRequired(t, applyRequestSchema, "target")
-		assertEnumValues(t, propertySchema(t, applyRequestSchema, "target"), "app", "runtime")
+		assertRequired(t, applyRequestSchema, "targets")
+		applyTargetsSchema := propertySchema(t, applyRequestSchema, "targets")
+		assertSettingsUpdateTargetSetSchema(t, applyTargetsSchema)
 		applyResponseSchema := jsonResponseSchema(t, applyUpdate, 200)
-		assertRequired(t, applyResponseSchema, "target", "status", "message")
-		assertEnumValues(t, propertySchema(t, applyResponseSchema, "target"), "app", "runtime")
+		assertRequired(t, applyResponseSchema, "targets", "status", "message")
+		applyResponseTargetsSchema := propertySchema(t, applyResponseSchema, "targets")
+		if applyResponseTargetsSchema.Type == nil || !applyResponseTargetsSchema.Type.Is("array") ||
+			applyResponseTargetsSchema.Items == nil || applyResponseTargetsSchema.Items.Value == nil {
+			t.Fatal("apply response targets schema must be an array with resolved items")
+		}
+		assertEnumValues(t, applyResponseTargetsSchema.Items.Value, "app", "runtime")
 		assertEnumValues(t, propertySchema(t, applyResponseSchema, "status"), "accepted", "blocked", "failed")
 
 		cancelUpdate := operationFor(t, doc, "/api/settings/update/cancel", "POST")
@@ -937,6 +944,27 @@ func TestSettingsRoutesAndSchemas(t *testing.T) {
 			t.Fatal("expected 403 response on POST /api/extensions")
 		}
 	})
+}
+
+func assertSettingsUpdateTargetSetSchema(t *testing.T, schema *openapi3.Schema) {
+	t.Helper()
+
+	if schema.Type == nil || !schema.Type.Is("array") {
+		t.Fatalf("settings update target set schema type = %#v, want array", schema.Type)
+	}
+	got := make([]string, 0, len(schema.Enum))
+	for index, value := range schema.Enum {
+		encoded, err := json.Marshal(value)
+		if err != nil {
+			t.Fatalf("settings update target set enum[%d] marshal error = %v", index, err)
+		}
+		got = append(got, string(encoded))
+	}
+	slices.Sort(got)
+	want := []string{`["app"]`, `["runtime","app"]`, `["runtime"]`}
+	if !slices.Equal(got, want) {
+		t.Fatalf("settings update target set enum = %v, want %v", got, want)
+	}
 }
 
 func assertMCPSecretInputExactlyOneOf(t *testing.T, schema *openapi3.Schema) {

--- a/internal/api/spec/settings_test.go
+++ b/internal/api/spec/settings_test.go
@@ -969,7 +969,6 @@ func assertSettingsUpdateTargetSetSchema(t *testing.T, schema *openapi3.Schema) 
 		{name: "Should reject duplicate runtime", value: []any{"runtime", "runtime"}},
 		{name: "Should reject an empty target set", value: []any{}},
 	} {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			if schema.IsMatching(test.value) {

--- a/internal/api/spec/settings_update_schema.go
+++ b/internal/api/spec/settings_update_schema.go
@@ -1,0 +1,39 @@
+package spec
+
+import (
+	"github.com/compozy/compozy/internal/api/contract"
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func customizeSettingsUpdateApplyRequestSchema(schema *openapi3.Schema) {
+	customizeSettingsUpdateTargetSetProperty(schema, "targets")
+}
+
+func customizeSettingsUpdateTargetSetProperty(schema *openapi3.Schema, property string) {
+	if schema == nil {
+		return
+	}
+	propertySchema := schema.Properties[property]
+	if propertySchema == nil {
+		return
+	}
+	propertySchema.Value = settingsUpdateTargetSetSchema()
+}
+
+func settingsUpdateTargetSetSchema() *openapi3.Schema {
+	targets := openapi3.NewArraySchema().WithItems(
+		openapi3.NewStringSchema().WithEnum(
+			string(contract.SettingsUpdateTargetRuntime),
+			string(contract.SettingsUpdateTargetApp),
+		),
+	)
+	targets.Enum = []any{
+		[]string{string(contract.SettingsUpdateTargetRuntime)},
+		[]string{string(contract.SettingsUpdateTargetApp)},
+		[]string{
+			string(contract.SettingsUpdateTargetRuntime),
+			string(contract.SettingsUpdateTargetApp),
+		},
+	}
+	return targets
+}

--- a/internal/api/spec/settings_update_schema.go
+++ b/internal/api/spec/settings_update_schema.go
@@ -9,6 +9,10 @@ func customizeSettingsUpdateApplyRequestSchema(schema *openapi3.Schema) {
 	customizeSettingsUpdateTargetSetProperty(schema, "targets")
 }
 
+func customizeSettingsUpdateApplyResponseSchema(schema *openapi3.Schema) {
+	customizeSettingsUpdateTargetSetProperty(schema, "targets")
+}
+
 func customizeSettingsUpdateTargetSetProperty(schema *openapi3.Schema, property string) {
 	if schema == nil {
 		return

--- a/internal/daemon/settings_test.go
+++ b/internal/daemon/settings_test.go
@@ -985,7 +985,11 @@ func TestSettingsUpdateControllerMutations(t *testing.T) {
 				targets []compozyupdate.Target,
 				holder compozyupdate.Holder,
 			) (compozyupdate.OperationRequest, error) {
-				if actor != compozyupdate.ActorWeb || len(targets) != 1 || targets[0] != compozyupdate.TargetRuntime {
+				if actor != compozyupdate.ActorWeb ||
+					!slices.Equal(targets, []compozyupdate.Target{
+						compozyupdate.TargetRuntime,
+						compozyupdate.TargetApp,
+					}) {
 					t.Fatalf("PlanOperation() actor/targets = %q/%v", actor, targets)
 				}
 				return daemonSettingsOperationRequest(holder, targets), nil
@@ -1026,11 +1030,18 @@ func TestSettingsUpdateControllerMutations(t *testing.T) {
 			spawned = true
 			return nil
 		}
-		result, err := controller.ApplyUpdate(requestCtx, compozyupdate.TargetRuntime)
+		result, err := controller.ApplyUpdate(requestCtx, []compozyupdate.Target{
+			compozyupdate.TargetRuntime,
+			compozyupdate.TargetApp,
+		})
 		if err != nil {
 			t.Fatalf("ApplyUpdate() error = %v", err)
 		}
-		if result.Status != compozyupdate.ApplyStatusAccepted || result.OperationID == "" || !spawned {
+		if result.Status != compozyupdate.ApplyStatusAccepted || result.OperationID == "" || !spawned ||
+			!slices.Equal(result.Targets, []compozyupdate.Target{
+				compozyupdate.TargetRuntime,
+				compozyupdate.TargetApp,
+			}) {
 			t.Fatalf("ApplyUpdate() = %#v spawned=%t, want durable acceptance", result, spawned)
 		}
 	})
@@ -1059,7 +1070,7 @@ func TestSettingsUpdateControllerMutations(t *testing.T) {
 				return errors.New("detached launch failed")
 			},
 		}
-		result, err := controller.ApplyUpdate(t.Context(), compozyupdate.TargetRuntime)
+		result, err := controller.ApplyUpdate(t.Context(), []compozyupdate.Target{compozyupdate.TargetRuntime})
 		if err != nil {
 			t.Fatalf("ApplyUpdate() error = %v", err)
 		}
@@ -1128,7 +1139,7 @@ func TestSettingsUpdateControllerMutations(t *testing.T) {
 				},
 			}
 
-			result, err := controller.ApplyUpdate(t.Context(), compozyupdate.TargetApp)
+			result, err := controller.ApplyUpdate(t.Context(), []compozyupdate.Target{compozyupdate.TargetApp})
 			if err != nil {
 				t.Fatalf("ApplyUpdate() error = %v", err)
 			}
@@ -1179,7 +1190,7 @@ func TestSettingsUpdateControllerMutations(t *testing.T) {
 			},
 		}
 
-		result, err := controller.ApplyUpdate(t.Context(), compozyupdate.TargetRuntime)
+		result, err := controller.ApplyUpdate(t.Context(), []compozyupdate.Target{compozyupdate.TargetRuntime})
 		if err != nil {
 			t.Fatalf("ApplyUpdate() error = %v", err)
 		}

--- a/internal/daemon/settings_update.go
+++ b/internal/daemon/settings_update.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"slices"
 	"time"
 
 	core "github.com/compozy/compozy/internal/api/core"
@@ -40,7 +41,7 @@ func (c settingsUpdateController) GetUpdate(ctx context.Context) (compozyupdate.
 
 func (c settingsUpdateController) ApplyUpdate(
 	ctx context.Context,
-	target compozyupdate.Target,
+	targets []compozyupdate.Target,
 ) (core.SettingsUpdateApply, error) {
 	if c.manager == nil || c.spawn == nil || c.holder == nil {
 		return core.SettingsUpdateApply{}, errors.New("daemon: settings update apply is not configured")
@@ -49,10 +50,11 @@ func (c settingsUpdateController) ApplyUpdate(
 	if err != nil {
 		return core.SettingsUpdateApply{}, err
 	}
-	request, err := c.manager.PlanOperation(ctx, compozyupdate.ActorWeb, []compozyupdate.Target{target}, holder)
+	requestedTargets := slices.Clone(targets)
+	request, err := c.manager.PlanOperation(ctx, compozyupdate.ActorWeb, targets, holder)
 	if err != nil {
 		return core.SettingsUpdateApply{
-			Target: target, Status: compozyupdate.ApplyStatusFailed, Message: err.Error(),
+			Targets: requestedTargets, Status: compozyupdate.ApplyStatusFailed, Message: err.Error(),
 		}, err
 	}
 	operation, err := c.manager.AcquireOperation(ctx, request)
@@ -60,13 +62,13 @@ func (c settingsUpdateController) ApplyUpdate(
 		var blocked *compozyupdate.BlockedError
 		if errors.As(err, &blocked) {
 			return core.SettingsUpdateApply{
-				Target: target, Status: compozyupdate.ApplyStatusBlocked,
+				Targets: requestedTargets, Status: compozyupdate.ApplyStatusBlocked,
 				OperationID: blocked.Operation.ID, Message: "An update operation is already active.",
 				Holder: blocked.Operation.Holder,
 			}, nil
 		}
 		return core.SettingsUpdateApply{
-			Target: target, Status: compozyupdate.ApplyStatusFailed, Message: err.Error(),
+			Targets: requestedTargets, Status: compozyupdate.ApplyStatusFailed, Message: err.Error(),
 		}, err
 	}
 	detachedCtx := context.WithoutCancel(ctx)
@@ -75,12 +77,12 @@ func (c settingsUpdateController) ApplyUpdate(
 			detachedCtx, operation.ID, operation.Holder.ExecutorGeneration, operation.Revision,
 			compozyupdate.Transition{
 				Kind: compozyupdate.TransitionPhase, Actor: compozyupdate.ActorDaemon,
-				Target: target, Phase: compozyupdate.PhaseFailed, Percent: -1,
+				Target: operation.ActiveTarget, Phase: compozyupdate.PhaseFailed, Percent: -1,
 				LastError: err.Error(), Outcome: string(compozyupdate.StatusFailed),
 			},
 		)
 		result := core.SettingsUpdateApply{
-			Target: target, Status: compozyupdate.ApplyStatusAccepted, OperationID: operation.ID,
+			Targets: requestedTargets, Status: compozyupdate.ApplyStatusAccepted, OperationID: operation.ID,
 			Message: "Update accepted.",
 		}
 		if transitionErr != nil {
@@ -89,7 +91,7 @@ func (c settingsUpdateController) ApplyUpdate(
 		return result, nil
 	}
 	return core.SettingsUpdateApply{
-		Target: target, Status: compozyupdate.ApplyStatusAccepted, OperationID: operation.ID,
+		Targets: requestedTargets, Status: compozyupdate.ApplyStatusAccepted, OperationID: operation.ID,
 		Message: "Update accepted.",
 	}, nil
 }

--- a/openapi/compozy.json
+++ b/openapi/compozy.json
@@ -167402,6 +167402,18 @@
                       "type": "string"
                     },
                     "targets": {
+                      "enum": [
+                        [
+                          "runtime"
+                        ],
+                        [
+                          "app"
+                        ],
+                        [
+                          "runtime",
+                          "app"
+                        ]
+                      ],
                       "items": {
                         "enum": [
                           "runtime",

--- a/openapi/compozy.json
+++ b/openapi/compozy.json
@@ -167312,16 +167312,31 @@
             "application/json": {
               "schema": {
                 "properties": {
-                  "target": {
+                  "targets": {
                     "enum": [
-                      "runtime",
-                      "app"
+                      [
+                        "runtime"
+                      ],
+                      [
+                        "app"
+                      ],
+                      [
+                        "runtime",
+                        "app"
+                      ]
                     ],
-                    "type": "string"
+                    "items": {
+                      "enum": [
+                        "runtime",
+                        "app"
+                      ],
+                      "type": "string"
+                    },
+                    "type": "array"
                   }
                 },
                 "required": [
-                  "target"
+                  "targets"
                 ],
                 "type": "object"
               }
@@ -167386,18 +167401,21 @@
                       ],
                       "type": "string"
                     },
-                    "target": {
-                      "enum": [
-                        "runtime",
-                        "app"
-                      ],
-                      "type": "string"
+                    "targets": {
+                      "items": {
+                        "enum": [
+                          "runtime",
+                          "app"
+                        ],
+                        "type": "string"
+                      },
+                      "type": "array"
                     }
                   },
                   "required": [
                     "message",
                     "status",
-                    "target"
+                    "targets"
                   ],
                   "type": "object"
                 }
@@ -167476,7 +167494,7 @@
                 }
               }
             },
-            "description": "Invalid update target"
+            "description": "Invalid update target set"
           },
           "403": {
             "content": {

--- a/packages/site/content/docs/getting-started/desktop-app.mdx
+++ b/packages/site/content/docs/getting-started/desktop-app.mdx
@@ -87,7 +87,8 @@ must be updated by downloading and installing the current `.deb` package over th
 
 The same host-global operation is available through `GET /api/settings/update`,
 `POST /api/settings/update/apply`, and `POST /api/settings/update/cancel` over HTTP and UDS.
-Status can report `available`, `applying`, `staged`, `blocked`, `failed`, `updated`, or
+Apply accepts a non-empty `targets` array, such as `{"targets":["runtime","app"]}`; runtime is
+listed first, and managed or unavailable tracks are omitted. Status can report `available`, `applying`, `staged`, `blocked`, `failed`, `updated`, or
 `up-to-date`; app status also carries the operation ID, phase, and progress when present.
 
 For a managed runtime, CompozyOS returns the exact package-manager command and does not replace the

--- a/skills/compozy/references/configuration.md
+++ b/skills/compozy/references/configuration.md
@@ -58,7 +58,8 @@ credential and requires `--yes` for non-interactive removal when the profile own
 `[app] update_check` defaults to `true`; `update_check_interval` defaults to `6h` and accepts
 `15m` through `168h`. The daemon is the sole consumer and schedules read-only runtime and app
 checks. The shell reads no update config. Read the host-global operation with
-`GET /api/settings/update`; mutate it through `POST /api/settings/update/apply` or
+`GET /api/settings/update`; mutate it with `POST /api/settings/update/apply` using a non-empty
+`targets` array (runtime first), or through
 `POST /api/settings/update/cancel` over HTTP or UDS. Use `compozy update --check -o json`,
 `compozy update -o json`, and `compozy update --cancel -o json` as the CLI paths.
 Read or change the cadence with `compozy config get|set|unset app.update_check -o json` and

--- a/skills/compozy/references/desktop.md
+++ b/skills/compozy/references/desktop.md
@@ -32,8 +32,9 @@ compozy update --cancel -o json
 
 Check and apply results always contain `runtime` and include `app` only when the desktop app is
 installed. Cancel returns `status`, `operation_id`, `message`, and an optional `holder`. A managed
-runtime returns its exact package-manager recommendation without changing the binary. Apply and
-cancel are also available through `POST /api/settings/update/apply` and
+runtime returns its exact package-manager recommendation without changing the binary. Apply accepts
+`{"targets":["runtime","app"]}` with runtime first; omit targets that are unavailable or managed.
+Apply and cancel are also available through `POST /api/settings/update/apply` and
 `POST /api/settings/update/cancel` over HTTP or UDS; read live state with `GET /api/settings/update`.
 Treat `available`, `applying`, `staged`, `blocked`, `failed`, `updated`, and
 `up-to-date` as the update statuses. A blocked result names the current holder. App status also

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -27,7 +27,8 @@ compozy.com docs instead of package managers, which may lag the active line.
 
 The command checks both the runtime and desktop app, applies the runtime first, and stages a closed
 app for its next launch. Use `--check` for a read-only result and `--cancel` only for a dormant
-operation. Read or control the same host-global operation through `GET /api/settings/update`,
+operation. The HTTP/UDS apply body is `{"targets":["runtime","app"]}` with runtime first; omit
+unavailable or managed tracks. Read or control the same host-global operation through `GET /api/settings/update`,
 `POST /api/settings/update/apply`, and `POST /api/settings/update/cancel` over HTTP or UDS.
 
 When an artifact-policy failure prevents an in-place update, follow the command's release-specific

--- a/web/e2e/__tests__/os-shell.spec.ts
+++ b/web/e2e/__tests__/os-shell.spec.ts
@@ -3917,14 +3917,14 @@ test("E2E-022: a keyboard-only operator reaches the indicator, opens Updates, an
     await route.fulfill({ json: settingsUpdateBothAvailableFixture });
   });
   await appPage.route("**/api/settings/update/apply", async route => {
-    const body = route.request().postDataJSON() as { target: string };
-    applyTargets.push(body.target);
+    const body = route.request().postDataJSON() as { targets: string[] };
+    applyTargets.push(...body.targets);
     await route.fulfill({
       json: {
-        target: body.target,
+        targets: body.targets,
         status: "accepted",
         operation_id: "op-e2e-keyboard",
-        message: "Started the runtime update.",
+        message: "Started the requested updates.",
         holder: null,
       },
     });
@@ -3947,12 +3947,12 @@ test("E2E-022: a keyboard-only operator reaches the indicator, opens Updates, an
   await expect(settingsUI.general.updates).toBeVisible({ timeout: 20_000 });
 
   // The apply affordance is a real button in the tab order, activatable by keyboard.
-  const apply = settingsUI.general.updateApply("runtime");
+  const apply = settingsUI.general.updateApply();
   await expect(apply).toBeVisible();
   await apply.focus();
   await expect(apply).toBeFocused();
   await appPage.keyboard.press("Enter");
-  await expect.poll(() => applyTargets).toEqual(["runtime"]);
+  await expect.poll(() => applyTargets).toEqual(["runtime", "app"]);
 });
 
 test("E2E-015: destination mode offers only eligible targets and exits clean when none are", async ({

--- a/web/e2e/__tests__/settings.spec.ts
+++ b/web/e2e/__tests__/settings.spec.ts
@@ -702,12 +702,11 @@ test("browser operator reads both update tracks, a managed runtime, and a headle
   const settingsUI = settingsOperatorSelectors(settingsWin);
   await expect(settingsUI.general.updates).toBeVisible({ timeout: 20_000 });
 
-  // Both tracks available: two rows, both versions, both apply affordances.
+  // Both tracks available: two rows, both versions, one combined action.
   await expect(settingsUI.general.updateTrack("runtime")).toContainText("0.5.0");
   await expect(settingsUI.general.updateTrack("runtime")).toContainText("0.5.1");
   await expect(settingsUI.general.updateTrack("app")).toContainText("0.5.1");
-  await expect(settingsUI.general.updateApply("runtime")).toBeVisible();
-  await expect(settingsUI.general.updateApply("app")).toBeVisible();
+  await expect(settingsUI.general.updateApply()).toBeVisible();
   await expect(settingsUI.general.updateRelease("runtime")).toHaveAttribute(
     "href",
     "https://github.com/compozy/compozy/releases/tag/v0.5.1"
@@ -718,7 +717,7 @@ test("browser operator reads both update tracks, a managed runtime, and a headle
   await appPage.reload({ waitUntil: "domcontentloaded" });
   await expect(settingsUI.general.updates).toBeVisible({ timeout: 20_000 });
   await expect(settingsUI.general.updateRecommendation).toContainText("brew upgrade compozy");
-  await expect(settingsUI.general.updateApply("runtime")).toHaveCount(0);
+  await expect(settingsUI.general.updateApply()).toHaveCount(0);
 
   // Headless host: the app row is absent entirely, not an empty row.
   updatePayload = updateFixtures.noApp;
@@ -729,11 +728,11 @@ test("browser operator reads both update tracks, a managed runtime, and a headle
 });
 
 /**
- * E2E-020 — applying the runtime from a plain browser: the apply call is issued
- * with its target, progress renders from the polled projection, and the terminal
+ * E2E-020 — applying all eligible tracks from a plain browser: the apply call is
+ * issued with the ordered target set, progress renders from the polled projection, and the terminal
  * outcome is read back rather than assumed (US-029 EC-2/EC-5).
  */
-test("browser operator applies the runtime update and reads staged progress and terminal truth from the daemon", async ({
+test("browser operator applies all eligible updates and reads staged progress and terminal truth from the daemon", async ({
   appPage,
   runtime,
 }) => {
@@ -747,16 +746,16 @@ test("browser operator applies the runtime update and reads staged progress and 
     await route.fulfill({ json: updatePayload });
   });
   await appPage.route("**/api/settings/update/apply", async route => {
-    const body = route.request().postDataJSON() as { target: string };
-    applyTargets.push(body.target);
+    const body = route.request().postDataJSON() as { targets: string[] };
+    applyTargets.push(...body.targets);
     // Apply only acknowledges acquisition; the GET above becomes the progress feed.
     updatePayload = updateFixtures.applying;
     await route.fulfill({
       json: {
-        target: body.target,
+        targets: body.targets,
         status: "accepted",
         operation_id: "op-e2e",
-        message: "Started the runtime update.",
+        message: "Started the requested updates.",
         holder: null,
       },
     });
@@ -766,16 +765,16 @@ test("browser operator applies the runtime update and reads staged progress and 
   const settingsWin = appWindow(appPage, "settings");
   await expect(settingsWin).toBeVisible({ timeout: 20_000 });
   const settingsUI = settingsOperatorSelectors(settingsWin);
-  await expect(settingsUI.general.updateApply("runtime")).toBeVisible({ timeout: 20_000 });
+  await expect(settingsUI.general.updateApply()).toBeVisible({ timeout: 20_000 });
 
-  await settingsUI.general.updateApply("runtime").click();
-  await expect.poll(() => applyTargets).toEqual(["runtime"]);
+  await settingsUI.general.updateApply().click();
+  await expect.poll(() => applyTargets).toEqual(["runtime", "app"]);
 
   // Progress is the daemon's named phase, not an invented spinner label.
   await expect(settingsUI.general.updateProgress("runtime")).toContainText("install", {
     timeout: 20_000,
   });
-  await expect(settingsUI.general.updateApply("runtime")).toHaveCount(0);
+  await expect(settingsUI.general.updateApply()).toHaveCount(0);
 
   // Terminal truth arrives through the polled read, including rollback.
   updatePayload = updateFixtures.rolledBack;

--- a/web/e2e/fixtures/selectors.ts
+++ b/web/e2e/fixtures/selectors.ts
@@ -718,9 +718,9 @@ interface SettingsGeneralSelectors {
   updateBlocked: Locator;
   updateRollback: Locator;
   updateCancel: Locator;
-  /** Per-track row, apply affordance, live progress, and release link. */
+  /** Per-track row, shared apply affordance, live progress, and release link. */
   updateTrack: (target: string) => Locator;
-  updateApply: (target: string) => Locator;
+  updateApply: () => Locator;
   updateProgress: (target: string) => Locator;
   updateRelease: (target: string) => Locator;
 }
@@ -1552,8 +1552,7 @@ export function settingsOperatorSelectors(
       updateCancel: page.getByTestId(settingsGeneralTestIds.updateCancel),
       updateTrack: (target: string) =>
         page.getByTestId(`settings-page-general-update-track-${target}`),
-      updateApply: (target: string) =>
-        page.getByTestId(`settings-page-general-update-apply-${target}`),
+      updateApply: () => page.getByTestId("settings-page-general-update-apply"),
       updateProgress: (target: string) =>
         page.getByTestId(`settings-page-general-update-progress-${target}`),
       updateRelease: (target: string) =>

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -68994,7 +68994,8 @@ export interface operations {
             operation_id?: string;
             /** @enum {string} */
             status: "accepted" | "blocked" | "failed";
-            targets: ("runtime" | "app")[];
+            /** @enum {array} */
+            targets: ["runtime"] | ["app"] | ["runtime", "app"];
           };
         };
       };

--- a/web/src/generated/compozy-openapi.d.ts
+++ b/web/src/generated/compozy-openapi.d.ts
@@ -68967,8 +68967,8 @@ export interface operations {
     requestBody: {
       content: {
         "application/json": {
-          /** @enum {string} */
-          target: "runtime" | "app";
+          /** @enum {array} */
+          targets: ["runtime"] | ["app"] | ["runtime", "app"];
         };
       };
     };
@@ -68994,12 +68994,11 @@ export interface operations {
             operation_id?: string;
             /** @enum {string} */
             status: "accepted" | "blocked" | "failed";
-            /** @enum {string} */
-            target: "runtime" | "app";
+            targets: ("runtime" | "app")[];
           };
         };
       };
-      /** @description Invalid update target */
+      /** @description Invalid update target set */
       400: {
         headers: {
           [name: string]: unknown;

--- a/web/src/routes/_app/settings/-general-update-section.tsx
+++ b/web/src/routes/_app/settings/-general-update-section.tsx
@@ -5,6 +5,7 @@ import {
   SettingRow,
   SettingValue,
   SettingsGroup,
+  settingsUpdateApplicableTargets,
   SettingsUpdateTrackRow,
   settingsUpdateTracks,
   settingsUpdateView,
@@ -14,13 +15,13 @@ import type {
   SettingsUpdateCancelResult,
   SettingsUpdateHolder,
   SettingsUpdateStatus,
-  SettingsUpdateTarget,
+  SettingsUpdateTargetSet,
 } from "@/systems/settings";
 
 export interface GeneralUpdateActions {
-  apply: (target: SettingsUpdateTarget) => void;
+  apply: (targets: SettingsUpdateTargetSet) => void;
   cancel: () => void;
-  pendingTarget: SettingsUpdateTarget | null;
+  isApplying: boolean;
   isCanceling: boolean;
   /** The daemon's own answer to the last apply — `accepted` or `blocked`. */
   result: SettingsUpdateApplyResult | null;
@@ -60,8 +61,8 @@ function UpdateHolderValue({ holder }: { holder: SettingsUpdateHolder }) {
 }
 
 /**
- * Settings → General → Updates: both update tracks the daemon reports, each with
- * the action it actually supports (ADR-006). The section holds no shell
+ * Settings → General → Updates: one durable action applies every eligible track,
+ * while each row keeps the track state the daemon reports (ADR-006). The section holds no shell
  * awareness — it reads the daemon like any browser client, so it renders
  * identically in the desktop app and in a plain browser.
  */
@@ -114,6 +115,7 @@ export function GeneralUpdateSection(props: GeneralUpdateSectionProps) {
 
   const snapshot = view.snapshot;
   const tracks = settingsUpdateTracks(snapshot);
+  const applicableTargets = view.refreshError ? null : settingsUpdateApplicableTargets(tracks);
   const runtime = tracks[0];
   // A blocked apply is a 200 whose body refuses; it never reads as success.
   const blocked = props.actions.result?.status === "blocked" ? props.actions.result : null;
@@ -131,10 +133,27 @@ export function GeneralUpdateSection(props: GeneralUpdateSectionProps) {
           : undefined
       }
       action={
-        view.refreshError ? (
+        view.refreshError || applicableTargets ? (
           <>
-            <Pill tone="danger">Refresh failed</Pill>
-            <RetryButton isFetching={props.isFetching} onRetry={props.onRetry} />
+            {applicableTargets ? (
+              <Button
+                data-testid="settings-page-general-update-apply"
+                disabled={props.actions.isApplying}
+                onClick={() => props.actions.apply(applicableTargets)}
+                size="sm"
+                type="button"
+                variant="neutral"
+              >
+                {props.actions.isApplying ? <Spinner className="size-3" /> : null}
+                Update CompozyOS
+              </Button>
+            ) : null}
+            {view.refreshError ? (
+              <>
+                <Pill tone="danger">Refresh failed</Pill>
+                <RetryButton isFetching={props.isFetching} onRetry={props.onRetry} />
+              </>
+            ) : null}
           </>
         ) : null
       }
@@ -143,9 +162,7 @@ export function GeneralUpdateSection(props: GeneralUpdateSectionProps) {
         <SettingsUpdateTrackRow
           key={track.id}
           isCanceling={props.actions.isCanceling}
-          onApply={props.actions.apply}
           onCancel={props.actions.cancel}
-          pendingTarget={props.actions.pendingTarget}
           track={track}
         />
       ))}

--- a/web/src/routes/_app/settings/__tests__/-general.test.tsx
+++ b/web/src/routes/_app/settings/__tests__/-general.test.tsx
@@ -46,7 +46,7 @@ type UpdateStatus = SettingsUpdateStatus;
 type UpdateActions = {
   apply: ReturnType<typeof vi.fn>;
   cancel: ReturnType<typeof vi.fn>;
-  pendingTarget: "runtime" | "app" | null;
+  isApplying: boolean;
   isCanceling: boolean;
   result: SettingsUpdateApplyResult | null;
   cancelResult: SettingsUpdateCancelResult | null;
@@ -221,7 +221,7 @@ beforeEach(() => {
     updateActions: {
       apply: vi.fn(),
       cancel: vi.fn(),
-      pendingTarget: null,
+      isApplying: false,
       isCanceling: false,
       result: null,
       cancelResult: null,
@@ -416,8 +416,7 @@ describe("GeneralSettingsPage", () => {
 describe("GeneralSettingsPage — Updates section", () => {
   const track = (target: "runtime" | "app") =>
     screen.getByTestId(`settings-page-general-update-track-${target}`);
-  const apply = (target: "runtime" | "app") =>
-    screen.queryByTestId(`settings-page-general-update-apply-${target}`);
+  const apply = () => screen.queryByTestId("settings-page-general-update-apply");
 
   it("UT-040: Should render both tracks with their own versions, status, and release link", () => {
     render(<GeneralSettingsPage />);
@@ -432,6 +431,7 @@ describe("GeneralSettingsPage — Updates section", () => {
       "https://github.com/compozy/compozy/releases/tag/v0.5.1"
     );
     expect(screen.getByTestId("settings-page-general-update-release-app")).toBeInTheDocument();
+    expect(apply()).toBeInTheDocument();
   });
 
   it("UT-041: Should render a single-track section when the host has no desktop app", () => {
@@ -453,14 +453,14 @@ describe("GeneralSettingsPage — Updates section", () => {
       "CompozyOS 0.5.1 is available. Upgrade with your package manager."
     );
     // Absent, not disabled — a dimmed button would still claim the capability.
-    expect(apply("runtime")).toBeNull();
+    expect(apply()).toBeNull();
   });
 
   it("UT-043: Should apply the clicked track and then render the daemon's staged phase", () => {
     const { rerender } = render(<GeneralSettingsPage />);
 
-    fireEvent.click(screen.getByTestId("settings-page-general-update-apply-runtime"));
-    expect(pageState.updateActions.apply).toHaveBeenCalledWith("runtime");
+    fireEvent.click(screen.getByTestId("settings-page-general-update-apply"));
+    expect(pageState.updateActions.apply).toHaveBeenCalledWith(["runtime", "app"]);
 
     // Progress is not optimistic: it appears only once the polled read reports it.
     pageState.update.data = settingsUpdateApplyingFixture;
@@ -470,7 +470,14 @@ describe("GeneralSettingsPage — Updates section", () => {
     expect(progress).toHaveTextContent("install · 62%");
     expect(progress).toHaveAttribute("role", "status");
     expect(progress).toHaveAttribute("aria-live", "polite");
-    expect(apply("runtime")).toBeNull();
+    expect(apply()).toBeNull();
+  });
+
+  it("Should disable the shared action while its durable request is pending", () => {
+    pageState.updateActions.isApplying = true;
+    render(<GeneralSettingsPage />);
+
+    expect(screen.getByTestId("settings-page-general-update-apply")).toBeDisabled();
   });
 
   it("UT-044: Should report a staged app with the daemon's next-launch message and a cancel action", () => {
@@ -531,7 +538,7 @@ describe("GeneralSettingsPage — Updates section", () => {
     expect(screen.getByText("Refresh failed")).toBeInTheDocument();
     // The rows keep their last truth rather than restating the failure per track.
     expect(track("runtime")).toHaveTextContent("0.5.1");
-    expect(apply("runtime")).toBeInTheDocument();
+    expect(apply()).toBeNull();
 
     fireEvent.click(screen.getByTestId("settings-page-general-update-retry"));
     expect(pageState.update.refetch).toHaveBeenCalledTimes(1);
@@ -540,7 +547,7 @@ describe("GeneralSettingsPage — Updates section", () => {
   it("UT-047: Should surface a blocked apply with its holder and claim no success", () => {
     pageState.update.data = settingsUpdateBlockedFixture;
     pageState.updateActions.result = {
-      target: "runtime",
+      targets: ["runtime"],
       status: "blocked",
       message: "A runtime update is already in progress. Retry after it completes.",
       holder: {
@@ -558,21 +565,21 @@ describe("GeneralSettingsPage — Updates section", () => {
     );
     expect(within(track("runtime")).getByText("Blocked")).toBeInTheDocument();
     expect(screen.queryByText("Updated")).toBeNull();
-    expect(apply("runtime")).toBeNull();
+    expect(apply()).toBeNull();
   });
 
-  it("UT-048: Should keep the apply action tab-reachable and Enter-activatable", async () => {
+  it("UT-048: Should keep the shared apply action tab-reachable and Enter-activatable", async () => {
     const user = userEvent.setup();
     pageState.update.data = settingsUpdateNoAppFixture;
     render(<GeneralSettingsPage />);
 
-    const applyButton = screen.getByTestId("settings-page-general-update-apply-runtime");
+    const applyButton = screen.getByTestId("settings-page-general-update-apply");
     screen.getByTestId("settings-page-general-update-release-runtime").focus();
     await user.tab({ shift: true });
     expect(applyButton).toHaveFocus();
 
     await user.keyboard("{Enter}");
-    expect(pageState.updateActions.apply).toHaveBeenCalledWith("runtime");
+    expect(pageState.updateActions.apply).toHaveBeenCalledWith(["runtime"]);
   });
 
   it("Should acknowledge a canceled dormant update", () => {
@@ -622,6 +629,6 @@ describe("GeneralSettingsPage — Updates section", () => {
       "health check failed after swap"
     );
     // The lease is free again, so the offer returns.
-    expect(apply("runtime")).toBeInTheDocument();
+    expect(apply()).toBeInTheDocument();
   });
 });

--- a/web/src/routes/_app/settings/__tests__/-general.test.tsx
+++ b/web/src/routes/_app/settings/__tests__/-general.test.tsx
@@ -628,7 +628,7 @@ describe("GeneralSettingsPage — Updates section", () => {
     expect(screen.getByTestId("settings-page-general-update-last-error")).toHaveTextContent(
       "health check failed after swap"
     );
-    // The lease is free again, so the offer returns.
-    expect(apply()).toBeInTheDocument();
+    // The failed projection is diagnostic-only until a fresh check reports available.
+    expect(apply()).toBeNull();
   });
 });

--- a/web/src/systems/settings/adapters/settings-sections-api.ts
+++ b/web/src/systems/settings/adapters/settings-sections-api.ts
@@ -34,6 +34,7 @@ import type {
   SettingsUpdateApplyRequest,
   SettingsUpdateApplyResult,
   SettingsUpdateCancelResult,
+  SettingsUpdateTargetSet,
   SettingsUpdateShellRequest,
   SettingsUpdateSkillsFilter,
   SettingsUpdateSkillsRequest,
@@ -123,7 +124,17 @@ export async function applySettingsUpdate(
       response.status
     );
   }
-  return requireResponseData(data, response, "Failed to start the update");
+  const result = requireResponseData(data, response, "Failed to start the update");
+  if (!isSettingsUpdateTargetSet(result.targets)) {
+    throw new SettingsApiError("Failed to start the update: invalid target set", response.status);
+  }
+  return { ...result, targets: result.targets };
+}
+
+function isSettingsUpdateTargetSet(value: unknown): value is SettingsUpdateTargetSet {
+  if (!Array.isArray(value)) return false;
+  if (value.length === 1) return value[0] === "runtime" || value[0] === "app";
+  return value.length === 2 && value[0] === "runtime" && value[1] === "app";
 }
 
 /** Cancels a dormant operation only; a live executor lease declines with its holder. */

--- a/web/src/systems/settings/adapters/settings-sections-api.ts
+++ b/web/src/systems/settings/adapters/settings-sections-api.ts
@@ -104,7 +104,7 @@ export async function getSettingsUpdate(signal?: AbortSignal): Promise<SettingsU
 }
 
 /**
- * Requests an apply for one track. The daemon answers `accepted` + operation id
+ * Requests an apply for all eligible tracks. The daemon answers `accepted` + operation id
  * after durable acquisition, or a deterministic `blocked` naming the holder — it
  * never returns a terminal verdict it cannot yet know. Terminal truth arrives
  * through `getSettingsUpdate`, so callers must not treat a 200 as success.

--- a/web/src/systems/settings/components/settings-update-track-row.tsx
+++ b/web/src/systems/settings/components/settings-update-track-row.tsx
@@ -4,15 +4,11 @@ import { Button, Pill, Spinner } from "@compozy/ui";
 
 import { settingsUpdateVersionTransition } from "../lib/update-presentation";
 import type { SettingsUpdateTrackView } from "../lib/update-presentation";
-import type { SettingsUpdateTarget } from "../types";
 import { SettingRow, SettingValue } from "./setting-row";
 
 export interface SettingsUpdateTrackRowProps {
   track: SettingsUpdateTrackView;
-  onApply: (target: SettingsUpdateTarget) => void;
   onCancel: () => void;
-  /** The track an apply request is currently in flight for, if any. */
-  pendingTarget: SettingsUpdateTarget | null;
   isCanceling: boolean;
 }
 
@@ -37,19 +33,16 @@ function TrackVersion({ track }: { track: SettingsUpdateTrackView }) {
 
 /**
  * One update track (runtime or app) as a settings row: label, the daemon's
- * consequence sentence where it adds truth, the version lane, and the controls
- * the projected track truth allows. Status, action, cancel, and release notes may
- * coexist when each communicates a distinct fact.
+ * consequence sentence where it adds truth, the version lane, cancel, and release
+ * notes. The shared apply action lives in the section header so one click can
+ * update every eligible track.
  *
- * The apply affordance is absent — never disabled — whenever the daemon says this
- * track is not ours to mutate (SD-007): a managed install, a track with nothing
- * to apply, or a home whose update channel is already held.
+ * `canApply` remains in the view model as the daemon-derived input for that
+ * shared action; this row never invents a per-track mutation affordance (SD-007).
  */
 export function SettingsUpdateTrackRow({
   track,
-  onApply,
   onCancel,
-  pendingTarget,
   isCanceling,
 }: SettingsUpdateTrackRowProps) {
   // A track with no live progress (settled, staged, refused) keeps its status
@@ -93,19 +86,6 @@ export function SettingsUpdateTrackRow({
               {track.statusLabel}
             </Pill>
           )}
-          {track.canApply ? (
-            <Button
-              data-testid={`settings-page-general-update-apply-${track.id}`}
-              disabled={pendingTarget !== null}
-              onClick={() => onApply(track.id)}
-              size="sm"
-              type="button"
-              variant="neutral"
-            >
-              {pendingTarget === track.id ? <Spinner className="size-3" /> : null}
-              Update {track.id}
-            </Button>
-          ) : null}
           {track.canCancel ? (
             <Button
               data-testid="settings-page-general-update-cancel"

--- a/web/src/systems/settings/hooks/__tests__/use-settings-general-page.test.tsx
+++ b/web/src/systems/settings/hooks/__tests__/use-settings-general-page.test.tsx
@@ -185,9 +185,9 @@ describe("useSettingsGeneralPage", () => {
     });
   });
 
-  it("Should send the requested track to the apply endpoint and expose the daemon's answer", async () => {
+  it("Should send all requested targets to the apply endpoint and expose the daemon's answer", async () => {
     vi.mocked(applySettingsUpdate).mockResolvedValue({
-      target: "runtime",
+      targets: ["runtime", "app"],
       status: "accepted",
       operation_id: "op-7f3a2c",
       message: "Started the runtime update.",
@@ -199,11 +199,11 @@ describe("useSettingsGeneralPage", () => {
     await waitFor(() => expect(result.current.update.data).toBeTruthy());
 
     act(() => {
-      result.current.updateActions.apply("runtime");
+      result.current.updateActions.apply(["runtime", "app"]);
     });
 
     await waitFor(() => {
-      expect(applySettingsUpdate).toHaveBeenCalledWith({ target: "runtime" });
+      expect(applySettingsUpdate).toHaveBeenCalledWith({ targets: ["runtime", "app"] });
       expect(result.current.updateActions.result).toMatchObject({
         status: "accepted",
         operation_id: "op-7f3a2c",
@@ -213,7 +213,7 @@ describe("useSettingsGeneralPage", () => {
 
   it("Should keep a blocked apply answer verbatim instead of reporting success", async () => {
     vi.mocked(applySettingsUpdate).mockResolvedValue({
-      target: "runtime",
+      targets: ["runtime"],
       status: "blocked",
       message:
         "A runtime update is already in progress (holder pid 4242). Retry after it completes.",
@@ -231,7 +231,7 @@ describe("useSettingsGeneralPage", () => {
     await waitFor(() => expect(result.current.update.data).toBeTruthy());
 
     act(() => {
-      result.current.updateActions.apply("runtime");
+      result.current.updateActions.apply(["runtime"]);
     });
 
     await waitFor(() => {

--- a/web/src/systems/settings/hooks/use-settings-general-page.ts
+++ b/web/src/systems/settings/hooks/use-settings-general-page.ts
@@ -6,7 +6,7 @@ import {
   SettingsApiError,
   type SettingsGeneralSection,
   type SettingsUpdateGeneralRequest,
-  type SettingsUpdateTarget,
+  type SettingsUpdateTargetSet,
   useApplySettingsUpdate,
   useCancelSettingsUpdate,
   useReloadSettings,
@@ -147,9 +147,9 @@ export function useSettingsGeneralPage() {
     // own answer (`accepted` or `blocked` with its holder) so the surface can
     // report it verbatim; terminal truth still comes from the `update` read.
     updateActions: {
-      apply: (target: SettingsUpdateTarget) => updateApply.mutate({ target }),
+      apply: (targets: SettingsUpdateTargetSet) => updateApply.mutate({ targets }),
       cancel: () => updateCancel.mutate(),
-      pendingTarget: updateApply.isPending ? (updateApply.variables?.target ?? null) : null,
+      isApplying: updateApply.isPending,
       isCanceling: updateCancel.isPending,
       result: updateApply.data ?? null,
       cancelResult: updateCancel.data ?? null,

--- a/web/src/systems/settings/hooks/use-settings-update-mutations.ts
+++ b/web/src/systems/settings/hooks/use-settings-update-mutations.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { applySettingsUpdate, cancelSettingsUpdate } from "../adapters/settings-api";
 import { settingsKeys } from "../lib/query-keys";
-import type { SettingsUpdateTarget } from "../types";
+import type { SettingsUpdateApplyRequest } from "../types";
 
 /**
  * Update-operation mutations (ADR-009). These are host-global lifecycle actions
@@ -19,9 +19,7 @@ export function useApplySettingsUpdate() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    // Typed on the closed target vocabulary rather than the generated `string`,
-    // so callers can read `variables.target` back without an assertion.
-    mutationFn: (body: { target: SettingsUpdateTarget }) => applySettingsUpdate(body),
+    mutationFn: (body: SettingsUpdateApplyRequest) => applySettingsUpdate(body),
     onSettled: () => queryClient.invalidateQueries({ queryKey: settingsKeys.updateStatus() }),
   });
 }

--- a/web/src/systems/settings/index.ts
+++ b/web/src/systems/settings/index.ts
@@ -380,6 +380,7 @@ export { useSettingsTopbar, type UseSettingsTopbarOptions } from "./hooks/use-se
 export type { SettingsSaveBarState } from "./lib/save-state";
 export {
   settingsUpdateIndicatorAvailable,
+  settingsUpdateApplicableTargets,
   settingsUpdateStatusLabel,
   settingsUpdateStatusTone,
   settingsUpdateTracks,

--- a/web/src/systems/settings/lib/__tests__/update-presentation.test.ts
+++ b/web/src/systems/settings/lib/__tests__/update-presentation.test.ts
@@ -166,8 +166,9 @@ describe("settingsUpdateTracks", () => {
       restoredVersion: "0.5.0",
       lastError: "health check failed after swap",
     });
-    // The operation is terminal and the lease is free, so the offer stands again.
-    expect(runtime.canApply).toBe(true);
+    // A failed projection is diagnostic-only until a fresh check reports available;
+    // PlanOperation rejects failed targets even after the lease is free.
+    expect(runtime.canApply).toBe(false);
   });
 
   it("Should not offer a failed track without release metadata", () => {

--- a/web/src/systems/settings/lib/__tests__/update-presentation.test.ts
+++ b/web/src/systems/settings/lib/__tests__/update-presentation.test.ts
@@ -13,6 +13,7 @@ import {
   settingsUpdateStatusFixture,
 } from "../../mocks/settings-update-fixture";
 import {
+  settingsUpdateApplicableTargets,
   settingsUpdateIndicatorAvailable,
   settingsUpdateTracks,
   settingsUpdateView,
@@ -218,6 +219,35 @@ describe("settingsUpdateTracks", () => {
       "CompozyOS 0.5.1 is available. Upgrade with your package manager."
     );
     expect(failed.description).toBe("Update failed; restored CompozyOS runtime 0.5.0.");
+  });
+});
+
+describe("settingsUpdateApplicableTargets", () => {
+  it("Should preserve runtime-first order for both eligible tracks", () => {
+    const tracks = settingsUpdateTracks(settingsUpdateBothAvailableFixture);
+
+    expect(settingsUpdateApplicableTargets(tracks)).toEqual(["runtime", "app"]);
+  });
+
+  it("Should return exactly the eligible one-track target", () => {
+    expect(
+      settingsUpdateApplicableTargets(settingsUpdateTracks(settingsUpdateRuntimeAvailableFixture))
+    ).toEqual(["runtime"]);
+    expect(
+      settingsUpdateApplicableTargets(settingsUpdateTracks(settingsUpdateAppAvailableFixture))
+    ).toEqual(["app"]);
+  });
+
+  it("Should return no targets for managed, absent, or live update states", () => {
+    expect(
+      settingsUpdateApplicableTargets(settingsUpdateTracks(settingsUpdateManagedFixture))
+    ).toBeNull();
+    expect(
+      settingsUpdateApplicableTargets(settingsUpdateTracks(settingsUpdateApplyingFixture))
+    ).toBeNull();
+    expect(
+      settingsUpdateApplicableTargets(settingsUpdateTracks(settingsUpdateStatusFixture))
+    ).toBeNull();
   });
 });
 

--- a/web/src/systems/settings/lib/update-presentation.ts
+++ b/web/src/systems/settings/lib/update-presentation.ts
@@ -5,6 +5,7 @@ import type {
   SettingsUpdateStatus,
   SettingsUpdateStatusKind,
   SettingsUpdateTarget,
+  SettingsUpdateTargetSet,
 } from "../types";
 import { updatePhasePercent, updateUiPhase, type UpdateUiPhase } from "./update-phase-map";
 
@@ -273,6 +274,23 @@ export function settingsUpdateTracks(snapshot: SettingsUpdateStatus): SettingsUp
     );
   }
   return tracks;
+}
+
+/** The ordered targets this surface may apply in one durable operation. */
+export function settingsUpdateApplicableTargets(
+  tracks: readonly Pick<SettingsUpdateTrackView, "id" | "canApply">[]
+): SettingsUpdateTargetSet | null {
+  let runtime = false;
+  let app = false;
+  for (const track of tracks) {
+    if (!track.canApply) continue;
+    if (track.id === "runtime") runtime = true;
+    if (track.id === "app") app = true;
+  }
+  if (runtime && app) return ["runtime", "app"];
+  if (runtime) return ["runtime"];
+  if (app) return ["app"];
+  return null;
 }
 
 /**

--- a/web/src/systems/settings/lib/update-presentation.ts
+++ b/web/src/systems/settings/lib/update-presentation.ts
@@ -145,8 +145,9 @@ function trackProgress(
  * Requires something to apply, a self-applicable install, and a free update
  * channel — acquisition is single-flight per home, so a live operation makes
  * apply impossible rather than merely inadvisable. Managed installs recommend
- * and never mutate, so they never qualify. A `failed` track qualifies again once
- * its operation is terminal: the lease is free and the offer still stands.
+ * and never mutate, so they never qualify. A failed track remains diagnostic-only
+ * until the daemon reports a fresh available state; PlanOperation rejects failed
+ * targets even when the lease is free.
  */
 function canApplyTrack(input: {
   status: SettingsUpdateStatusKind;
@@ -155,7 +156,7 @@ function canApplyTrack(input: {
   latestVersion: string | null;
 }): boolean {
   if (input.managed || input.operation !== null || input.latestVersion === null) return false;
-  return input.status === "available" || input.status === "failed";
+  return input.status === "available";
 }
 
 function dormantOperationTarget(

--- a/web/src/systems/settings/mocks/handlers.ts
+++ b/web/src/systems/settings/mocks/handlers.ts
@@ -152,10 +152,10 @@ export const handlers: HttpHandler[] = [
   compozyApiMock.post("/api/settings/update/apply", async ({ request }) => {
     const body = (await request.json()) as SettingsUpdateApplyRequest;
     return HttpResponse.json({
-      target: body.target,
+      targets: body.targets,
       status: "accepted",
       operation_id: "op-storybook",
-      message: `Started the ${body.target} update.`,
+      message: "Started the requested updates.",
       holder: null,
     });
   }),

--- a/web/src/systems/settings/public-types.ts
+++ b/web/src/systems/settings/public-types.ts
@@ -108,6 +108,7 @@ export type {
   SettingsUpdateStatus,
   SettingsUpdateStatusKind,
   SettingsUpdateTarget,
+  SettingsUpdateTargetSet,
   SettingsUpdateWindowManagerRequest,
   SettingsWindowManagerSection,
   SettingsWriteTarget,

--- a/web/src/systems/settings/routes/settings-general.stories.tsx
+++ b/web/src/systems/settings/routes/settings-general.stories.tsx
@@ -324,7 +324,7 @@ export const UpdatesChecking: Story = {
 /** Both tracks are current: the calm, explicit settled state. */
 export const UpdatesUpToDate: Story = updateStory(settingsUpdateStatusFixture);
 
-/** Both tracks offer a release: two rows, two actions, no combined "update all". */
+/** Both tracks offer a release: two rows, one combined action. */
 export const UpdatesBothAvailable: Story = updateStory(settingsUpdateBothAvailableFixture);
 
 /** Runtime only offers a release; the current app keeps its settled lane. */

--- a/web/src/systems/settings/types.ts
+++ b/web/src/systems/settings/types.ts
@@ -171,6 +171,7 @@ export type SettingsUpdateOperation = NonNullable<SettingsUpdateStatus["operatio
 export type SettingsUpdateHolder = NonNullable<SettingsUpdateOperation["holder"]>;
 export type SettingsUpdateStatusKind = SettingsUpdateRuntimeTrack["status"];
 export type SettingsUpdateApplyRequest = OperationRequestBody<"applySettingsUpdate">;
+export type SettingsUpdateTargetSet = SettingsUpdateApplyRequest["targets"];
 export type SettingsUpdateApplyResult = OperationResponse<"applySettingsUpdate", 200>;
 export type SettingsUpdateCancelResult = OperationResponse<"cancelSettingsUpdate", 200>;
 /** The two update tracks the daemon models. Mirrors `compozyupdate.Target`. */


### PR DESCRIPTION
## Summary

Closes ENG-144.

Settings → General → Updates now has one durable action for every update track that is currently eligible. When both the CompozyOS runtime and the desktop app can be updated, the action submits one ordered operation (`runtime` then `app`). When only one track is eligible, it submits that single target. Managed installs, unavailable tracks, live operations, and stale snapshots never expose a mutation action.

## Issue and root cause

The page previously rendered one apply button per track and the public mutation contract carried one `target` value. That made a two-track update require separate requests, allowed the UI to present independently actionable rows, and left the generated OpenAPI/TypeScript contract unable to describe the durable multi-target operation. The daemon already owns the single-flight channel and ordered coordinator, so the split was a web/API projection problem rather than a new update engine requirement.

## Implementation

- Replaced `target` with a required `targets` array across the HTTP/UDS contract, handler, daemon controller, response mapping, generated OpenAPI, and generated TypeScript.
- Added exact request validation: at least one target, no duplicates, no more than two targets, exact `runtime`/`app` values, and runtime first. The removed singular request and whitespace-normalized values now return clear 400 errors.
- Published the three valid target sets in OpenAPI/TypeScript: `["runtime"]`, `["app"]`, and `["runtime", "app"]`.
- Passed the resolved ordered slice directly into `PlanOperation`; the durable response preserves the requested target set for accepted, blocked, and failed outcomes.
- Added `settingsUpdateApplicableTargets` to derive one ordered action from daemon truth. The header action is absent when no target is eligible, while rows retain status, progress, release notes, recommendation, restored version, and error information.
- Hid the action during refresh failure so a stale snapshot cannot authorize a mutation; rows remain visible and the retry control remains available.
- Updated Storybook/MSW fixtures, browser selectors, E2E assertions, site guidance, and the official `skills/compozy/` references.
- Flagged `MS-settings-update-mutations` with a focused QA report. The browser walk is recorded as `blocked-verify` because a focused Playwright command is not registered in Turbo and the broader web lane is deferred to CI by task scope; no unverified result is claimed as a pass.

## Tests and verification

Passed locally:

- `go test -race ./internal/api/core ./internal/api/spec ./internal/daemon -run 'TestSettingsUpdate|TestSettingsRoutesAndSchemas' -count=1` — 86 tests.
- `bunx turbo run test --filter=./web -- --run src/systems/settings/lib/__tests__/update-presentation.test.ts src/systems/settings/hooks/__tests__/use-settings-general-page.test.tsx src/routes/_app/settings/__tests__/-general.test.tsx` — 58 tests.
- `bunx turbo run typecheck --filter=./web`.
- `bunx turbo run lint --filter=./web` — zero warnings and errors.
- `make codegen` and Turbo `codegen-check`.
- `git diff --check`.

`make gate` was invoked as required. Because this change touches the OpenAPI contract, the repository classifier automatically escalated it to the full verification path. The local full escalation was intentionally not completed; `make verify` and `make gate-full` were not run directly, and CI owns that full gate as requested.

## Risks and rollout

- This is an intentional alpha hard cut: clients must send `{"targets":[...]}` and no singular-field compatibility shim remains.
- The ordered operation remains host-global and single-flight; managed installs remain recommendation-only.
- The OpenAPI request union is deliberately narrower than a generic string array, so generated clients cannot form empty, duplicate, reversed, or over-sized target sets.
- The browser E2E walk is the only remaining local verification limitation and is explicitly recorded in `docs/qa/reports/2026-08-24-eng-144.md`; CI web checks must provide the final browser evidence.

## Compozy Impact Audit

- **Native tools:** No new or changed `compozy__*` tool ID, toolset, descriptor, schema digest, risk flag, capability gate, or availability diagnostic. Existing CLI/HTTP/UDS update surfaces were checked and now share the array contract.
- **Extensibility and hooks:** No extension, hook, skill/capability, tools/resources, registry, bridge SDK, MCP sidecar, or `config.toml` lifecycle change. The existing agent-manageable HTTP/UDS mutation remains the extension boundary. Public guidance was updated in `skills/compozy/`.
- **Workspace data isolation:** No impact. Update state remains host-global to the resolved Compozy home; no workspace-scoped datum or workspace propagation path changed.
- **Official Compozy skill:** Updated `skills/compozy/references/desktop.md`, `runtime-operations.md`, and `configuration.md` with the hard-cut ordered target-set request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings updates can now be applied to runtime, app, or both targets in a single action.
  * Added one shared **Apply Updates** button for all eligible tracks.
  * Update results now report all requested targets.

* **Bug Fixes**
  * Added validation for target combinations, ordering, duplicates, and unsupported values.
  * Improved handling of update failures across multiple targets.
  * Failed or unavailable tracks are no longer offered for updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->