### PR TITLE
feat: group session tool calls

### DIFF
--- a/docs/qa/reports/2026-08-24-eng-135-session-groups.md
+++ b/docs/qa/reports/2026-08-24-eng-135-session-groups.md
@@ -64,7 +64,7 @@ None.
 
 ## Focused Verification
 
-- `bunx turbo run test --filter=./web -- --run src/components/assistant-ui/__tests__/session-timeline.logic.test.ts src/components/assistant-ui/__tests__/timeline-scroll-anchoring.test.ts src/components/assistant-ui/__tests__/session-thread.test.tsx` — PASS (130 tests).
+- `bunx turbo run test --filter=./web --force -- --run src/components/assistant-ui/__tests__/session-timeline.logic.test.ts src/components/assistant-ui/__tests__/timeline-scroll-anchoring.test.ts src/components/assistant-ui/__tests__/session-thread.test.tsx` — PASS (131 tests after the review remediation).
 - `bunx turbo run typecheck --filter=./web` — PASS.
 - Targeted `oxfmt --check` and `oxlint --deny-warnings` — PASS (0 warnings, 0 errors).
 - First `make gate` — FAIL in the unrelated `use-window-manager-stream.test.tsx` test (`expected null to be "workspace:home"`); 713/714 web test files passed.

--- a/docs/qa/reports/2026-08-24-eng-135-session-groups.md
+++ b/docs/qa/reports/2026-08-24-eng-135-session-groups.md
@@ -1,0 +1,79 @@
+# QA Run Report — 2026-08-24 — ENG-135 session groups
+
+- **Scope:** Sessions timeline grouped tool calls, live tail disclosure, stable expansion identity, and disclosure accessibility.
+- **Cadence tier:** targeted
+- **Build:** working tree for ENG-135 · **Environment:** isolated web lab; daemon seed blocked before transcript access
+- **Started:** 2026-08-25T00:21:22Z · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Théo | Existing calm-transcript charter | desktop / wifi-fast / en-US | CH-session-calm-transcript |
+
+## Flows in Scope
+
+- `J-14` — Read a finished transcript and audit grouped work (`../journeys/J-14-read-a-finished-transcript.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-session-calm-transcript | J-14 / ET-web-session-transcript-calm-grammar | Théo | Feature Tour | Blocked (needs human verify) | Isolated daemon seed fails at `internal/demoseed/seed.go:79` because `GlobalDB.ListPresets` is unavailable; screenshot is in the lab evidence path below. | |
+
+## Session Debriefs
+
+### CH-session-calm-transcript — Théo
+
+- **Ran:** 2026-08-25T00:21:22Z → 2026-08-25T00:25:00Z (box respected: yes)
+- **Findings:** The web shell opened, but setup prevented entry to a finished session. The daemon seed compile error is outside ENG-135 and was not changed.
+- **Bugs filed/updated:** none; this is a precondition/tooling blocker, not a transcript behavior finding.
+- **Scenarios settled:** `ET-web-session-transcript-calm-grammar` → `blocked-verify`
+- **Paper cuts:** none assessed because the transcript was unreachable.
+- **Surprises:** the isolated seed path fails before daemon startup with an unavailable `GlobalDB.ListPresets` method.
+- **Suggested next charter:** re-run this same charter after the seed/compiler blocker is repaired.
+
+## What Was Fixed
+
+- Settled consecutive tool runs now render truthful semantic summaries while preserving
+  failures as individual rows and keeping the live tail within the existing four-row budget.
+- Local work-group anchors survive streaming re-derivation, reorder, duplicate lifecycle
+  events, lower-sorting arrivals, and live-to-settled failure splits.
+- Summary, live-tail, turn-fold, and changed-file disclosures expose stable ARIA targets and
+  keep hidden detail containers out of the layout until expanded.
+
+## Paper Cuts
+
+None assessed.
+
+## Runtime Errors Observed
+
+- `db.ListPresets undefined (type *globaldb.GlobalDB has no field or method ListPresets)` — isolated `go run ./scripts/demo-seed`; retained as a blocker for a future QA pass, not filed against ENG-135.
+
+## Human Verifications Needed
+
+- [ ] Repair or provide the isolated daemon seed path, then walk `CH-session-calm-transcript` from the finished-session entry point and verify grouping, failures, live tail, keyboard disclosure, refresh, and anchor preservation.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- The focused web contract is covered by the canonical unit/component suites, but a production-parity transcript walk depends on the daemon seed compiling.
+
+## Focused Verification
+
+- `bunx turbo run test --filter=./web -- --run src/components/assistant-ui/__tests__/session-timeline.logic.test.ts src/components/assistant-ui/__tests__/timeline-scroll-anchoring.test.ts src/components/assistant-ui/__tests__/session-thread.test.tsx` — PASS (130 tests).
+- `bunx turbo run typecheck --filter=./web` — PASS.
+- Targeted `oxfmt --check` and `oxlint --deny-warnings` — PASS (0 warnings, 0 errors).
+- First `make gate` — FAIL in the unrelated `use-window-manager-stream.test.tsx` test (`expected null to be "workspace:home"`); 713/714 web test files passed.
+- Re-running that exact test through Turbo reproduced the same failure (10/11 tests passed); no out-of-scope changes were made.
+- Second `make gate` — FAIL in the unrelated `web-storybook-visual-contract.test.ts` test after its 20s timeout; lint, typecheck, and codegen passed in that run.
+
+## Final Status
+
+- **Exit gate:** `make gate` was run twice; both runs were blocked by unrelated web tests recorded above. Full `make verify`/`make gate-full` was not run by task instruction and is intentionally deferred to CI.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 0/1 journeys walked; the only journey is explicitly blocked by the isolated daemon seed/compiler precondition.
+- **Verdict:** ready with blocked items — merge the implementation only with the transcript QA re-walk scheduled after the seed blocker and unrelated local gate failures are repaired or cleared in CI.

--- a/docs/qa/scenarios/ET-web-session-transcript-calm-grammar.md
+++ b/docs/qa/scenarios/ET-web-session-transcript-calm-grammar.md
@@ -6,7 +6,7 @@ persona: Théo
 journey: J-14
 expected: Settled tool runs rest as one semantic summary line ("Ran N commands · Edited N files", distinct-file counts) that expands to plain 24px tool rows; the live tail shows the last 4 calls behind a "+N previous tool calls" toggle; failed calls stay individually visible and collapsed with the red × glyph and error-first-line preview (row text never turns red, success check is grey); settled turns fold behind "Worked for Ns" (the only border), interrupted turns never fold; normal queue, steer, interrupt, and dropped-input lifecycle markers do not render as warning noise; the active turn has one working row immediately above the composer; runtime events render as calm one-line markers, never tinted Alert cards; the user message, TodoWrite plan, and changed-file roll-up retain their compact semantic treatments.
 entry_points: web session window transcript; session transcript REST + SSE
-qa_status: skipped
+qa_status: blocked-verify
 bug_ids: BUG-20260803-prompt-cancel-warning-noise
 fix_status: fixed
 retest_status: pass
@@ -46,3 +46,5 @@ QA pass 2026-08-03: lifecycle markers stayed durable but invisible as warning no
 QA impact 2026-08-03 (CodeRabbit remediation): reset after a live steer/interrupt walk exposed the singular `transcript_marker.prompt_cancel` as duplicate warning noise.
 
 QA pass 2026-08-03 (CodeRabbit remediation): after the canonical lifecycle filter fix, a fresh load rendered no prompt-cancel warning while preserving the settled replacement conversation and one active-turn Working row.
+
+QA blocked 2026-08-25 (ENG-135): the isolated web shell reached setup, but the transcript journey could not be seeded because `internal/demoseed/seed.go:79` references the unavailable `GlobalDB.ListPresets` method. Focused UI tests passed; real-user transcript verification remains pending until the daemon seed compiles.

--- a/web/src/components/assistant-ui/__tests__/session-thread.test.tsx
+++ b/web/src/components/assistant-ui/__tests__/session-thread.test.tsx
@@ -1157,13 +1157,20 @@ describe("SessionThread transcript states", () => {
 
     const toggle = screen.getByRole("button", { name: /Read 8 files/ });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
+    const detailsId = toggle.getAttribute("aria-controls");
+    expect(detailsId).toBeTruthy();
+    const details = document.getElementById(detailsId ?? "");
+    expect(details).toBeInTheDocument();
+    expect(details).toHaveAttribute("hidden");
     await user.click(toggle);
 
     expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(details).not.toHaveAttribute("hidden");
     expect(await screen.findByText(/\/tmp\/file-1\.ts/)).toBeInTheDocument();
     expect(screen.getAllByTestId("tool-call-row")).toHaveLength(8);
 
-    await user.click(toggle);
+    toggle.focus();
+    await user.keyboard("{Enter}");
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     expect(screen.queryAllByTestId("tool-call-row")).toHaveLength(0);
     expect(screen.queryByText(/\/tmp\/file-1\.ts/)).not.toBeInTheDocument();
@@ -1466,7 +1473,7 @@ describe("SessionThread transcript states", () => {
     expect(within(rollup).getByText("Edited 2 files")).toBeInTheDocument();
     const toggle = within(rollup).getByRole("button", { name: /Edited 2 files/ });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
-    expect(screen.queryByTestId("changed-files-list")).not.toBeInTheDocument();
+    expect(screen.getByTestId("changed-files-list")).toHaveAttribute("hidden");
 
     await user.click(toggle);
 
@@ -1757,6 +1764,48 @@ describe("SessionThread transcript states", () => {
     expect(timer.textContent).toMatch(/^\d+s$/);
   });
 
+  it("Should keep a settled tool tail live when the message id differs from its part turn id", async () => {
+    const transcript = [
+      {
+        id: "assistant-live-tools",
+        role: "assistant",
+        status: { type: "running" },
+        parts: [
+          {
+            type: "tool-Read",
+            toolCallId: "live-read-1",
+            state: "output-available",
+            turn_id: "turn-live-tools",
+            timestamp: "2026-07-07T12:00:00Z",
+            input: { file_path: "/tmp/live-1.ts" },
+            output: { type: "tool_result", title: "Read", raw: { content: "one" } },
+          },
+          {
+            type: "tool-Read",
+            toolCallId: "live-read-2",
+            state: "output-available",
+            turn_id: "turn-live-tools",
+            timestamp: "2026-07-07T12:00:01Z",
+            input: { file_path: "/tmp/live-2.ts" },
+            output: { type: "tool_result", title: "Read", raw: { content: "two" } },
+          },
+        ] as unknown as SessionMessage["parts"],
+      } as SessionMessage,
+    ];
+
+    renderThreadState({
+      status: "success",
+      messages: toReadonlyThreadMessages(transcript),
+      isSessionRunning: true,
+    });
+
+    const workRow = await screen.findByTestId("work-row");
+    expect(workRow).toBeInTheDocument();
+    expect(workRow.querySelectorAll('[data-testid="tool-call-row"]')).toHaveLength(2);
+    expect(screen.queryByTestId("work-summary-label")).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("session-working-row")).toHaveLength(1);
+  });
+
   it("Should degrade the working row to a static label under prefers-reduced-motion with no animation classes", async () => {
     const originalMatchMedia = window.matchMedia;
     window.matchMedia = ((query: string) => ({
@@ -1944,6 +1993,73 @@ describe("SessionThread transcript states", () => {
 
     expect(await screen.findByText(/\/tmp\/anchor-1\.ts/)).toBeInTheDocument();
     expect(viewport.scrollTop).toBe(300);
+  });
+
+  it("Should preserve a work disclosure node and focus when a lower-sorting call arrives", async () => {
+    const user = userEvent.setup();
+    const queryClient = createQueryClient();
+    const toolPart = (toolCallId: string, index: number) => ({
+      type: "tool-Read",
+      toolCallId,
+      state: "output-available",
+      turn_id: "turn-anchor-stable",
+      timestamp: `2026-07-07T12:00:0${index}Z`,
+      input: { file_path: `/tmp/stable-${toolCallId}.ts` },
+      output: { type: "tool_result", title: "Read", raw: { content: toolCallId } },
+    });
+    const initialMessages = toReadonlyThreadMessages([
+      {
+        id: "assistant-anchor-stable",
+        role: "assistant",
+        parts: ["b", "c", "d", "e", "f"].map((id, index) => toolPart(id, index)),
+      } as SessionMessage,
+    ]);
+    const grownMessages = toReadonlyThreadMessages([
+      {
+        id: "assistant-anchor-stable",
+        role: "assistant",
+        parts: ["a", "b", "c", "d", "e", "f"].map((id, index) => toolPart(id, index)),
+      } as SessionMessage,
+    ]);
+    const tree = (messages: readonly ThreadMessage[]) => (
+      <QueryClientProvider client={queryClient}>
+        <SessionChatRuntimeProvider
+          sessionId={primarySessionFixture.id}
+          workspaceId={fixtureWorkspaceId()}
+        >
+          <SessionTranscriptThreadProvider
+            messages={messages}
+            status="success"
+            error={null}
+            retry={() => {}}
+          >
+            <SessionThread
+              sessionId={primarySessionFixture.id}
+              agentName={primarySessionFixture.agent_name}
+              canPrompt
+              onCancelPrompt={() => {}}
+              isSessionRunning={false}
+            />
+          </SessionTranscriptThreadProvider>
+        </SessionChatRuntimeProvider>
+      </QueryClientProvider>
+    );
+
+    const view = render(tree(initialMessages));
+    const initialButton = await screen.findByRole("button", { name: "Read 5 files" });
+    initialButton.focus();
+    await user.click(initialButton);
+    expect(initialButton).toHaveAttribute("aria-expanded", "true");
+
+    view.rerender(tree(grownMessages));
+
+    const grownButton = await screen.findByRole("button", { name: "Read 6 files" });
+    expect(grownButton).toBe(initialButton);
+    expect(grownButton).toHaveAttribute("aria-expanded", "true");
+    grownButton.focus();
+    await user.keyboard("{Enter}");
+    expect(grownButton).toHaveAttribute("aria-expanded", "false");
+    expect(document.activeElement).toBe(grownButton);
   });
 });
 

--- a/web/src/components/assistant-ui/__tests__/session-timeline.logic.test.ts
+++ b/web/src/components/assistant-ui/__tests__/session-timeline.logic.test.ts
@@ -186,6 +186,42 @@ describe("session timeline derivation", () => {
     expect(failedRow.summary).toBeNull();
   });
 
+  it("Should avoid identity collisions when an expanded run splits after a lower-sorting call", () => {
+    const historicalGroupId = "work:turn-1:tool-call-4";
+    const streamingParts = [
+      tool(4, { status: "running", result: undefined }),
+      tool(5, { status: "running", result: undefined }),
+    ];
+    const expandedRows = deriveSessionRows(streamingParts, {
+      activeTurnId: "turn-1",
+      expandedWorkGroupIds: new Set([historicalGroupId]),
+    });
+    const expandedWork = expandedRows.find(row => row.kind === "work");
+    if (expandedWork?.kind !== "work") throw new Error("expected expanded work row");
+    expect(expandedWork.groupId).toBe(historicalGroupId);
+
+    const observedAnchors = new Map([
+      [
+        historicalGroupId,
+        {
+          groupId: historicalGroupId,
+          turnId: "turn-1",
+          anchorToolCallId: "tool-call-1",
+        },
+      ],
+    ]);
+    const settledRows = deriveSessionRows(
+      [tool(1), tool(4, { isError: true, result: undefined }), tool(5)],
+      { workGroupAnchors: observedAnchors }
+    );
+    const workRows = settledRows.filter(row => row.kind === "work");
+
+    expect(workRows).toHaveLength(3);
+    expect(new Set(workRows.map(row => row.groupId)).size).toBe(workRows.length);
+    expect(workRows[0]?.groupId).toBe(historicalGroupId);
+    expect(workRows[1]?.groupId).not.toBe(historicalGroupId);
+  });
+
   it("Should break the cluster into two runs when text and reasoning interleave", () => {
     const parts: SessionTimelinePart[] = [
       tool(1),

--- a/web/src/components/assistant-ui/__tests__/session-timeline.logic.test.ts
+++ b/web/src/components/assistant-ui/__tests__/session-timeline.logic.test.ts
@@ -49,7 +49,7 @@ describe("session timeline derivation", () => {
   });
 
   it("Should mark the summary row expanded once the work group is toggled open", () => {
-    const groupId = "work:turn-1:tool-1";
+    const groupId = "work:turn-1:tool-call-1";
     const rows = deriveSessionRows(
       Array.from({ length: 8 }, (_, index) => tool(index + 1)),
       { expandedWorkGroupIds: new Set([groupId]) }
@@ -61,6 +61,129 @@ describe("session timeline derivation", () => {
     expect(workRow.expanded).toBe(true);
     expect(workRow.summary).not.toBeNull();
     expect(visibleWorkEntries(workRow)).toHaveLength(8);
+  });
+
+  it("Should keep a work disclosure expanded when the rendered part id is replaced", () => {
+    const initialParts = [...Array.from({ length: 4 }, (_, index) => tool(index + 1)), tool(5)];
+    const groupId = "work:turn-1:tool-call-1";
+    const initialRows = deriveSessionRows(initialParts, {
+      expandedWorkGroupIds: new Set([groupId]),
+    });
+
+    const rederivedParts = initialParts.map((part, index) => ({
+      ...part,
+      id: `replacement-${index + 1}`,
+    }));
+    const rederivedRows = deriveSessionRows(rederivedParts, {
+      expandedWorkGroupIds: new Set([groupId]),
+    });
+
+    const initialWork = initialRows.find(row => row.kind === "work");
+    const rederivedWork = rederivedRows.find(row => row.kind === "work");
+    if (initialWork?.kind !== "work" || rederivedWork?.kind !== "work") {
+      throw new Error("expected work rows");
+    }
+    expect(initialWork.groupId).toBe(groupId);
+    expect(rederivedWork.groupId).toBe(groupId);
+    expect(rederivedWork.expanded).toBe(true);
+    expect(visibleWorkEntries(rederivedWork)).toHaveLength(5);
+  });
+
+  it("Should keep a work disclosure stable when calls reorder or duplicate events settle", () => {
+    const initialParts = Array.from({ length: 5 }, (_, index) => tool(index + 1));
+    const groupId = "work:turn-1:tool-call-1";
+    const initialRows = deriveSessionRows(initialParts, {
+      expandedWorkGroupIds: new Set([groupId]),
+    });
+
+    const reorderedRows = deriveSessionRows(
+      [initialParts[1]!, initialParts[0]!, ...initialParts.slice(2)],
+      { expandedWorkGroupIds: new Set([groupId]) }
+    );
+    const duplicateRemovedRows = deriveSessionRows(
+      [
+        initialParts[0]!,
+        { ...initialParts[0]!, id: "duplicate-rendered-tool-1" },
+        ...initialParts.slice(1),
+      ],
+      { expandedWorkGroupIds: new Set([groupId]) }
+    );
+
+    for (const rows of [initialRows, reorderedRows, duplicateRemovedRows]) {
+      const workRow = rows.find(row => row.kind === "work");
+      if (workRow?.kind !== "work") throw new Error("expected work row");
+      expect(workRow.groupId).toBe(groupId);
+      expect(workRow.expanded).toBe(true);
+    }
+  });
+
+  it("Should retain a group's key when a lower-sorting call arrives and the group closes", () => {
+    const initialParts = Array.from({ length: 5 }, (_, index) => tool(index + 1));
+    const groupId = "work:turn-1:tool-call-1";
+    const anchors = new Map([
+      [
+        groupId,
+        {
+          groupId,
+          turnId: "turn-1",
+          anchorToolCallId: "tool-call-1",
+        },
+      ],
+    ]);
+
+    const initialRows = deriveSessionRows(initialParts, {
+      expandedWorkGroupIds: new Set([groupId]),
+      workGroupAnchors: anchors,
+    });
+    const grownParts = [tool(0), ...initialParts];
+    const grownRows = deriveSessionRows(grownParts, {
+      expandedWorkGroupIds: new Set([groupId]),
+      workGroupAnchors: anchors,
+    });
+    const closedRows = deriveSessionRows(grownParts, { workGroupAnchors: anchors });
+
+    for (const rows of [initialRows, grownRows, closedRows]) {
+      const workRow = rows.find(row => row.kind === "work");
+      if (workRow?.kind !== "work") throw new Error("expected work row");
+      expect(workRow.groupId).toBe(groupId);
+    }
+    const grownWork = grownRows.find(row => row.kind === "work");
+    const closedWork = closedRows.find(row => row.kind === "work");
+    if (grownWork?.kind !== "work" || closedWork?.kind !== "work") {
+      throw new Error("expected grown and closed work rows");
+    }
+    expect(grownWork.expanded).toBe(true);
+    expect(closedWork.expanded).toBe(false);
+  });
+
+  it("Should give settled success and failure chunks distinct group identities", () => {
+    const liveParts = Array.from({ length: 5 }, (_, index) =>
+      tool(index + 1, { status: "running", result: undefined })
+    );
+    const liveRows = deriveSessionRows(liveParts, { activeTurnId: "turn-1" });
+    const liveWork = liveRows.find(row => row.kind === "work");
+    if (liveWork?.kind !== "work") throw new Error("expected live work row");
+
+    const anchors = new Map([
+      [
+        liveWork.groupId,
+        { groupId: liveWork.groupId, turnId: "turn-1", anchorToolCallId: "tool-call-1" },
+      ],
+    ]);
+    const settledParts = liveParts.map((part, index) =>
+      index === 2
+        ? { ...part, status: "settled" as const, isError: true, result: undefined }
+        : { ...part, status: "settled" as const, result: { content: `file-${index + 1}` } }
+    );
+    const settledRows = deriveSessionRows(settledParts, { workGroupAnchors: anchors });
+    const workRows = settledRows.filter(row => row.kind === "work");
+
+    expect(workRows).toHaveLength(3);
+    expect(new Set(workRows.map(row => row.groupId)).size).toBe(3);
+    const failedRow = workRows.find(row => row.entries[0]?.isError === true);
+    if (failedRow?.kind !== "work") throw new Error("expected failed work row");
+    expect(failedRow.entries).toHaveLength(1);
+    expect(failedRow.summary).toBeNull();
   });
 
   it("Should break the cluster into two runs when text and reasoning interleave", () => {

--- a/web/src/components/assistant-ui/hooks/use-assistant-message-timeline.ts
+++ b/web/src/components/assistant-ui/hooks/use-assistant-message-timeline.ts
@@ -1,5 +1,6 @@
 import { useAuiState } from "@assistant-ui/react";
 import { useSelector, useStore } from "@xstate/store-react";
+import { useLayoutEffect } from "react";
 
 import {
   deriveSessionRows,
@@ -7,6 +8,7 @@ import {
   type SessionRow,
   type SessionTimelinePart,
   type SessionTimelineWorkingPart,
+  type SessionWorkGroupAnchor,
 } from "../session-timeline.logic";
 import { isRecord, stringField, toTimelineParts } from "../timeline-message-parts";
 import { timelineRowLogic } from "./use-timeline-row-context";
@@ -25,6 +27,17 @@ function partIsLive(part: SessionTimelinePart): boolean {
     return part.status === "running";
   }
   return isStreamingState(part.state);
+}
+
+function messageTurnId(
+  message: { id?: string },
+  parts: readonly SessionTimelinePart[]
+): string | undefined {
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const turnId = parts[index]?.turnId;
+    if (turnId) return turnId;
+  }
+  return typeof message.id === "string" && message.id.length > 0 ? message.id : undefined;
 }
 
 // The turn start anchors the "Working for Xs" timer. Parts carry ISO timestamps
@@ -51,10 +64,10 @@ function deriveWorkingPart(
   if (!messageStatusIsRunning(message) && !parts.some(partIsLive)) {
     return null;
   }
-  const turnId = typeof message.id === "string" && message.id.length > 0 ? message.id : undefined;
+  const turnId = messageTurnId(message, parts);
   return {
     kind: "working",
-    id: `${message.id ?? "message"}:working`,
+    id: `${turnId ?? message.id ?? "message"}:working`,
     turnId,
     startedAt: earliestTimestampMs(parts),
   };
@@ -129,6 +142,38 @@ function goalPromptMeta(content: unknown): GoalPromptMeta | null {
   return null;
 }
 
+function canonicalToolCallId(row: Extract<SessionRow, { kind: "work" }>): string {
+  let anchor = row.entries[0]?.toolCallId.trim() || row.entries[0]?.id || row.id;
+  for (const tool of row.entries.slice(1)) {
+    const identity = tool.toolCallId.trim() || tool.id;
+    if (identity < anchor) anchor = identity;
+  }
+  return anchor;
+}
+
+function workGroupAnchorsFromRows(
+  rows: readonly SessionRow[],
+  previousAnchors: ReadonlyMap<string, SessionWorkGroupAnchor>
+): SessionWorkGroupAnchor[] {
+  const anchors = new Map<string, SessionWorkGroupAnchor>();
+  const visit = (nestedRows: readonly SessionRow[]) => {
+    for (const row of nestedRows) {
+      if (row.kind === "work") {
+        const previous = previousAnchors.get(row.groupId) ?? anchors.get(row.groupId);
+        anchors.set(row.groupId, {
+          groupId: row.groupId,
+          turnId: row.turnId,
+          anchorToolCallId: previous?.anchorToolCallId ?? canonicalToolCallId(row),
+        });
+        continue;
+      }
+      if (row.kind === "turn-fold") visit(row.rows);
+    }
+  };
+  visit(rows);
+  return [...anchors.values()];
+}
+
 export function useAssistantMessageTimeline() {
   const message = useAuiState(
     state => state.message as { id?: string; content?: unknown; status?: unknown }
@@ -147,12 +192,21 @@ export function useAssistantMessageTimeline() {
     timelineStore,
     state => state.context.expandedChangedFiles
   );
+  const workGroupAnchors = useSelector(timelineStore, state => state.context.workGroupAnchors);
   const rows = deriveSessionRows(parts, {
+    activeTurnId: workingPart?.turnId,
     foldSettledTurns: true,
     interruptedTurnIds: interruptedTurns,
     expandedWorkGroupIds: expandedWorkGroups,
+    workGroupAnchors,
     expandedChangedFilesIds: expandedChangedFiles,
   });
+  const observedWorkGroupAnchors = workGroupAnchorsFromRows(rows, workGroupAnchors);
+  useLayoutEffect(() => {
+    for (const anchor of observedWorkGroupAnchors) {
+      timelineStore.trigger.workGroupAnchorObserved(anchor);
+    }
+  }, [observedWorkGroupAnchors, timelineStore]);
 
   return {
     rows,

--- a/web/src/components/assistant-ui/hooks/use-timeline-row-context.ts
+++ b/web/src/components/assistant-ui/hooks/use-timeline-row-context.ts
@@ -1,5 +1,6 @@
 import { createContext, use } from "react";
 import { createStoreLogic } from "@xstate/store";
+import type { SessionWorkGroupAnchor } from "../session-timeline.logic";
 
 export type TimelineExpansion = "work-group" | "turn" | "changed-files";
 
@@ -13,6 +14,7 @@ function toggled(ids: ReadonlySet<string>, id: string): Set<string> {
 export const timelineRowLogic = createStoreLogic({
   context: (_input: undefined) => ({
     expandedWorkGroups: new Set<string>(),
+    workGroupAnchors: new Map<string, SessionWorkGroupAnchor>(),
     expandedTurns: new Set<string>(),
     expandedChangedFiles: new Set<string>(),
   }),
@@ -21,6 +23,17 @@ export const timelineRowLogic = createStoreLogic({
       ...context,
       expandedWorkGroups: toggled(context.expandedWorkGroups, event.id),
     }),
+    workGroupAnchorObserved: (context, event: SessionWorkGroupAnchor) => {
+      const previous = context.workGroupAnchors.get(event.groupId);
+      const sameAnchor =
+        previous !== undefined &&
+        previous.turnId === event.turnId &&
+        previous.anchorToolCallId === event.anchorToolCallId;
+      if (sameAnchor) return context;
+      const workGroupAnchors = new Map(context.workGroupAnchors);
+      workGroupAnchors.set(event.groupId, event);
+      return { ...context, workGroupAnchors };
+    },
     turnExpansionToggled: (context, event: { id: string }) => ({
       ...context,
       expandedTurns: toggled(context.expandedTurns, event.id),

--- a/web/src/components/assistant-ui/session-changed-files-row.tsx
+++ b/web/src/components/assistant-ui/session-changed-files-row.tsx
@@ -61,11 +61,13 @@ export function SessionChangedFilesRowView({
   const fileCount = row.files.length;
   const visibleFiles = row.files.slice(0, CHANGED_FILES_VISIBLE_CAP);
   const hiddenCount = fileCount - visibleFiles.length;
+  const detailsId = `${row.id}:entries`;
   return (
     <div data-testid="changed-files-row" data-expanded={String(row.expanded)} className="min-w-0">
       <TranscriptDisclosure
         expanded={row.expanded}
         onToggle={onToggle}
+        aria-controls={detailsId}
         icon={
           <FileText aria-hidden="true" className="size-3 shrink-0 text-subtle" strokeWidth={1.8} />
         }
@@ -76,21 +78,31 @@ export function SessionChangedFilesRowView({
         }
         trailing={<DiffStat additions={row.additions} deletions={row.deletions} />}
       />
-      {row.expanded ? (
-        <div
-          data-testid="changed-files-list"
-          className="mt-0.5 mb-0.5 ml-transcript-detail-indent flex flex-col gap-px border-l border-line pl-transcript-detail-gutter"
-        >
-          {visibleFiles.map(file => (
-            <ChangedFileRow key={file.path} file={file} />
-          ))}
-          {hiddenCount > 0 ? (
-            <span className="min-h-transcript-row content-center text-transcript-meta text-subtle">
-              +{hiddenCount} more
-            </span>
-          ) : null}
-        </div>
-      ) : null}
+      <div
+        id={detailsId}
+        data-testid="changed-files-list"
+        hidden={!row.expanded}
+        aria-hidden={!row.expanded}
+        inert={!row.expanded}
+        className={
+          row.expanded
+            ? "mt-0.5 mb-0.5 ml-transcript-detail-indent flex flex-col gap-px border-l border-line pl-transcript-detail-gutter"
+            : undefined
+        }
+      >
+        {row.expanded ? (
+          <>
+            {visibleFiles.map(file => (
+              <ChangedFileRow key={file.path} file={file} />
+            ))}
+            {hiddenCount > 0 ? (
+              <span className="min-h-transcript-row content-center text-transcript-meta text-subtle">
+                +{hiddenCount} more
+              </span>
+            ) : null}
+          </>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/web/src/components/assistant-ui/session-timeline-group-identity.ts
+++ b/web/src/components/assistant-ui/session-timeline-group-identity.ts
@@ -10,6 +10,7 @@ export interface SessionWorkGroupAnchor {
 interface WorkGroupIdentityOptions {
   expandedWorkGroupIds?: ReadonlySet<string>;
   workGroupAnchors?: ReadonlyMap<string, SessionWorkGroupAnchor>;
+  usedGroupIds?: ReadonlySet<string>;
 }
 
 export function workGroupId(
@@ -22,7 +23,10 @@ export function workGroupId(
   const identitySet = new Set(identities);
 
   const retainedAnchor = [...(options.workGroupAnchors?.values() ?? [])].find(
-    anchor => anchor.turnId === first.turnId && identitySet.has(anchor.anchorToolCallId)
+    anchor =>
+      anchor.turnId === first.turnId &&
+      identitySet.has(anchor.anchorToolCallId) &&
+      !options.usedGroupIds?.has(anchor.groupId)
   );
   if (retainedAnchor) return retainedAnchor.groupId;
 
@@ -37,7 +41,17 @@ export function workGroupId(
     const expandedIdentity = groupId.slice(turnPrefix.length);
     return identitySet.has(expandedIdentity);
   });
-  return expandedGroupId ?? `${turnPrefix}${identity}`;
+  const candidate = expandedGroupId ?? `${turnPrefix}${identity}`;
+  const usedGroupIds = options.usedGroupIds;
+  if (!usedGroupIds || !usedGroupIds.has(candidate)) return candidate;
+
+  let suffix = 2;
+  let uniqueCandidate = `${candidate}:part-${suffix}`;
+  while (usedGroupIds.has(uniqueCandidate)) {
+    suffix += 1;
+    uniqueCandidate = `${candidate}:part-${suffix}`;
+  }
+  return uniqueCandidate;
 }
 
 function compareIdentities(left: string, right: string): number {

--- a/web/src/components/assistant-ui/session-timeline-group-identity.ts
+++ b/web/src/components/assistant-ui/session-timeline-group-identity.ts
@@ -1,0 +1,46 @@
+import type { SessionTimelineToolPart } from "./session-timeline.logic";
+
+/** Local identity retained across streaming re-derivations of one message. */
+export interface SessionWorkGroupAnchor {
+  groupId: string;
+  turnId?: string;
+  anchorToolCallId: string;
+}
+
+interface WorkGroupIdentityOptions {
+  expandedWorkGroupIds?: ReadonlySet<string>;
+  workGroupAnchors?: ReadonlyMap<string, SessionWorkGroupAnchor>;
+}
+
+export function workGroupId(
+  entries: readonly SessionTimelineToolPart[],
+  options: WorkGroupIdentityOptions
+): string {
+  const first = entries[0]!;
+  const turnPrefix = `work:${first.turnId ?? "none"}:`;
+  const identities = entries.map(tool => tool.toolCallId.trim() || tool.id);
+  const identitySet = new Set(identities);
+
+  const retainedAnchor = [...(options.workGroupAnchors?.values() ?? [])].find(
+    anchor => anchor.turnId === first.turnId && identitySet.has(anchor.anchorToolCallId)
+  );
+  if (retainedAnchor) return retainedAnchor.groupId;
+
+  const orderedIdentities = [...new Set(identities)].sort(compareIdentities);
+  const identity = orderedIdentities[0] ?? first.id;
+
+  // A deterministic anchor keeps a reorder from changing the row key. If a
+  // new call sorts before the old anchor, retain the expanded group's existing
+  // id when its logical tool call is still present in this run.
+  const expandedGroupId = [...(options.expandedWorkGroupIds ?? [])].find(groupId => {
+    if (!groupId.startsWith(turnPrefix)) return false;
+    const expandedIdentity = groupId.slice(turnPrefix.length);
+    return identitySet.has(expandedIdentity);
+  });
+  return expandedGroupId ?? `${turnPrefix}${identity}`;
+}
+
+function compareIdentities(left: string, right: string): number {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}

--- a/web/src/components/assistant-ui/session-timeline-render.tsx
+++ b/web/src/components/assistant-ui/session-timeline-render.tsx
@@ -94,12 +94,21 @@ function workToggleLabel(row: SessionWorkToggleRow): string {
 }
 
 // `.tmore` — bare-text overflow toggle above the visible live tail.
-function WorkToggleButton({ row, onToggle }: { row: SessionWorkToggleRow; onToggle: () => void }) {
+function WorkToggleButton({
+  row,
+  onToggle,
+  controlsId,
+}: {
+  row: SessionWorkToggleRow;
+  onToggle: () => void;
+  controlsId: string;
+}) {
   return (
     <button
       type="button"
       data-testid="work-toggle-row"
       aria-expanded={row.expanded}
+      aria-controls={controlsId}
       onClick={onToggle}
       className={cn(
         "ml-transcript-detail-indent inline-flex min-h-transcript-row w-fit items-center gap-1.5 rounded-xs px-1",
@@ -124,6 +133,7 @@ function SessionWorkSummaryRow({
   onToggle: () => void;
 }) {
   const first = row.entries[0];
+  const detailsId = `${row.groupId}:entries`;
   const leadIcon = createElement(
     getToolIcon(resolveRegisteredToolName(first?.toolName ?? "tool"), first?.args),
     { "aria-hidden": true, className: "size-3 shrink-0 text-subtle", strokeWidth: 1.8 }
@@ -133,16 +143,24 @@ function SessionWorkSummaryRow({
       <TranscriptDisclosure
         expanded={row.expanded}
         onToggle={onToggle}
+        aria-controls={detailsId}
         icon={leadIcon}
         label={<span data-testid="work-summary-label">{summary.label}</span>}
       />
-      {row.expanded ? (
-        <div data-testid="work-summary-entries" className="flex min-w-0 flex-col gap-0.5 pt-0.5">
-          {row.entries.map(tool => (
-            <SessionToolCallRow key={tool.id} message={toolMessageFromPart(tool)} turnSettled />
-          ))}
-        </div>
-      ) : null}
+      <div
+        id={detailsId}
+        data-testid="work-summary-entries"
+        hidden={!row.expanded}
+        aria-hidden={!row.expanded}
+        inert={!row.expanded}
+        className={row.expanded ? "flex min-w-0 flex-col gap-0.5 pt-0.5" : undefined}
+      >
+        {row.expanded
+          ? row.entries.map(tool => (
+              <SessionToolCallRow key={tool.id} message={toolMessageFromPart(tool)} turnSettled />
+            ))
+          : null}
+      </div>
     </div>
   );
 }
@@ -159,8 +177,9 @@ function SessionWorkRowView({ row }: { row: SessionWorkRow }) {
     );
   }
   const tools = visibleWorkEntries(row);
+  const detailsId = row.grouped ? `${row.groupId}:entries` : undefined;
   return (
-    <div data-testid="work-row" className="flex min-w-0 flex-col gap-0.5">
+    <div id={detailsId} data-testid="work-row" className="flex min-w-0 flex-col gap-0.5">
       {tools.map(tool => (
         <SessionToolCallRow
           key={tool.id}
@@ -174,9 +193,11 @@ function SessionWorkRowView({ row }: { row: SessionWorkRow }) {
 
 function SessionWorkToggleRowView({ row }: { row: SessionWorkToggleRow }) {
   const store = useTimelineRowContext();
+  const detailsId = `${row.groupId}:entries`;
   return (
     <WorkToggleButton
       row={row}
+      controlsId={detailsId}
       onToggle={() => toggleTimelineExpansion(store, "work-group", row.groupId)}
     />
   );
@@ -198,6 +219,7 @@ function SessionChangedFilesRowContent({ row }: { row: SessionChangedFilesRow })
 function SessionTurnFoldRowView({ row }: { row: SessionTurnFoldRow }) {
   const store = useTimelineRowContext();
   const turnId = row.turnId ?? row.id;
+  const detailsId = `turn-fold:${turnId}:entries`;
   const expanded = useSelector(store, state => state.context.expandedTurns.has(turnId));
   if (row.interrupted) {
     return (
@@ -222,13 +244,20 @@ function SessionTurnFoldRowView({ row }: { row: SessionTurnFoldRow }) {
         data-testid="turn-fold-row"
         expanded={expanded}
         onToggle={() => toggleTimelineExpansion(store, "turn", turnId)}
+        aria-controls={detailsId}
         icon={null}
         label={row.label}
         variant="turn"
       />
-      {expanded ? (
-        <div className="flex min-w-0 flex-col gap-0.5 pt-1">{renderTimelineRows(row.rows)}</div>
-      ) : null}
+      <div
+        id={detailsId}
+        hidden={!expanded}
+        aria-hidden={!expanded}
+        inert={!expanded}
+        className={expanded ? "flex min-w-0 flex-col gap-0.5 pt-1" : undefined}
+      >
+        {expanded ? renderTimelineRows(row.rows) : null}
+      </div>
     </div>
   );
 }

--- a/web/src/components/assistant-ui/session-timeline.logic.ts
+++ b/web/src/components/assistant-ui/session-timeline.logic.ts
@@ -13,6 +13,7 @@
 // `./session-row-equality`; the run summarizer in `./session-timeline-summary`.
 
 import { foldSettledTurns } from "./session-timeline-fold";
+import { workGroupId, type SessionWorkGroupAnchor } from "./session-timeline-group-identity";
 import { markerClusterKey } from "./session-timeline-markers";
 import {
   MIN_COLLAPSIBLE_TOOL_GROUP_SIZE,
@@ -182,10 +183,12 @@ export interface DeriveSessionRowsOptions {
   activeTurnId?: string;
   interruptedTurnIds?: ReadonlySet<string>;
   expandedWorkGroupIds?: ReadonlySet<string>;
+  workGroupAnchors?: ReadonlyMap<string, SessionWorkGroupAnchor>;
   expandedTurnIds?: ReadonlySet<string>;
   expandedChangedFilesIds?: ReadonlySet<string>;
   foldSettledTurns?: boolean;
 }
+export type { SessionWorkGroupAnchor } from "./session-timeline-group-identity";
 
 const ACTIVE_WORK_VISIBLE_LIMIT = 4;
 
@@ -347,10 +350,6 @@ function findLiveTailClusterStart(
   return hasRunning || activeTurn ? (cluster[0]?.id ?? null) : null;
 }
 
-function workGroupId(first: SessionTimelineToolPart): string {
-  return `work:${first.turnId ?? "none"}:${first.id}`;
-}
-
 function workRowsFromCluster(
   tools: SessionTimelineToolPart[],
   options: DeriveSessionRowsOptions,
@@ -369,7 +368,7 @@ function liveWorkRows(
   options: DeriveSessionRowsOptions
 ): SessionRow[] {
   const first = tools[0]!;
-  const groupId = workGroupId(first);
+  const groupId = workGroupId(tools, options);
   const grouped = tools.length > ACTIVE_WORK_VISIBLE_LIMIT;
   const expanded = grouped ? (options.expandedWorkGroupIds?.has(groupId) ?? false) : false;
   const workRow: SessionWorkRow = {
@@ -434,7 +433,7 @@ function settledWorkRow(
   options: DeriveSessionRowsOptions
 ): SessionWorkRow {
   const first = entries[0]!;
-  const groupId = workGroupId(first);
+  const groupId = workGroupId(entries, options);
   return {
     kind: "work",
     id: groupId,

--- a/web/src/components/assistant-ui/session-timeline.logic.ts
+++ b/web/src/components/assistant-ui/session-timeline.logic.ts
@@ -213,6 +213,7 @@ function deriveBaseRows(
   options: DeriveSessionRowsOptions
 ): SessionRow[] {
   const rows: SessionRow[] = [];
+  const usedWorkGroupIds = new Set<string>();
   const liveTailStartId = findLiveTailClusterStart(parts, options.activeTurnId);
   let toolCluster: SessionTimelineToolPart[] = [];
   let reasoningCluster: SessionTimelineReasoningPart[] = [];
@@ -221,7 +222,7 @@ function deriveBaseRows(
 
   const flushToolCluster = () => {
     if (toolCluster.length === 0) return;
-    rows.push(...workRowsFromCluster(toolCluster, options, liveTailStartId));
+    rows.push(...workRowsFromCluster(toolCluster, options, liveTailStartId, usedWorkGroupIds));
     toolCluster = [];
   };
 
@@ -353,22 +354,27 @@ function findLiveTailClusterStart(
 function workRowsFromCluster(
   tools: SessionTimelineToolPart[],
   options: DeriveSessionRowsOptions,
-  liveTailStartId: string | null
+  liveTailStartId: string | null,
+  usedGroupIds: Set<string>
 ): SessionRow[] {
   const first = tools[0];
   if (!first) return [];
   const live = first.id === liveTailStartId || tools.some(tool => tool.status === "running");
-  return live ? liveWorkRows(tools, options) : settledWorkRows(tools, options);
+  return live
+    ? liveWorkRows(tools, options, usedGroupIds)
+    : settledWorkRows(tools, options, usedGroupIds);
 }
 
 // The live tail: one open run, the newest ACTIVE_WORK_VISIBLE_LIMIT rows
 // visible, a "+N previous tool calls" toggle above them when the run overflows.
 function liveWorkRows(
   tools: SessionTimelineToolPart[],
-  options: DeriveSessionRowsOptions
+  options: DeriveSessionRowsOptions,
+  usedGroupIds: Set<string>
 ): SessionRow[] {
   const first = tools[0]!;
-  const groupId = workGroupId(tools, options);
+  const groupId = workGroupId(tools, { ...options, usedGroupIds });
+  usedGroupIds.add(groupId);
   const grouped = tools.length > ACTIVE_WORK_VISIBLE_LIMIT;
   const expanded = grouped ? (options.expandedWorkGroupIds?.has(groupId) ?? false) : false;
   const workRow: SessionWorkRow = {
@@ -406,7 +412,8 @@ function liveWorkRows(
 // between them) stay individually visible — a summary never hides a failure.
 function settledWorkRows(
   tools: SessionTimelineToolPart[],
-  options: DeriveSessionRowsOptions
+  options: DeriveSessionRowsOptions,
+  usedGroupIds: Set<string>
 ): SessionRow[] {
   const chunks: { summarizable: boolean; entries: SessionTimelineToolPart[] }[] = [];
   for (const tool of tools) {
@@ -423,17 +430,19 @@ function settledWorkRows(
       chunk.summarizable && chunk.entries.length >= MIN_COLLAPSIBLE_TOOL_GROUP_SIZE
         ? summarizeToolGroup(chunk.entries)
         : null;
-    return settledWorkRow(chunk.entries, summary, options);
+    const groupId = workGroupId(chunk.entries, { ...options, usedGroupIds });
+    usedGroupIds.add(groupId);
+    return settledWorkRow(chunk.entries, summary, groupId, options);
   });
 }
 
 function settledWorkRow(
   entries: SessionTimelineToolPart[],
   summary: SessionToolGroupSummary | null,
+  groupId: string,
   options: DeriveSessionRowsOptions
 ): SessionWorkRow {
   const first = entries[0]!;
-  const groupId = workGroupId(entries, options);
   return {
     kind: "work",
     id: groupId,


### PR DESCRIPTION
## Summary

Implements Linear issue [ENG-135](https://linear.app/compozy/issue/ENG-135), “Group tool calls (Synara pattern)”, for the web session transcript.

The session timeline now groups consecutive tool calls within a turn while preserving the existing event projection and storage contracts. Ordinary single calls remain ordinary rows, non-tool boundaries split groups, failures stay standalone, and a still-growing trailing group remains visibly open until the turn settles.

## Root cause

The timeline renderer treated every tool-call part as an independent row. That made tool-heavy turns noisy and prevented the transcript from communicating the higher-level work phase. The existing derived-row pipeline also needed a stable identity that survives streaming replacement, retries, deduplication, and arrival-order changes without changing the user’s local disclosure state.

## Implementation

- Added deterministic work-group identity based on the canonical tool-call IDs, with a persisted per-message anchor for groups already rendered during streaming.
- Derived groups from consecutive tool calls in the same turn, splitting at non-tool entries and failed calls.
- Kept the active trailing group open with a four-row visible budget and truthful remaining-count summaries.
- Preserved the existing interrupted-turn expansion behavior and kept settled groups collapsed by default.
- Added stable hidden disclosure targets and `aria-controls` links so keyboard and assistive-technology users can operate summaries before and after expansion.
- Preserved the existing scroll anchoring behavior; grouping does not alter the underlying timeline scroll model.
- Split group identity into its own module so production source files remain below the repository’s 500-line limit.
- Kept the change web-local: no daemon, SQLite, ACP/JSON-RPC, HTTP/SSE, UDS, native-tool, or public API changes.

## Verification

Focused checks completed:

- `bunx turbo run test --filter=./web --force -- --run src/components/assistant-ui/__tests__/session-timeline.logic.test.ts src/components/assistant-ui/__tests__/timeline-scroll-anchoring.test.ts src/components/assistant-ui/__tests__/session-thread.test.tsx`
  - PASS: 3 files, 131 tests (including the review regression).
- `bunx turbo run typecheck --filter=./web`
  - PASS.
- Targeted `oxfmt` and `oxlint` for all changed source and test files
  - PASS with zero warnings/errors.
- `git diff --check`
  - PASS.
- Independent GPT-5.6-Sol review at high reasoning effort
  - No actionable findings after review fixes.
- Greptile P1 review finding
  - Fixed in `f0d07aa2c`: work-group derivation now tracks IDs already assigned within the message, prevents retained-anchor reuse, and disambiguates a colliding fallback with a stable part suffix. The regression is in the canonical timeline logic suite and passes.
- CodeRabbit review artifact
  - `.codex/artifacts/coderabbit/pr-466-review.json` was refreshed repeatedly; no actionable CodeRabbit findings were available because the bot reported `Review limit reached`. A `/review` request was also posted and remained rate-limited.

## Focused gate and QA notes

`make gate` was run twice as required for focused gates. Both runs reached the web lane but were blocked by unrelated existing failures outside this diff:

1. The first run had a single failure in `web/src/systems/os/hooks/__tests__/use-window-manager-stream.test.tsx` (expected `null`, received `workspace:home`); the lane otherwise passed 713/714 files. Re-running the exact test through Turbo reproduced it.
2. The second run passed lint, typecheck, and codegen but timed out in the unrelated Storybook visual-contract test `src/storybook/__tests__/web-storybook-visual-contract.test.ts`.

Per the task instruction, `make verify` and `make gate-full` were not run.

The isolated real-user QA walk was attempted with a fresh QA lab and was torn down cleanly. It is blocked before the transcript can be exercised because the unrelated demo seed does not compile: `internal/demoseed/seed.go:79:33: db.ListPresets undefined`. Evidence and teardown details are recorded in `docs/qa/reports/2026-08-24-eng-135-session-groups.md`.

## CI monitoring

The post-push CI run was monitored through completion:

- Run `32803898802`, attempt 1: web/Desktop/Preflight/Build and race shard 2/2 passed; `Go (format, lint)` hit its fixed 10-minute golangci-lint timeout; race shard 1/2 reported 648 failures across `internal/store/globaldb`.
- The failed jobs were retried once, as `32803898802`, attempt 2. `Go (format, lint)` passed on retry, while race shard 1/2 reproduced the unrelated globaldb failure with 729 failures after 2,922 seconds. All other checks passed.
- No ENG-135 source path appears in either failing job; no out-of-scope daemon or database change was made to silence the external blocker.
- CodeRabbit has no unresolved comments but cannot approve the latest commit because its review limit is exhausted. Greptile's P1 identity-collision finding was fixed and its thread is resolved.

## Risks and follow-up

- The implementation is isolated to the session timeline projection and renderer; the main residual risk is integration behavior under the repository’s existing web gate failures.
- CI should provide the authoritative full-repository validation.
- The local QA scenario remains `blocked-verify` until the unrelated demo-seed compile failure is fixed.

## Compozy Impact Audit

- Native tools: no impact. No `compozy__*` tool IDs, toolsets, descriptors, schemas, digests, risk flags, capability gates, diagnostics, or CLI/API fallbacks changed; only the web session projection and disclosure renderer were checked.
- Extensibility and hooks: no impact. No extensions, hooks, skills/capabilities, tools/resources, registries, bridge SDKs, MCP sidecars, or `config.toml` lifecycle changed; the existing event-to-row path remains the source of truth.
- Workspace data isolation: no impact. Group identity is session-message scoped in the existing local XState timeline store; no global/workspace/session/agent ownership, storage queries, SSE/event propagation, cache keys, or cross-workspace list/read paths changed.
- Official Compozy skill: no impact. No public tool IDs, CLI paths, hook events, capabilities, extension resources, or memory/network/task semantics changed.

Closes ENG-135.
