### PR TITLE
fix: add runtime provider tooltips

### DIFF
--- a/docs/qa/reports/2026-08-24-eng-143-runtime-selector.md
+++ b/docs/qa/reports/2026-08-24-eng-143-runtime-selector.md
@@ -1,0 +1,72 @@
+# QA Run Report — 2026-08-24 — eng-143-runtime-selector
+
+- **Scope:** ENG-143 runtime-selector provider tooltips
+- **Cadence tier:** targeted
+- **Build:** working tree for `linear-eng-143` · **Environment:** isolated Web lab at `http://[::1]:3000/`, with `COMPOZY_WEB_API_PROXY_TARGET=http://127.0.0.1:60608`
+- **Started:** 2026-08-25T00:51:20Z · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Sol | default onboarding | desktop / local isolated lab / en-US | CH-untested-018-17-sol |
+
+## Flows in Scope
+
+- `J-17` — discover provider identity in the runtime selector (`../journeys/J-17.md`)
+- `ET-web-runtime-selector-minimal-slider` — runtime selector entry points and provider/model surfaces
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-untested-018-17-sol | J-17 / ET-web-runtime-selector-minimal-slider | Sol | Feature Tour | Pass | | |
+
+## Session Debriefs
+
+### CH-untested-018-17-sol — Sol
+
+- **Ran:** 2026-08-25T00:51:20Z → 2026-08-25T00:53:38Z (box respected: yes)
+- **Findings:**
+  - Codex displayed the exact `Codex` tooltip on hover and the shared tooltip appeared above the popup.
+  - Keyboard focus on the Codex provider chip displayed the same tooltip while preserving the radio trigger.
+  - Groq displayed the truthful `Groq · needs sign in` label.
+  - The pinned cross-provider GPT-5.6 Sol row displayed the exact `Codex` tooltip when its provider glyph was hovered.
+  - Searching for `gpt` disabled the provider radios and did not show a tooltip when a disabled chip was hovered.
+- **Bugs filed/updated:** none
+- **Scenarios settled:** provider hover, keyboard focus, needs-sign-in hover, pinned model-glyph hover, and disabled-search behavior all passed in the live walk
+- **Paper cuts:** none
+- **Surprises:** none
+- **Suggested next charter:** none for ENG-143; CI should complete the repository-wide verification gate
+
+## What Was Fixed
+
+No QA bugs were found. ENG-143 implementation details and regression coverage are recorded in the PR.
+
+## Paper Cuts
+
+| Persona | Where (journey/step) | Felt | Sharpness | Outcome |
+|---|---|---|---|---|
+| Sol | J-17 provider rail | none | dull | no action |
+
+## Runtime Errors Observed
+
+- None. `agent-browser errors` returned no page errors during the walk.
+
+## Decisions for a Human
+
+None. The full repository gate is an automated CI release-readiness prerequisite, not a human-only verification step.
+
+## Learnings
+
+- The shared tooltip primitive provides the required portal and stacking behavior without adding a local provider.
+
+## Final Status
+
+- **Exit gate (full automated suite):** not run locally by instruction; CI must run `make verify` as the automated release-readiness prerequisite.
+- **Task-scoped gate:** `make gate` ran the Web lint/typecheck/test lane; lint and typecheck passed, while the pre-existing `web-storybook-visual-contract.test.ts` timeout and `use-window-manager-stream.test.tsx` failure occurred independently of the ENG-143 files. Both failures reproduced or were isolated separately.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1/1 targeted journey walked; pointer, keyboard-focus, needs-sign-in, pinned-glyph, and disabled-search states all passed.
+- **Verdict:** ready — ENG-143 behavior passed automated and live checks; CI still owns the full gate and the unrelated baseline test failure.
+
+Evidence: `/Users/pedronauck/dev/qa-labs/compozy-eng-143-runtime-selector-20260825-004835-671661-lab/qa-artifacts/qa/`; teardown evidence: `teardown.json` (`clean: true`, no survivors).

--- a/docs/qa/scenarios/ET-web-runtime-selector-minimal-slider.md
+++ b/docs/qa/scenarios/ET-web-runtime-selector-minimal-slider.md
@@ -9,10 +9,10 @@ entry_points: web session-composer runtime selector; agent create/settings runti
 qa_status: pass
 bug_ids:
 fix_status:
-retest_status: pass
+retest_status:
 fix_commits:
-evidence: /Users/pedronauck/dev/qa-labs/compozy-qa-et-current-source-20260730-061655-910372-lab/qa-artifacts/qa;docs/qa/evidence/2026-07-30-session-runtime-selector/05-session-runtime-selector.png;docs/qa/evidence/2026-07-30-session-runtime-selector/12-claude-max-selected.png;docs/qa/evidence/2026-07-30-session-runtime-selector/runtime-selector-proof.md
-last_report: docs/qa/reports/2026-07-30-session-runtime-selector.md
+evidence: /Users/pedronauck/dev/qa-labs/compozy-qa-et-current-source-20260730-061655-910372-lab/qa-artifacts/qa;docs/qa/evidence/2026-07-30-session-runtime-selector/05-session-runtime-selector.png;docs/qa/evidence/2026-07-30-session-runtime-selector/12-claude-max-selected.png;docs/qa/evidence/2026-07-30-session-runtime-selector/runtime-selector-proof.md;/Users/pedronauck/dev/qa-labs/compozy-eng-143-runtime-selector-20260825-004835-671661-lab/qa-artifacts/qa/provider-tooltip-hover.png;/Users/pedronauck/dev/qa-labs/compozy-eng-143-runtime-selector-20260825-004835-671661-lab/qa-artifacts/qa/provider-tooltip-keyboard-focus.png;/Users/pedronauck/dev/qa-labs/compozy-eng-143-runtime-selector-20260825-004835-671661-lab/qa-artifacts/qa/provider-tooltip-needs-signin.png;/Users/pedronauck/dev/qa-labs/compozy-eng-143-runtime-selector-20260825-004835-671661-lab/qa-artifacts/qa/provider-tooltip-model-glyph.png;/Users/pedronauck/dev/qa-labs/compozy-eng-143-runtime-selector-20260825-004835-671661-lab/qa-artifacts/qa/provider-tooltip-disabled-search.png;/Users/pedronauck/dev/qa-labs/compozy-eng-143-runtime-selector-20260825-004835-671661-lab/qa-artifacts/qa/verification-report.md;/Users/pedronauck/dev/qa-labs/compozy-eng-143-runtime-selector-20260825-004835-671661-lab/qa-artifacts/qa/teardown.json
+last_report: docs/qa/reports/2026-08-24-eng-143-runtime-selector.md
 overlaps: RT-068;RT-072;RT-071;RT-064;RT-061
 ---
 
@@ -20,3 +20,7 @@ Added by the 2026-07-22 runtime-selector redesign (reference: docs/design/opende
 
 QA impact 2026-07-25 (deep-review remediation): every slider thumb now has an accessible label,
 including multi-thumb use. Flag only; the next QA cycle owns screen-reader and keyboard retesting.
+
+QA impact 2026-08-25 (ENG-143): provider chips and cross-provider model glyphs now expose the
+provider display name through the shared tooltip, while disabled provider chips stay silent during
+search. Reset for targeted web hover and keyboard-focus verification.

--- a/web/src/systems/runtime/components/runtime-selector/__tests__/runtime-selector.test.tsx
+++ b/web/src/systems/runtime/components/runtime-selector/__tests__/runtime-selector.test.tsx
@@ -11,7 +11,7 @@ import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { IntensityMeter, UIProvider } from "@compozy/ui";
+import { IntensityMeter, TooltipProvider, UIProvider } from "@compozy/ui";
 
 import { FAVORITES_STORAGE_KEY, RECENTS_LIMIT, RECENTS_STORAGE_KEY } from "../favorites";
 import { runtimeModelKey } from "../model-key";
@@ -82,17 +82,19 @@ function renderSelector({
     const [current, setCurrent] = useState<RuntimeSelectorValue>(value);
     return (
       <UIProvider reducedMotion="never" skipAnimations>
-        <RuntimeSelector
-          {...props}
-          value={current}
-          onChange={next => {
-            onChange(next);
-            setCurrent(next);
-          }}
-          providers={providers}
-          models={models}
-          triggerTestId="rt-trigger"
-        />
+        <TooltipProvider delay={0}>
+          <RuntimeSelector
+            {...props}
+            value={current}
+            onChange={next => {
+              onChange(next);
+              setCurrent(next);
+            }}
+            providers={providers}
+            models={models}
+            triggerTestId="rt-trigger"
+          />
+        </TooltipProvider>
       </UIProvider>
     );
   }
@@ -656,6 +658,106 @@ describe("RuntimeSelector needs-auth provider", () => {
     await user.click(row("gpt-a"));
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+describe("RuntimeSelector provider tooltips", () => {
+  it("Should show the provider name on hover and keyboard focus without a native title", async () => {
+    const user = userEvent.setup();
+    renderSelector({
+      value: { provider: "codex", model: "", reasoning_effort: "" },
+      providers: [codexProvider, claudeProvider],
+      models: [model("gpt-a")],
+    });
+
+    await openSelector(user);
+    const providerChip = screen.getByRole("radio", { name: "Codex" });
+    expect(providerChip).not.toHaveAttribute("title");
+
+    await user.hover(providerChip);
+    expect(
+      await screen.findByText("Codex", { selector: '[data-slot="tooltip-content"]' })
+    ).toBeInTheDocument();
+
+    await user.unhover(providerChip);
+    act(() => providerChip.focus());
+    expect(
+      await screen.findByText("Codex", { selector: '[data-slot="tooltip-content"]' })
+    ).toBeInTheDocument();
+  });
+
+  it("Should preserve the needs-sign-in label in the provider tooltip", async () => {
+    const user = userEvent.setup();
+    const authProvider: RuntimeProviderOption = {
+      ...codexProvider,
+      needs_auth: true,
+    };
+    renderSelector({
+      value: { provider: "codex", model: "", reasoning_effort: "" },
+      providers: [authProvider],
+      models: [
+        model("gpt-a", {
+          availability: "unavailable",
+          disabled: true,
+          disabled_reason: "Sign in",
+        }),
+      ],
+    });
+
+    await openSelector(user);
+    const providerChip = screen.getByRole("radio", { name: "Codex · needs sign in" });
+    expect(providerChip).not.toHaveAttribute("title");
+    await user.hover(providerChip);
+
+    expect(
+      await screen.findByText("Codex · needs sign in", {
+        selector: '[data-slot="tooltip-content"]',
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("Should not show a provider tooltip for disabled chips while searching", async () => {
+    const user = userEvent.setup();
+    renderSelector({
+      value: { provider: "codex", model: "", reasoning_effort: "" },
+      providers: [codexProvider],
+      models: [model("gpt-a")],
+    });
+
+    await openSelector(user);
+    fireEvent.change(screen.getByTestId("runtime-selector-search"), {
+      target: { value: "gpt" },
+    });
+    const providerChip = screen.getByRole("radio", { name: "Codex" });
+    expect(providerChip).toBeDisabled();
+
+    await user.hover(providerChip);
+    expect(
+      screen.queryByText("Codex", { selector: '[data-slot="tooltip-content"]' })
+    ).not.toBeInTheDocument();
+  });
+
+  it("Should show the provider name when a pinned model row glyph is hovered", async () => {
+    const user = userEvent.setup();
+    window.localStorage.setItem(
+      FAVORITES_STORAGE_KEY,
+      JSON.stringify([runtimeModelKey("codex", "gpt-a")])
+    );
+    await hydrateRuntimeFavoritesFromStorage();
+    renderSelector({
+      value: { provider: "", model: "", reasoning_effort: "" },
+      models: [model("gpt-a", { name: "GPT A" })],
+    });
+
+    await openSelector(user);
+    const providerGlyph = row("gpt-a").querySelector<HTMLElement>('[data-kind="codex"]');
+    expect(providerGlyph).not.toBeNull();
+    expect(providerGlyph).not.toHaveAttribute("title");
+
+    await user.hover(providerGlyph!);
+    expect(
+      await screen.findByText("Codex", { selector: '[data-slot="tooltip-content"]' })
+    ).toBeInTheDocument();
   });
 });
 

--- a/web/src/systems/runtime/components/runtime-selector/model-row.tsx
+++ b/web/src/systems/runtime/components/runtime-selector/model-row.tsx
@@ -1,6 +1,13 @@
 import { Brain, Check, Star } from "lucide-react";
 
-import { cn, KindIcon, providerKindIconRegistry } from "@compozy/ui";
+import {
+  cn,
+  KindIcon,
+  providerKindIconRegistry,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@compozy/ui";
 
 import type { RuntimeModelOption } from "./types";
 
@@ -79,13 +86,20 @@ export function ModelRow({
       }}
     >
       {showGlyph ? (
-        <KindIcon
-          kind={iconKind}
-          registry={providerKindIconRegistry}
-          size="sm"
-          tone="default"
-          className="shrink-0"
-        />
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <KindIcon
+                kind={iconKind}
+                registry={providerKindIconRegistry}
+                size="sm"
+                tone="default"
+                className="shrink-0"
+              />
+            }
+          />
+          <TooltipContent>{providerName}</TooltipContent>
+        </Tooltip>
       ) : null}
       <span className="flex min-w-0 flex-1 items-center gap-2">
         <span

--- a/web/src/systems/runtime/components/runtime-selector/provider-chips.tsx
+++ b/web/src/systems/runtime/components/runtime-selector/provider-chips.tsx
@@ -1,7 +1,14 @@
 import { LayoutGrid, Settings, Star } from "lucide-react";
 import { useRef, type KeyboardEvent, type ReactNode } from "react";
 
-import { cn, KindIcon, providerKindIconRegistry } from "@compozy/ui";
+import {
+  cn,
+  KindIcon,
+  providerKindIconRegistry,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@compozy/ui";
 
 import type { RailFilter } from "./use-runtime-selector";
 import type { RuntimeProviderOption } from "./types";
@@ -78,16 +85,22 @@ export function ProviderChips({
     }
   };
 
-  const chipRadio = (target: RailFilter, label: string, content: ReactNode, dim = false) => {
+  const chipRadio = (
+    target: RailFilter,
+    label: string,
+    content: ReactNode,
+    dim = false,
+    tooltipText?: string
+  ) => {
     const active = railFilter === target;
-    return (
+    const chip = (
       <button
         key={target}
         type="button"
         role="radio"
         aria-checked={active}
         aria-label={label}
-        title={label}
+        title={tooltipText ? undefined : label}
         data-rail={target}
         data-active={active}
         data-dim={dim ? "true" : undefined}
@@ -101,6 +114,15 @@ export function ProviderChips({
       >
         {content}
       </button>
+    );
+
+    if (!tooltipText) return chip;
+
+    return (
+      <Tooltip key={target} disabled={searching}>
+        <TooltipTrigger render={chip} />
+        <TooltipContent>{tooltipText}</TooltipContent>
+      </Tooltip>
     );
   };
 
@@ -121,10 +143,11 @@ export function ProviderChips({
         {chipRadio("all", "All models", <LayoutGrid aria-hidden="true" className="size-3.5" />)}
         {chipRadio("fav", "Favorites", <Star aria-hidden="true" className="size-3.5" />)}
         <span aria-hidden="true" className="mx-1 h-3.5 w-px shrink-0 bg-line" />
-        {providers.map(provider =>
-          chipRadio(
+        {providers.map(provider => {
+          const label = provider.needs_auth ? `${provider.name} · needs sign in` : provider.name;
+          return chipRadio(
             provider.id,
-            provider.needs_auth ? `${provider.name} · needs sign in` : provider.name,
+            label,
             <KindIcon
               kind={provider.runtime_provider ?? provider.id}
               registry={providerKindIconRegistry}
@@ -132,9 +155,10 @@ export function ProviderChips({
               tone={railFilter === provider.id ? "default" : "muted"}
               className="size-3.5"
             />,
-            Boolean(provider.needs_auth)
-          )
-        )}
+            Boolean(provider.needs_auth),
+            label
+          );
+        })}
       </div>
       {onOpenSettings ? (
         <button


### PR DESCRIPTION
## Summary

Fixes Linear ENG-143: add shared provider-name tooltips throughout the web runtime selector.

The provider rail and cross-provider model rows now make provider identity discoverable without changing the selector's compact visual layout, radio behavior, or listbox semantics.

## Issue and root cause

Provider chips exposed their accessible name through a native `title` attribute. That browser tooltip was not consistent with the rest of Compozy's UI, was not rendered through the shared portal/stacking behavior, and did not provide the required keyboard-focus path. Provider glyphs on pinned cross-provider model rows had no tooltip at all, so their identity depended on nearby or screen-reader-only context.

## Implementation

- Wrapped provider chips with `Tooltip`, `TooltipTrigger`, and `TooltipContent` from `@compozy/ui`.
- Removed the native `title` from migrated provider chips while preserving their existing `aria-label`, radio role, roving tabindex, and search-disabled behavior.
- Kept the existing truthful needs-auth wording (`Provider · needs sign in`) in both the accessible label and tooltip.
- Wrapped the existing `KindIcon` directly in the model-row tooltip trigger so the row remains a non-focusable `role="option"` and keeps its existing `sr-only` provider text.
- Disabled provider tooltips while search disables the provider radiogroup, avoiding misleading hints on disabled controls.
- Added behavior coverage to the canonical runtime-selector suite for hover, keyboard focus, needs-auth copy, disabled search, native-title removal, and a pinned cross-provider glyph.
- Updated the living QA scenario and targeted run report with live evidence for all of those states.

No production-local `TooltipProvider` was added; the application continues to use the provider mounted in `web/src/main.tsx`.

## Verification

Passing checks:

- `rtk bunx turbo run test --filter=./web --force -- --run src/systems/runtime/components/runtime-selector/__tests__/runtime-selector.test.tsx` — 1 file, 93 tests passed.
- `rtk git diff --check` — clean.
- Isolated browser QA through the Web surface — Codex hover, Codex keyboard focus, Groq needs-sign-in copy, pinned cross-provider glyph hover, and disabled-provider search behavior all passed; `agent-browser errors` was empty.
- QA teardown — `teardown.json` reports `clean: true` with no survivors.
- GPT-5.6-Sol review at high reasoning effort — no actionable production or test findings; QA tracker findings were addressed with a second live walk.

`rtk make gate` was run as requested. Lint and typecheck passed. The full Web test lane also passed the 93 ENG-143 tests, but the gate returned non-zero because two unrelated baseline tests failed: `src/storybook/__tests__/web-storybook-visual-contract.test.ts` timed out at 20 seconds, and `src/systems/os/hooks/__tests__/use-window-manager-stream.test.tsx` expected `workspace:home` but received `null`. The visual-contract timeout was reproduced in an isolated Turbo run; neither file is changed here. The repository-wide `make verify`/`make gate-full` commands were intentionally not run per task scope and remain CI responsibilities.

## Risks and mitigations

- Tooltip rendering uses the existing portal and `z-50` shared primitive, so it remains above the selector popup without introducing a new stacking context.
- Provider chips remain the same buttons and keep their radio/roving-focus contract; only their explanation surface changed.
- The model glyph remains a non-focusable child of the listbox option to avoid nested focusable controls. Its existing screen-reader provider name remains in place, and pointer hover now adds the visual tooltip.
- No runtime/API/storage/config behavior changed.

## Compozy Impact Audit

- **Native tools:** no impact — no `compozy__*` tool IDs, toolsets, descriptors, schemas, digests, capability gates, diagnostics, or CLI/API fallbacks changed.
- **Extensibility and hooks:** no impact — checked extensions, hooks, skills/capabilities, tools/resources, registries, bridge SDKs, MCP sidecars, and `config.toml`; this is a web-only presentation change using an existing UI primitive.
- **Workspace data isolation:** no impact — no global, workspace, session, or agent data, cache, SSE/event, route, CLI, HTTP, UDS, or store ownership changed.
- **Official Compozy skill:** no impact — `skills/compozy/` does not describe provider-selector tooltip behavior or any changed public capability/tool/CLI path.

## QA tracker impact

`docs/qa/scenarios/ET-web-runtime-selector-minimal-slider.md` is settled as `qa_status: pass`. The durable report is `docs/qa/reports/2026-08-24-eng-143-runtime-selector.md`; the isolated evidence bundle and clean teardown are recorded there.

## Follow-up

CI should run the repository-wide verification checks and investigate the two unrelated baseline test failures noted above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider-name tooltips to runtime provider chips and model rows.
  * Tooltips are available on hover and keyboard focus for improved accessibility.
  * Tooltips preserve important provider status details, including “Needs sign in.”
* **Accessibility**
  * Improved provider identification without relying on native browser title popups.
  * Disabled provider chips do not display tooltips while searching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->