### PR TITLE
fix: route command palette entities directly

### DIFF
--- a/docs/qa/reports/2026-08-24-eng-131-palette-direct.md
+++ b/docs/qa/reports/2026-08-24-eng-131-palette-direct.md
@@ -1,0 +1,68 @@
+# QA Run Report — 2026-08-24 — ENG-131 command-palette direct entity routes
+
+- **Scope:** Concrete entity rows in the OS command palette now open their detail/action route directly, with workspace ownership preserved.
+- **Cadence tier:** targeted
+- **Build:** `a7a89709d` + ENG-131 working tree · **Environment:** isolated CompozyOS lab, Vite `http://localhost:3031`, daemon `127.0.0.1:60018`
+- **Started:** 2026-08-25T00:47:48Z · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Sol | isolated workspace `ws_8f9af3086c3bf927` | Chromium / local / pt-BR operator environment | web palette walk |
+
+## Flows in Scope
+
+- `J-command-os-from-palette` — open one concrete workspace loop from the command palette and land on its detail route (`docs/qa/journeys/J-command-os-from-palette.md`).
+- `ET-palette-direct-entity-routes` — verify direct identity, workspace ownership, and deep-link readability (`docs/qa/scenarios/ET-palette-direct-entity-routes.md`).
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | targeted web lab | J-command-os-from-palette / ET-palette-direct-entity-routes | Sol | workspace loop direct route | Pass | — | working tree |
+
+## Session Debriefs
+
+### Targeted web walk — Sol
+
+- **Ran:** 2026-08-25T00:47:48Z → 2026-08-25T00:54:00Z (box respected: yes)
+- **Findings:** The workspace was selected from the shell scope picker. Searching for `palette-direct-loop` displayed the concrete loop row, and selecting it opened `/loops/palette-direct-loop?workspace=ws_8f9af3086c3bf927`. The loop detail rendered its name, contract, graph summary, and run state. A fresh direct navigation to the same route rendered the same detail.
+- **Bugs filed/updated:** none
+- **Scenarios settled:** `ET-palette-direct-entity-routes` → pass
+- **Paper cuts:** none observed
+- **Surprises:** The global palette correctly omitted the workspace loop until the workspace scope was selected; this confirms ownership is part of the search contract rather than a fallback filter.
+- **Suggested next charter:** Walk the remaining concrete domain rows (jobs, triggers, bridges, marketplace, and vault) in a broader palette coverage pass.
+
+## What Was Fixed
+
+No runtime defect was found during the targeted walk. The implementation under test is the ENG-131 direct-route change.
+
+## Paper Cuts
+
+| Persona | Where (journey/step) | Felt | Sharpness | Outcome |
+|---|---|---|---|---|
+| Sol | J-command-os-from-palette scope selection | Workspace rows require an explicit workspace scope before they appear | dull | expected ownership behavior; no action |
+
+## Runtime Errors Observed
+
+- None in the walked flow. The lab initially hit the already-occupied default Vite port, so it was restarted on the manifest-safe isolated port `3031`; the first lab process was torn down before retrying.
+
+## Human Verifications Needed
+
+- [ ] None for this targeted scenario; the direct row and independent deep link both passed.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- A concrete row must carry enough ownership context to select the correct workspace before opening its route; global search should not silently broaden into a catalog fallback.
+
+## Final Status
+
+- **Exit gate (focused automated evidence):** See `focused-verify.log` in the lab artifacts. The task explicitly forbids `make verify` and `make gate-full`; focused Turbo tests, lint, typecheck, codegen-check, and diff checks all passed.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 1 targeted journey walked / 1 targeted journey in scope; adjacent broad palette scenarios remain untested and are not claimed by this focused run.
+- **Verdict:** PASS — the walked workspace-owned entity opens its exact detail route from the palette and survives independent deep linking.

--- a/docs/qa/scenarios/ET-palette-action-panel.md
+++ b/docs/qa/scenarios/ET-palette-action-panel.md
@@ -19,6 +19,10 @@ overlaps: ET-palette-registry-driven-root; ET-web-command-palette-shortcuts; ET-
 Flagged by command-palette task 04. Task 12 owns the first real-user walk, visual-contract
 comparison, and verdict.
 
+2026-08-24 qa-impact (ENG-131): the concrete-row action now names the direct entity open (or the
+Worktree scope action) rather than implying catalog search. Include one action-panel activation in
+the direct-target walk.
+
 Walk (task_11 plan):
 
 1. Select any command row and press ⌘K — the panel opens anchored to the row with sections,

--- a/docs/qa/scenarios/ET-palette-direct-entity-routes.md
+++ b/docs/qa/scenarios/ET-palette-direct-entity-routes.md
@@ -1,0 +1,21 @@
+---
+id: ET-palette-direct-entity-routes
+area: ET
+title: Open a workspace loop from the palette on its own target
+persona: Sol
+journey: J-command-os-from-palette
+expected: Selecting a concrete workspace Loop from the root command palette after choosing its workspace opens the loop detail route directly, and the same route remains readable through an independent deep link.
+entry_points: Command-K root search; Global workspace scope
+qa_status: pass
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: /Users/pedronauck/dev/qa-labs/compozy-eng-131-palette-direct-20260825-004748-874920-lab/qa-artifacts/evidence/direct-loop-detail.png; /Users/pedronauck/dev/qa-labs/compozy-eng-131-palette-direct-20260825-004748-874920-lab/qa-artifacts/qa/journey-log.jsonl
+last_report: docs/qa/reports/2026-08-24-eng-131-palette-direct.md
+overlaps: ET-palette-domain-views;ET-palette-nested-views;ET-palette-action-panel
+---
+
+Added for the targeted ENG-131 walk. This scenario owns the real workspace-loop journey recorded
+in the report; focused automated suites cover the other direct-route projections, while the broader
+root/pushed entity matrix remains a separate follow-up scenario rather than an unearned pass here.

--- a/docs/qa/scenarios/ET-palette-domain-views.md
+++ b/docs/qa/scenarios/ET-palette-domain-views.md
@@ -31,6 +31,11 @@ semantics, so `ET-profile-palette-view` owns it and this row keeps the generic g
 walking, confirm one domain's chip counts differ correctly between two profiles and that a profile
 switch with a view open re-fences it instead of showing the previous lens's rows.
 
+2026-08-24 qa-impact (ENG-131): concrete rows now land on identity-bearing detail routes (or the
+existing Vault/Extension selection surface) instead of catalog filters. The direct-target walk is
+tracked in `ET-palette-direct-entity-routes`; keep this scenario untested until that walk confirms
+root and pushed views remain consistent.
+
 Walk (task_11 plan):
 
 1. Open the Tasks view — chips show truthful counts with single-select; pick a chip with zero

--- a/docs/qa/scenarios/ET-palette-nested-views.md
+++ b/docs/qa/scenarios/ET-palette-nested-views.md
@@ -33,6 +33,10 @@ order, Escape dismissal, and reopen-at-root behavior.
 the shared stack's observability contract. Keep this scenario `untested`; task 12 owns the re-walk.
 2026-08-20 qa-impact: Palette density/alignment polish tightened pushed-view rows (32px single-line / 40px two-line) and the shared left rail. Keep `untested`; re-walk Sessions and other nested views for scanability.
 
+2026-08-24 qa-impact (ENG-131): pushed domain rows share the root opener and now resolve direct
+entity targets. The direct route and foreign-workspace checks are tracked in
+`ET-palette-direct-entity-routes`.
+
 Walk (task_11 plan — stack semantics across all four kinds):
 
 1. Push a List view from the Views group — query clears, breadcrumb names the path, only that

--- a/web/e2e/__tests__/os-shell.spec.ts
+++ b/web/e2e/__tests__/os-shell.spec.ts
@@ -744,6 +744,29 @@ test("Command palette E2E-009: Tasks reports truthful zero counts and clears one
   );
 });
 
+test("Command palette ENG-131: a loop row opens its detail route", async ({ appPage, runtime }) => {
+  const workspace = await prepareShell(appPage, runtime);
+  const loopName = "palette-direct-loop";
+  await createPaletteLoop(runtime, workspace.id, loopName);
+
+  const palette = await openCommandPalette(appPage);
+  const search = palette.getByPlaceholder("Search apps, sessions, and actions…");
+  await search.fill(loopName);
+  const loopRow = palette.getByTestId(`os-palette-domain-row-loop:${workspace.id}:${loopName}`);
+  await expect(loopRow).toBeVisible();
+  await loopRow.click();
+
+  const loops = appWindow(appPage, "loops");
+  await expect(loops).toBeVisible();
+  await expect
+    .poll(async () => {
+      const snapshot = await windowManagerSnapshot(runtime, workspace.id);
+      return Object.values(snapshot.windows).find(window => window.app === "loops")?.route.pathname;
+    })
+    .toBe(`/loops/${encodeURIComponent(loopName)}`);
+  await expect(loops.getByTestId("loop-detail")).toBeVisible();
+});
+
 test("E2E-010 and E2E-018: peers converge topology while presentation stays client-local", async ({
   appPage,
   browser,
@@ -3631,6 +3654,50 @@ async function createTask(
     }),
   });
   return payload.task;
+}
+
+async function createPaletteLoop(
+  runtime: BrowserRuntime,
+  workspaceId: string,
+  name: string
+): Promise<void> {
+  const workspacePath = `/api/workspaces/${encodeURIComponent(workspaceId)}`;
+  await runtime.requestJSON(`${workspacePath}/loops`, {
+    method: "POST",
+    body: JSON.stringify({
+      definition: {
+        apiVersion: "compozy.loop/v1",
+        kind: "Loop",
+        meta: {
+          name,
+          description: "Command palette direct-route fixture.",
+          catalog: { category: "Testing" },
+        },
+        concurrency: "allow",
+        contract: {
+          goal: "Open one concrete loop from the command palette.",
+          definition_of_done: "The loop is available in the workspace catalog.",
+          stop_when: "nodes.finish.status == 'succeeded'",
+          iteration_cap: 1,
+          no_progress: { window: 2 },
+          budget: { tokens: 0, wall_clock_sec: 0, on_exceeded: "halt" },
+          terminal_states: ["done", "failed", "blocked", "exhausted", "stalled"],
+        },
+        graph: {
+          nodes: [
+            {
+              id: "finish",
+              class: "action",
+              kind: "transform",
+              params: { map: { ready: { value: true } } },
+            },
+          ],
+          edges: [],
+        },
+        start: [{ kind: "http" }],
+      },
+    }),
+  });
 }
 
 async function createTaskRun(runtime: BrowserRuntime, taskId: string): Promise<{ id: string }> {

--- a/web/src/systems/os/components/__tests__/os-palette-view-stack.test.tsx
+++ b/web/src/systems/os/components/__tests__/os-palette-view-stack.test.tsx
@@ -1,5 +1,6 @@
 // Suite: OS palette view stack integration
-// Invariant: the stack adapts profiles-domain content without owning profile lifecycle behavior.
+// Invariant: the stack adapts profiles-domain content without owning profile lifecycle behavior,
+// and pushed domain rows use the root-owned opener that survives view dismissal.
 // Boundary IN: a profiles controller projection and the profiles view registration.
 // Boundary OUT: profile queries, switching, and lifecycle dialogs.
 
@@ -55,6 +56,7 @@ describe("OsPaletteViewStack profiles integration", () => {
           dispatch={dispatch}
           onDismiss={vi.fn()}
           onPop={vi.fn()}
+          openDomainRow={vi.fn()}
           viewId="profiles"
         />
       </UIProvider>

--- a/web/src/systems/os/components/os-command-palette.tsx
+++ b/web/src/systems/os/components/os-command-palette.tsx
@@ -123,6 +123,7 @@ export function OsCommandPalette({
                 viewId={frame.viewId}
                 onDismiss={() => onOpenChange(false)}
                 onPop={viewStack.pop}
+                openDomainRow={root.openDomainRow}
               />
             </div>
           ))}

--- a/web/src/systems/os/components/os-palette-view-stack.tsx
+++ b/web/src/systems/os/components/os-palette-view-stack.tsx
@@ -18,6 +18,7 @@ import type { WindowManagerRegisteredClientView } from "../lib/window-manager-ty
 import { useProfileLens, useProfilesPaletteView } from "@/systems/profiles";
 
 import { OsPaletteViewShell } from "./os-palette-view-shell";
+import type { OsPaletteDomainRow } from "../lib/os-palette-domain-search";
 
 interface PaletteViewFrameProps {
   dispatch: CmdPaletteDispatch;
@@ -69,14 +70,16 @@ function DomainPaletteViewFrame({
   client: _client,
   dispatch: _dispatch,
   onDismiss,
+  openDomainRow,
   viewId,
   ...shell
-}: PaletteViewFrameProps & { viewId: string }) {
+}: PaletteViewFrameProps & { viewId: string; openDomainRow: (row: OsPaletteDomainRow) => void }) {
   const definition = paletteViewDefinition(viewId);
   const fallbackDefinition = definition ?? unavailableDefinition(viewId);
   const content = useOsPaletteDomainView(fallbackDefinition, {
     query: shell.query,
     onDismiss,
+    openDomainRow,
   });
   return <OsPaletteViewShell definition={fallbackDefinition} content={content} {...shell} />;
 }
@@ -148,6 +151,7 @@ export interface OsPaletteViewStackProps {
   breadcrumb: PaletteBreadcrumb;
   onPop: () => void;
   onDismiss: () => void;
+  openDomainRow: (row: OsPaletteDomainRow) => void;
 }
 
 /**
@@ -164,6 +168,7 @@ export function OsPaletteViewStack({
   breadcrumb,
   onPop,
   onDismiss,
+  openDomainRow,
 }: OsPaletteViewStackProps) {
   const [ownedQuery, setOwnedQuery] = useState({ viewId, value: "" });
   if (ownedQuery.viewId !== viewId) {
@@ -186,7 +191,14 @@ export function OsPaletteViewStack({
     return <ProfilesPaletteViewFrame {...shell} />;
   }
   if (definition?.domainTitle) {
-    return <DomainPaletteViewFrame key={viewId} {...shell} viewId={viewId} />;
+    return (
+      <DomainPaletteViewFrame
+        key={viewId}
+        {...shell}
+        openDomainRow={openDomainRow}
+        viewId={viewId}
+      />
+    );
   }
   return <DeclarativePaletteViewFrame key={viewId} {...shell} viewId={viewId} />;
 }

--- a/web/src/systems/os/hooks/__tests__/use-os-palette-root.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-os-palette-root.test.tsx
@@ -84,11 +84,13 @@ const paletteMocks = vi.hoisted(() => {
   return {
     activeWorkspaceId: "workspace:alpha" as string | null,
     closeWindow: vi.fn(async () => true),
+    setActiveWorkspaceId: vi.fn(),
     coordinator: {
       userActivateWindow: vi.fn(async () => true),
       userOpen: vi.fn(async () => "window:new-tab" as string | null),
     },
     desktop: null as OsDesktopRuntimeStore | null,
+    commandAvailable: false,
     isWaiting: vi.fn<(sessionId: string) => boolean>(() => false),
     jumpToSession: vi.fn(),
     notifyUser: vi.fn<(feedback: { message: string; tone: string }) => void>(),
@@ -193,7 +195,7 @@ vi.mock("@/systems/workspace", async importOriginal => ({
   useActiveWorkspace: () => ({
     activeWorkspaceId: paletteMocks.activeWorkspaceId,
     runtimeWorkspaceId: paletteMocks.activeWorkspaceId,
-    setActiveWorkspaceId: vi.fn(),
+    setActiveWorkspaceId: paletteMocks.setActiveWorkspaceId,
     workspaces: paletteMocks.workspaces,
     registeredWorkspaces: paletteMocks.registeredWorkspaces,
     scope: paletteMocks.scope,
@@ -262,6 +264,10 @@ vi.mock("../../hooks/use-desktop", () => ({
     if (paletteMocks.desktop === null) throw new Error("Desktop fixture was not configured.");
     return selector(paletteMocks.desktop);
   },
+}));
+
+vi.mock("../../lib/window-manager-command-availability", () => ({
+  windowManagerCommandsAvailable: () => paletteMocks.commandAvailable,
 }));
 
 vi.mock("../../hooks/use-os-shell", () => ({
@@ -378,6 +384,10 @@ const DESKTOPS: readonly LayoutDesktop[] = [
 function desktopState(): OsDesktopRuntimeStore {
   if (paletteMocks.desktop === null) throw new Error("Desktop fixture was not configured.");
   return paletteMocks.desktop;
+}
+
+function commandSnapshot(workspaceId: string): NonNullable<OsDesktopRuntimeStore["snapshot"]> {
+  return { workspaceId } as NonNullable<OsDesktopRuntimeStore["snapshot"]>;
 }
 
 function desktopFixture(
@@ -610,6 +620,7 @@ function resetPaletteHarness() {
   paletteDispatch.setPinned.mockClear();
   paletteMocks.activeWorkspaceId = "workspace:alpha";
   paletteMocks.closeWindow.mockClear();
+  paletteMocks.setActiveWorkspaceId.mockClear();
   paletteMocks.coordinator.userActivateWindow.mockClear();
   paletteMocks.coordinator.userOpen.mockClear();
   paletteMocks.coordinator.userOpen.mockResolvedValue("window:new-tab");
@@ -643,6 +654,7 @@ function resetPaletteHarness() {
   paletteMocks.windowSlots.clear();
   paletteMocks.windowCommands.commandsAvailable = true;
   paletteMocks.desktop = desktopFixture({ "window:tasks": windowFixture() }, "window:tasks");
+  paletteMocks.commandAvailable = false;
 }
 
 function renderRoot(open = true, onOpenChange = vi.fn()) {
@@ -843,6 +855,171 @@ describe("useOsPaletteRoot", () => {
     });
     // The root must not keep a second landing implementation of its own.
     expect(paletteMocks.coordinator.userOpen).not.toHaveBeenCalled();
+  });
+
+  it("Should open a concrete domain row on its identity route", async () => {
+    paletteMocks.commandAvailable = true;
+    paletteMocks.desktop = {
+      ...desktopFixture({ "window:tasks": windowFixture() }, "window:tasks"),
+      snapshot: commandSnapshot("workspace:alpha"),
+    };
+    const onOpenChange = vi.fn();
+    const { result } = renderRoot(true, onOpenChange);
+
+    await act(async () => {
+      result.current.openDomainRow({
+        app: "tasks",
+        key: "task:task-42",
+        label: "Review release",
+        route: { pathname: "/tasks/task-42", search: {} },
+      });
+    });
+
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+    expect(paletteMocks.coordinator.userOpen).toHaveBeenCalledExactlyOnceWith({
+      app: "tasks",
+      route: { pathname: "/tasks/task-42", search: {} },
+    });
+  });
+
+  it("Should report when the coordinator refuses a concrete domain target", async () => {
+    paletteMocks.commandAvailable = true;
+    paletteMocks.desktop = {
+      ...desktopFixture({ "window:tasks": windowFixture() }, "window:tasks"),
+      snapshot: commandSnapshot("workspace:alpha"),
+    };
+    paletteMocks.coordinator.userOpen.mockResolvedValueOnce(null);
+    const onOpenChange = vi.fn();
+    const { result } = renderRoot(true, onOpenChange);
+
+    await act(async () => {
+      result.current.openDomainRow({
+        app: "tasks",
+        key: "task:unreachable",
+        label: "Unavailable task",
+        route: { pathname: "/tasks/unreachable", search: {} },
+      });
+    });
+
+    await waitFor(() =>
+      expect(paletteMocks.notifyUser).toHaveBeenCalledWith({
+        message: "Couldn't open Unavailable task. Try again.",
+        tone: "error",
+      })
+    );
+  });
+
+  it("Should switch to a global row's owning workspace before opening it", async () => {
+    paletteMocks.scope = "global";
+    paletteMocks.commandAvailable = true;
+    paletteMocks.desktop = {
+      ...desktopFixture({ "window:tasks": windowFixture() }, "window:tasks"),
+      snapshot: commandSnapshot("workspace:alpha"),
+    };
+    const onOpenChange = vi.fn();
+    const rendered = renderRoot(true, onOpenChange);
+
+    act(() => {
+      rendered.result.current.openDomainRow({
+        app: "jobs",
+        key: "job:job-beta",
+        label: "Beta job",
+        route: { pathname: "/jobs/job-beta", search: {} },
+        workspaceId: "workspace:beta",
+      });
+    });
+
+    expect(paletteMocks.setActiveWorkspaceId).toHaveBeenCalledExactlyOnceWith("workspace:beta");
+    expect(paletteMocks.coordinator.userOpen).not.toHaveBeenCalled();
+
+    paletteMocks.activeWorkspaceId = "workspace:beta";
+    paletteMocks.desktop = {
+      ...paletteMocks.desktop,
+      snapshot: commandSnapshot("workspace:beta"),
+    };
+    rendered.rerender({ open: true });
+
+    await waitFor(() =>
+      expect(paletteMocks.coordinator.userOpen).toHaveBeenCalledExactlyOnceWith({
+        app: "jobs",
+        route: { pathname: "/jobs/job-beta", search: {} },
+      })
+    );
+  });
+
+  it("Should retain a foreign target after the pushed palette view closes", async () => {
+    paletteMocks.scope = "global";
+    paletteMocks.commandAvailable = true;
+    paletteMocks.desktop = {
+      ...desktopFixture({ "window:tasks": windowFixture() }, "window:tasks"),
+      snapshot: commandSnapshot("workspace:alpha"),
+    };
+    const onOpenChange = vi.fn();
+    const rendered = renderRoot(true, onOpenChange);
+
+    act(() => {
+      rendered.result.current.openDomainRow({
+        app: "jobs",
+        key: "job:job-beta",
+        label: "Beta job",
+        route: { pathname: "/jobs/job-beta", search: {} },
+        workspaceId: "workspace:beta",
+      });
+    });
+
+    expect(onOpenChange).toHaveBeenCalledExactlyOnceWith(false);
+    expect(paletteMocks.coordinator.userOpen).not.toHaveBeenCalled();
+
+    rendered.rerender({ open: false });
+    paletteMocks.activeWorkspaceId = "workspace:beta";
+    paletteMocks.desktop = {
+      ...paletteMocks.desktop,
+      snapshot: commandSnapshot("workspace:beta"),
+    };
+    rendered.rerender({ open: false });
+
+    await waitFor(() =>
+      expect(paletteMocks.coordinator.userOpen).toHaveBeenCalledExactlyOnceWith({
+        app: "jobs",
+        route: { pathname: "/jobs/job-beta", search: {} },
+      })
+    );
+  });
+
+  it("Should wait for the window manager workspace after the runtime is ready", async () => {
+    paletteMocks.commandAvailable = true;
+    paletteMocks.desktop = {
+      ...desktopFixture({ "window:tasks": windowFixture() }, "window:tasks"),
+      snapshot: commandSnapshot("workspace:stale"),
+    };
+    const onOpenChange = vi.fn();
+    const rendered = renderRoot(true, onOpenChange);
+
+    act(() => {
+      rendered.result.current.openDomainRow({
+        app: "tasks",
+        key: "task:task-alpha",
+        label: "Alpha task",
+        route: { pathname: "/tasks/task-alpha", search: {} },
+        workspaceId: "workspace:alpha",
+      });
+    });
+
+    expect(paletteMocks.setActiveWorkspaceId).not.toHaveBeenCalled();
+    expect(paletteMocks.coordinator.userOpen).not.toHaveBeenCalled();
+
+    paletteMocks.desktop = {
+      ...paletteMocks.desktop,
+      snapshot: commandSnapshot("workspace:alpha"),
+    };
+    rendered.rerender({ open: true });
+
+    await waitFor(() =>
+      expect(paletteMocks.coordinator.userOpen).toHaveBeenCalledExactlyOnceWith({
+        app: "tasks",
+        route: { pathname: "/tasks/task-alpha", search: {} },
+      })
+    );
   });
 
   it("Should offer only navigable targets in destination mode and stay honest when none are eligible [UT-107, UT-108]", () => {

--- a/web/src/systems/os/hooks/use-os-palette-domain-open.ts
+++ b/web/src/systems/os/hooks/use-os-palette-domain-open.ts
@@ -1,0 +1,109 @@
+import { useEffect, useRef } from "react";
+
+import { notifyUser } from "@/lib/user-feedback";
+import { useActiveWorkspace } from "@/systems/workspace";
+
+import { useDesktop } from "./use-desktop";
+import { useFocusedWorktreeScopeId } from "./use-worktree-scope";
+import { useOsShell } from "./use-os-shell";
+import { windowManagerCommandsAvailable } from "../lib/window-manager-command-availability";
+import { applyPaletteWorktreeSelection } from "../lib/os-palette-worktree-selection";
+import type { OsPaletteDomainRow } from "../lib/os-palette-domain-search";
+import type { RoutingCoordinator } from "../lib/routing-coordinator";
+
+interface PendingDomainOpen {
+  readonly row: OsPaletteDomainRow;
+  readonly workspaceId: string;
+}
+
+function domainOpenError(row: OsPaletteDomainRow): void {
+  notifyUser({
+    message: `Couldn't open ${row.label}. Try again.`,
+    tone: "error",
+  });
+}
+
+function openDomainRoute(coordinator: RoutingCoordinator, row: OsPaletteDomainRow): void {
+  void coordinator
+    .userOpen({ app: row.app, route: row.route })
+    .then(windowId => {
+      if (windowId === null) domainOpenError(row);
+    })
+    .catch(() => domainOpenError(row));
+}
+
+/**
+ * One landing path for concrete palette rows in both the root and pushed views.
+ * Foreign workspace rows wait for the workspace window manager to become live;
+ * worktree rows use the shell's canonical scope-selection action instead of a
+ * dashboard search route.
+ */
+export function useOsPaletteDomainOpen(onDismiss: () => void): (row: OsPaletteDomainRow) => void {
+  const { coordinator } = useOsShell();
+  const {
+    activeWorkspaceId,
+    registeredWorkspaces,
+    runtimeWorkspaceId,
+    scope,
+    setActiveWorkspaceId,
+  } = useActiveWorkspace();
+  const commandAvailable = useDesktop(windowManagerCommandsAvailable);
+  const commandWorkspaceId = useDesktop(state => state.snapshot?.workspaceId.trim() || null);
+  const worktreeScopeId = useFocusedWorktreeScopeId();
+  const pendingRef = useRef<PendingDomainOpen | null>(null);
+
+  useEffect(() => {
+    const pending = pendingRef.current;
+    if (pending === null) return;
+    if (
+      pending.workspaceId !== runtimeWorkspaceId?.trim() ||
+      !commandAvailable ||
+      pending.workspaceId !== commandWorkspaceId
+    ) {
+      return;
+    }
+    pendingRef.current = null;
+    openDomainRoute(coordinator, pending.row);
+  }, [commandAvailable, commandWorkspaceId, coordinator, runtimeWorkspaceId]);
+
+  return (row: OsPaletteDomainRow) => {
+    onDismiss();
+    if (row.worktreeSelection) {
+      try {
+        applyPaletteWorktreeSelection({
+          activeWorkspaceId,
+          entry: {
+            workspaceId: row.worktreeSelection.workspaceId,
+            worktree: { id: row.worktreeSelection.worktreeId },
+          },
+          scope,
+          setActiveWorkspaceId,
+          worktreeScopeId,
+        });
+      } catch {
+        domainOpenError(row);
+      }
+      return;
+    }
+
+    const workspaceId = row.workspaceId?.trim();
+    if (!workspaceId) {
+      openDomainRoute(coordinator, row);
+      return;
+    }
+    if (!registeredWorkspaces.some(workspace => workspace.id === workspaceId)) {
+      domainOpenError(row);
+      return;
+    }
+    if (
+      workspaceId !== runtimeWorkspaceId?.trim() ||
+      !commandAvailable ||
+      workspaceId !== commandWorkspaceId
+    ) {
+      pendingRef.current = { row, workspaceId };
+      if (workspaceId !== runtimeWorkspaceId?.trim()) setActiveWorkspaceId(workspaceId);
+      return;
+    }
+    openDomainRoute(coordinator, row);
+  };
+}

--- a/web/src/systems/os/hooks/use-os-palette-domain-search.ts
+++ b/web/src/systems/os/hooks/use-os-palette-domain-search.ts
@@ -14,16 +14,21 @@ import { useWorktrees, type WorkspaceScopeMode } from "@/systems/workspace";
 import { usePaletteInfiniteCatalog } from "./use-palette-infinite-catalog";
 import {
   isPaletteDomainSearchEnabled,
+  agentRoute,
+  bridgeRoute,
+  jobRoute,
   knowledgeRoute,
+  loopRoute,
   marketplaceCatalogTotal,
+  marketplaceEntryRoute,
   networkChannelRoute,
   paletteTaskFilters,
   paletteWorkspaceCatalogFilters,
   projectVaultRows,
   rowSeed,
-  searchRoute,
   section,
-  tasksRoute,
+  taskRoute,
+  triggerRoute,
   workspaceLabel,
   type OsPaletteDomainSection,
 } from "../lib/os-palette-domain-search";
@@ -181,7 +186,11 @@ export function useOsPaletteDomainSearch({
           workspaceLabel: wsLabel(worktree.workspace_id),
           status: worktree.state,
           app: "dashboard",
-          route: searchRoute("/", worktree.name),
+          route: { pathname: "/", search: {} },
+          worktreeSelection: {
+            workspaceId: worktree.workspace_id,
+            worktreeId: worktree.id,
+          },
         })
       ),
       scope === "global" ? catalogs.worktreeState : worktrees,
@@ -203,7 +212,10 @@ export function useOsPaletteDomainSearch({
           detail: agent.provider,
           workspaceLabel: wsLabel(agent.origin === "workspace" ? agentWorkspaceId : undefined),
           app: "agents",
-          route: searchRoute("/agents", agent.name),
+          route: agentRoute(agent.name),
+          ...(agent.origin === "workspace" && agentWorkspaceId
+            ? { workspaceId: agentWorkspaceId }
+            : {}),
         })
       ),
       scope === "global"
@@ -230,7 +242,8 @@ export function useOsPaletteDomainSearch({
             status: task.status,
             workspaceLabel: wsLabel(task.workspace_id),
             app: "tasks",
-            route: tasksRoute(task.title),
+            route: taskRoute(task.id),
+            ...(task.workspace_id ? { workspaceId: task.workspace_id } : {}),
           },
           task.identifier ? [task.identifier] : []
         )
@@ -250,7 +263,8 @@ export function useOsPaletteDomainSearch({
           detail: loop.contract.goal,
           workspaceLabel: wsLabel(loopWorkspaceId),
           app: "loops",
-          route: searchRoute("/loops", loop.name),
+          route: loopRoute(loop.name, loopWorkspaceId),
+          ...(loopWorkspaceId ? { workspaceId: loopWorkspaceId } : {}),
         })
       ),
       loopState,
@@ -268,7 +282,8 @@ export function useOsPaletteDomainSearch({
           detail: job.agent_name,
           workspaceLabel: wsLabel(job.workspace_id),
           app: "jobs",
-          route: searchRoute("/jobs", job.name),
+          route: jobRoute(job.id),
+          ...(job.workspace_id ? { workspaceId: job.workspace_id } : {}),
         })
       ),
       jobs,
@@ -286,7 +301,8 @@ export function useOsPaletteDomainSearch({
           detail: trigger.event,
           workspaceLabel: wsLabel(trigger.workspace_id),
           app: "triggers",
-          route: searchRoute("/triggers", trigger.name),
+          route: triggerRoute(trigger.id),
+          ...(trigger.workspace_id ? { workspaceId: trigger.workspace_id } : {}),
         })
       ),
       triggers,
@@ -304,7 +320,8 @@ export function useOsPaletteDomainSearch({
           detail: bridge.platform,
           workspaceLabel: wsLabel(bridge.workspace_id),
           app: "bridges",
-          route: searchRoute("/bridges", bridge.display_name),
+          route: bridgeRoute(bridge.id),
+          ...(bridge.workspace_id ? { workspaceId: bridge.workspace_id } : {}),
         })
       ),
       bridges,
@@ -338,6 +355,7 @@ export function useOsPaletteDomainSearch({
             scope: memory.scope === "workspace" ? "workspace" : "global",
             workspaceId: memory.workspace_id,
           }),
+          workspaceId: memory.scope === "workspace" ? memory.workspace_id : undefined,
         })
       ),
       {
@@ -384,6 +402,7 @@ export function useOsPaletteDomainSearch({
             workspaceLabel: wsLabel(channelWorkspaceId),
             app: "network",
             route: networkChannelRoute(channelWorkspaceId, channel.channel),
+            workspaceId: channelWorkspaceId,
           }),
         ];
       }),
@@ -406,7 +425,14 @@ export function useOsPaletteDomainSearch({
             detail: item.description,
             workspaceLabel: wsLabel(scopedWorkspace),
             app: "marketplace",
-            route: { pathname: item.manage_path ?? "/marketplace", search: { q: item.name } },
+            route: marketplaceEntryRoute({
+              kind: item.kind,
+              entryId: item.entry_id,
+              scope,
+              workspaceId: scopedWorkspace,
+              installedName: item.installed_name,
+            }),
+            ...(scopedWorkspace ? { workspaceId: scopedWorkspace } : {}),
           })
         )
       ),
@@ -437,7 +463,14 @@ export function useOsPaletteDomainSearch({
           detail: extension.health,
           workspaceLabel: wsLabel(extensionWorkspaceId),
           app: "marketplace",
-          route: searchRoute("/marketplace/extensions", extension.name),
+          route: marketplaceEntryRoute({
+            kind: "extension",
+            entryId: extension.marketplace?.entry_id ?? extension.name,
+            scope: extensionWorkspaceId ? "workspace" : "global",
+            workspaceId: extensionWorkspaceId,
+            installedName: extension.name,
+          }),
+          ...(extensionWorkspaceId ? { workspaceId: extensionWorkspaceId } : {}),
         })
       ),
       scope === "global" ? catalogs.workspaceExtensionState : publishedExtensions,

--- a/web/src/systems/os/hooks/use-os-palette-domain-view.tsx
+++ b/web/src/systems/os/hooks/use-os-palette-domain-view.tsx
@@ -13,17 +13,20 @@ import type {
   PaletteViewDefinition,
 } from "../lib/palette-view-registry";
 import { useCmdPaletteRankSignals } from "./use-cmd-palette-rank-signals";
-import { useOsShell } from "./use-os-shell";
 import { domainChips, domainEmptyMessage, domainFilter } from "./os-palette-domain-filters";
-import { useOsPaletteDomainSearch } from "./use-os-palette-domain-search";
+import {
+  useOsPaletteDomainSearch,
+  type OsPaletteDomainRow as OsPaletteDomainRowModel,
+} from "./use-os-palette-domain-search";
+
+type OpenDomainRow = (row: OsPaletteDomainRowModel) => void;
 
 export function useOsPaletteDomainView(
   definition: PaletteViewDefinition,
-  { query, onDismiss }: PaletteViewControllerInput
+  { query, openDomainRow }: PaletteViewControllerInput & { openDomainRow: OpenDomainRow }
 ): PaletteViewContent {
   const domainTitle = definition.domainTitle ?? definition.title;
   const [filter, setFilter] = useState("all");
-  const { coordinator } = useOsShell();
   const { runtimeWorkspaceId, scope, workspaces } = useActiveWorkspace();
   const signals = useCmdPaletteRankSignals(runtimeWorkspaceId, true);
   const sections = useOsPaletteDomainSearch({
@@ -75,8 +78,7 @@ export function useOsPaletteDomainView(
             const rowKey = action.action?.args?.row_key;
             const row = visible.find(candidate => candidate.key === rowKey);
             if (!row) return;
-            onDismiss();
-            void coordinator.userOpen({ app: row.app, route: row.route });
+            openDomainRow(row);
           }}
         />
       ),
@@ -97,8 +99,7 @@ export function useOsPaletteDomainView(
       twoLine: Boolean(row.detail || row.workspaceLabel),
       node: <OsPaletteDomainRow row={row} />,
       onSelect: () => {
-        onDismiss();
-        void coordinator.userOpen({ app: row.app, route: row.route });
+        openDomainRow(row);
       },
     })),
     header:

--- a/web/src/systems/os/hooks/use-os-palette-root.ts
+++ b/web/src/systems/os/hooks/use-os-palette-root.ts
@@ -21,6 +21,7 @@ import type { OsAppId, OsWindowRoute } from "../lib/os-types";
 import { windowManagerStore } from "../stores/window-manager-store";
 import { WorktreeDialogActionsContext } from "../contexts/worktree-dialog-actions-context";
 import { useAttentionJump } from "./use-attention-jump";
+import { useOsPaletteDomainOpen } from "./use-os-palette-domain-open";
 import { useOsShell } from "./use-os-shell";
 import {
   useOsPaletteEntities,
@@ -146,6 +147,7 @@ export function useOsPaletteRoot({
   });
 
   const close = () => onOpenChange(false);
+  const openDomainRow = useOsPaletteDomainOpen(close);
   const fallback =
     assembly.fallback !== null &&
     assembly.sections.length === 0 &&
@@ -213,11 +215,6 @@ export function useOsPaletteRoot({
   const goToTab = (windowId: string) => {
     close();
     void coordinator.userActivateWindow(windowId);
-  };
-
-  const openDomainRow = (row: OsPaletteDomainRow) => {
-    close();
-    void coordinator.userOpen({ app: row.app, route: row.route });
   };
 
   const scopeToWorktree = (entry: OsPaletteWorktreeResult) => {

--- a/web/src/systems/os/lib/__tests__/os-palette-domain-search.test.ts
+++ b/web/src/systems/os/lib/__tests__/os-palette-domain-search.test.ts
@@ -9,13 +9,20 @@ import { describe, expect, it } from "vitest";
 
 import type { CmdPaletteRankSignals } from "../cmd-palette-types";
 import {
+  agentRoute,
+  bridgeRoute,
   knowledgeRoute,
+  jobRoute,
+  loopRoute,
   marketplaceCatalogTotal,
+  marketplaceEntryRoute,
   networkChannelRoute,
   paletteTaskFilters,
   paletteWorkspaceCatalogFilters,
   section,
-  tasksRoute,
+  taskRoute,
+  triggerRoute,
+  vaultRoute,
   workspaceLabel,
 } from "../os-palette-domain-search";
 
@@ -46,16 +53,53 @@ function seed(label: string, index: number) {
       key: `task:${index}`,
       label,
       app: "tasks" as const,
-      route: tasksRoute(label),
+      route: taskRoute(`task-${index}`),
     },
   };
 }
 
 describe("os-palette-domain-search helpers", () => {
-  it("Should land a task on the catalog query the Tasks page consumes", () => {
-    expect(tasksRoute("Ship review")).toEqual({
-      pathname: "/tasks",
-      search: { query: "Ship review" },
+  it("Should build identity-bearing routes for concrete entities", () => {
+    expect(taskRoute("task/42")).toEqual({ pathname: "/tasks/task%2F42", search: {} });
+    expect(loopRoute("Release / Ops", "ws-a")).toEqual({
+      pathname: "/loops/Release%20%2F%20Ops",
+      search: { workspace: "ws-a" },
+    });
+    expect(jobRoute("job-42")).toEqual({ pathname: "/jobs/job-42", search: {} });
+    expect(triggerRoute("trigger-42")).toEqual({ pathname: "/triggers/trigger-42", search: {} });
+    expect(bridgeRoute("bridge-42")).toEqual({ pathname: "/bridges/bridge-42", search: {} });
+    expect(agentRoute("agent/ops")).toEqual({ pathname: "/agents/agent%2Fops", search: {} });
+
+    const sameNameRoutes = ["task-a", "task-b"].map(id => taskRoute(id));
+    expect(sameNameRoutes).toEqual([
+      { pathname: "/tasks/task-a", search: {} },
+      { pathname: "/tasks/task-b", search: {} },
+    ]);
+  });
+
+  it("Should carry marketplace scope and installed identity into the detail route", () => {
+    expect(
+      marketplaceEntryRoute({
+        entryId: "ops/extension",
+        installedName: "ops-extension",
+        kind: "extension",
+        scope: "workspace",
+        workspaceId: "ws-a",
+      })
+    ).toEqual({
+      pathname: "/marketplace/extension/ops%2Fextension",
+      search: {
+        installed_name: "ops-extension",
+        scope: "workspace",
+        workspace_id: "ws-a",
+      },
+    });
+  });
+
+  it("Should select a Vault secret by ref instead of filtering by its display name", () => {
+    expect(vaultRoute("vault:providers/ops/api-token")).toEqual({
+      pathname: "/vault",
+      search: { ref: "vault:providers/ops/api-token" },
     });
   });
 

--- a/web/src/systems/os/lib/cmd-palette-row-actions.ts
+++ b/web/src/systems/os/lib/cmd-palette-row-actions.ts
@@ -300,7 +300,7 @@ function domainModel(row: OsPaletteDomainRow): PaletteRowActionModel {
         actions: [
           {
             id: "domain.open",
-            title: `Open ${row.label}`,
+            title: row.worktreeSelection ? `Scope to ${row.label}` : `Open ${row.label}`,
             icon: "arrow-right",
             section: "Open",
             primary: true,

--- a/web/src/systems/os/lib/os-palette-domain-search.ts
+++ b/web/src/systems/os/lib/os-palette-domain-search.ts
@@ -14,8 +14,15 @@ export interface OsPaletteDomainRow {
   readonly label: string;
   readonly detail?: string;
   readonly workspaceLabel?: string;
+  /** Owning workspace for global rows that need a workspace switch before opening. */
+  readonly workspaceId?: string;
   readonly app: OsAppId;
   readonly route: OsWindowRoute;
+  /** Worktree rows scope the shell instead of opening an application route. */
+  readonly worktreeSelection?: {
+    readonly workspaceId: string;
+    readonly worktreeId: string;
+  };
   readonly status?: string;
 }
 
@@ -66,12 +73,66 @@ export function workspaceLabel(
   return names.get(workspaceId) ?? workspaceId;
 }
 
-export function searchRoute(pathname: string, q: string): OsWindowRoute {
-  return { pathname, search: { q } };
+function encodedSegment(value: string): string {
+  return encodeURIComponent(value.trim());
 }
 
-export function tasksRoute(title: string): OsWindowRoute {
-  return { pathname: "/tasks", search: { query: title } };
+export function taskRoute(id: string): OsWindowRoute {
+  return { pathname: `/tasks/${encodedSegment(id)}`, search: {} };
+}
+
+export function loopRoute(name: string, workspaceId?: string | null): OsWindowRoute {
+  const workspace = workspaceId?.trim();
+  return {
+    pathname: `/loops/${encodedSegment(name)}`,
+    search: workspace ? { workspace } : {},
+  };
+}
+
+export function jobRoute(id: string): OsWindowRoute {
+  return { pathname: `/jobs/${encodedSegment(id)}`, search: {} };
+}
+
+export function triggerRoute(id: string): OsWindowRoute {
+  return { pathname: `/triggers/${encodedSegment(id)}`, search: {} };
+}
+
+export function bridgeRoute(id: string): OsWindowRoute {
+  return { pathname: `/bridges/${encodedSegment(id)}`, search: {} };
+}
+
+export function agentRoute(name: string): OsWindowRoute {
+  return { pathname: `/agents/${encodedSegment(name)}`, search: {} };
+}
+
+export function marketplaceEntryRoute(input: {
+  kind: "mcp" | "extension" | "skill";
+  entryId: string;
+  scope: WorkspaceScopeMode;
+  workspaceId?: string | null;
+  installedName?: string | null;
+}): OsWindowRoute {
+  const workspace = input.workspaceId?.trim();
+  const installedName = input.installedName?.trim();
+  const search =
+    input.scope === "workspace" && workspace
+      ? {
+          scope: "workspace",
+          workspace_id: workspace,
+          ...(installedName ? { installed_name: installedName } : {}),
+        }
+      : {
+          scope: "user",
+          ...(installedName ? { installed_name: installedName } : {}),
+        };
+  return {
+    pathname: `/marketplace/${input.kind}/${encodedSegment(input.entryId)}`,
+    search,
+  };
+}
+
+export function vaultRoute(ref: string): OsWindowRoute {
+  return { pathname: "/vault", search: { ref: ref.trim() } };
 }
 
 export function networkChannelRoute(workspaceId: string, channel: string): OsWindowRoute {
@@ -159,7 +220,7 @@ export function projectVaultRows(
       detail: [secret.namespace, secret.kind].filter(Boolean).join(" · "),
       workspaceLabel: workspaceLabel(scope, undefined, names),
       app: "vault",
-      route: searchRoute("/vault", name),
+      route: vaultRoute(secret.ref),
       namespace: secret.namespace,
       kind: secret.kind ?? "",
     };

--- a/web/src/systems/os/lib/os-palette-worktree-selection.ts
+++ b/web/src/systems/os/lib/os-palette-worktree-selection.ts
@@ -8,6 +8,7 @@ export function applyPaletteWorktreeSelection(input: {
   readonly scope: WorkspaceScopeMode;
   readonly worktreeScopeId: string;
   readonly activeWorkspaceId: string | null;
+  readonly setActiveWorkspaceId?: (workspaceId: string) => void;
   readonly entry: {
     readonly workspaceId?: string;
     readonly worktree?: { readonly id: string } | null;
@@ -16,7 +17,7 @@ export function applyPaletteWorktreeSelection(input: {
   const targetWorkspaceId = input.entry.workspaceId ?? input.activeWorkspaceId;
   if (!input.entry.worktree || targetWorkspaceId === null) return;
   if (input.scope === "global") {
-    setActiveWorkspaceId(targetWorkspaceId);
+    (input.setActiveWorkspaceId ?? setActiveWorkspaceId)(targetWorkspaceId);
   }
   selectWorktreeForScope(input.worktreeScopeId, targetWorkspaceId, input.entry.worktree.id);
 }

--- a/web/src/systems/vault/hooks/__tests__/use-vault-page.test.tsx
+++ b/web/src/systems/vault/hooks/__tests__/use-vault-page.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   allSecretsState: {
     error: null as Error | null,
     isFetching: false,
+    isError: false,
     isLoading: false,
     isStale: false,
     isSuccess: true,
@@ -59,6 +60,7 @@ vi.mock("@/systems/vault/hooks/use-vault", () => ({
       data: mocks.secrets,
       error: isUnfiltered ? mocks.allSecretsState.error : null,
       isFetching: isUnfiltered ? mocks.allSecretsState.isFetching : false,
+      isError: isUnfiltered ? mocks.allSecretsState.isError : false,
       isLoading: isUnfiltered ? mocks.allSecretsState.isLoading : false,
       isStale: isUnfiltered ? mocks.allSecretsState.isStale : false,
       isSuccess: isUnfiltered ? mocks.allSecretsState.isSuccess : true,
@@ -100,6 +102,7 @@ describe("useVaultPage route state", () => {
     mocks.secrets = [];
     mocks.allSecretsState.error = null;
     mocks.allSecretsState.isFetching = false;
+    mocks.allSecretsState.isError = false;
     mocks.allSecretsState.isLoading = false;
     mocks.allSecretsState.isStale = false;
     mocks.allSecretsState.isSuccess = true;
@@ -153,6 +156,36 @@ describe("useVaultPage route state", () => {
     expect(normalizeVaultPrefixForNamespace("vault:providers/openai", undefined)).toBe(
       "vault:providers/openai"
     );
+  });
+
+  it("Should open a requested secret by exact ref and clear that route selection on close", async () => {
+    mocks.secrets = [providerSecret];
+    const { result } = renderHook(() => useVaultPage({ ref: providerSecret.ref }));
+
+    await waitFor(() => expect(result.current.selectedSecret?.ref).toBe(providerSecret.ref));
+    expect(result.current.selectionError).toBeNull();
+
+    act(() => result.current.closeInspect());
+    const routeSearch = mocks.navigate.mock.lastCall?.[0].search;
+    if (typeof routeSearch !== "function") throw new Error("Expected a route search updater.");
+    expect(routeSearch({ ref: providerSecret.ref })).toEqual({ ref: undefined });
+  });
+
+  it("Should expose a clear error when a requested secret is gone", () => {
+    const { result } = renderHook(() => useVaultPage({ ref: "vault:providers/missing" }));
+
+    expect(result.current.selectionError).toBe("Vault secret not found");
+    expect(result.current.selectedSecret).toBeNull();
+  });
+
+  it("Should keep a direct Vault route out of the catalog when exact resolution fails", () => {
+    mocks.allSecretsState.error = new Error("Vault inventory unavailable");
+    mocks.allSecretsState.isError = true;
+    mocks.allSecretsState.isSuccess = false;
+    const { result } = renderHook(() => useVaultPage({ ref: "vault:providers/unreachable" }));
+
+    expect(result.current.selectionError).toBe("Vault inventory unavailable");
+    expect(result.current.selectedSecret).toBeNull();
   });
 
   it("Should replace the selected secret with its exact ref and kind, rejecting blank values", async () => {

--- a/web/src/systems/vault/hooks/use-vault-page.ts
+++ b/web/src/systems/vault/hooks/use-vault-page.ts
@@ -1,5 +1,6 @@
 import { useNavigate } from "@tanstack/react-router";
 import { useSelector, useStore } from "@xstate/store-react";
+import { useEffect, useRef } from "react";
 
 import type { ListingViewMode } from "@compozy/ui";
 
@@ -72,6 +73,7 @@ export function useVaultPage(search: VaultRouteSearch = {}) {
   const navigate = useNavigate({ from: "/vault" });
   const prefix = search.q ?? "";
   const namespace: VaultNamespaceFilter = search.namespace ?? "all";
+  const routeRef = search.ref?.trim() || null;
   const view: ListingViewMode = search.view ?? "rows";
   const pageStore = useStore(vaultPageLogic);
   const flow = useSelector(pageStore, snapshot => snapshot.context);
@@ -82,7 +84,10 @@ export function useVaultPage(search: VaultRouteSearch = {}) {
   // only the active namespace/prefix projection. Keep that unbounded read cold
   // until an action actually needs cross-filter truth.
   const inventoryRequired =
-    flow.editor.mode === "create" || flow.selectedRef !== null || flow.deleteTargetRef !== null;
+    routeRef !== null ||
+    flow.editor.mode === "create" ||
+    flow.selectedRef !== null ||
+    flow.deleteTargetRef !== null;
   const allSecretsQuery = useVaultSecrets({}, { enabled: inventoryRequired });
   const putMutation = usePutVaultSecret();
   const deleteMutation = useDeleteVaultSecret();
@@ -93,6 +98,18 @@ export function useVaultPage(search: VaultRouteSearch = {}) {
   const selectedSecret = flow.selectedRef
     ? (secretInventory.find(secret => secret.ref === flow.selectedRef) ?? null)
     : null;
+  const previousRouteRef = useRef<string | null | undefined>(undefined);
+  useEffect(() => {
+    const previous = previousRouteRef.current;
+    previousRouteRef.current = routeRef;
+    if (routeRef !== null) {
+      if (flow.selectedRef !== routeRef) pageStore.trigger.inspectOpened({ ref: routeRef });
+      return;
+    }
+    if (previous !== undefined && previous !== null && flow.selectedRef !== null) {
+      pageStore.trigger.inspectClosed();
+    }
+  }, [flow.selectedRef, pageStore, routeRef]);
   const deleteTargetSecret = flow.deleteTargetRef
     ? (secretInventory.find(secret => secret.ref === flow.deleteTargetRef) ?? null)
     : null;
@@ -145,11 +162,13 @@ export function useVaultPage(search: VaultRouteSearch = {}) {
   const openInspect = (secret: VaultSecret) => {
     putMutation.reset();
     pageStore.trigger.inspectOpened({ ref: secret.ref });
+    updateSearch(current => ({ ...current, ref: secret.ref }));
   };
   const closeInspect = () => {
     if (flow.pendingPutAttempt !== null) return;
     pageStore.trigger.inspectClosed();
     putMutation.reset();
+    updateSearch(current => ({ ...current, ref: undefined }));
   };
   const replaceIsValid = Boolean(
     selectedSecret &&
@@ -184,6 +203,14 @@ export function useVaultPage(search: VaultRouteSearch = {}) {
   };
 
   const putError = errorMessage(putMutation.error);
+  const selectionError =
+    routeRef !== null && !allSecretsQuery.isFetching
+      ? allSecretsQuery.isError
+        ? (errorMessage(allSecretsQuery.error) ?? "Vault secret unavailable")
+        : allSecretsQuery.isSuccess && selectedSecret === null
+          ? "Vault secret not found"
+          : null
+      : null;
   return {
     counts,
     deleteError: errorMessage(deleteMutation.error),
@@ -212,6 +239,7 @@ export function useVaultPage(search: VaultRouteSearch = {}) {
     replaceIsValid,
     replaceSecret,
     replaceValue: flow.replaceValue,
+    selectionError,
     secrets,
     selectedSecret,
     setNamespace: (next: VaultNamespaceFilter) =>

--- a/web/src/systems/vault/lib/__tests__/vault-route-search.test.ts
+++ b/web/src/systems/vault/lib/__tests__/vault-route-search.test.ts
@@ -1,0 +1,34 @@
+// Suite: Vault route validation
+// Invariant: a direct Vault selection survives route normalization as an exact, trimmed ref.
+// Boundary IN: TanStack Router search values.
+// Boundary OUT: Vault page selection and API transport.
+import { describe, expect, it } from "vitest";
+
+import { validateVaultSearch } from "../vault-route-search";
+
+describe("validateVaultSearch", () => {
+  it("Should preserve a trimmed direct-selection ref alongside list controls", () => {
+    expect(
+      validateVaultSearch({
+        namespace: "providers",
+        q: "vault:providers/",
+        ref: "  vault:providers/openai  ",
+        view: "cards",
+      })
+    ).toEqual({
+      namespace: "providers",
+      q: "vault:providers/",
+      ref: "vault:providers/openai",
+      view: "cards",
+    });
+  });
+
+  it("Should drop a blank direct-selection ref", () => {
+    expect(validateVaultSearch({ ref: "   " })).toEqual({
+      namespace: undefined,
+      q: undefined,
+      ref: undefined,
+      view: undefined,
+    });
+  });
+});

--- a/web/src/systems/vault/lib/vault-route-search.ts
+++ b/web/src/systems/vault/lib/vault-route-search.ts
@@ -8,6 +8,7 @@ export type VaultNamespaceFilter = VaultNamespace | "all";
 export interface VaultRouteSearch {
   q?: string;
   namespace?: VaultNamespace;
+  ref?: string;
   view?: ListingViewMode;
 }
 
@@ -31,9 +32,11 @@ export function parseVaultNamespaceFilter(value: unknown): VaultNamespace | unde
 
 export function validateVaultSearch(search: Record<string, unknown>): VaultRouteSearch {
   const namespace = parseVaultNamespaceFilter(search.namespace);
+  const ref = typeof search.ref === "string" ? search.ref.trim() || undefined : undefined;
   return {
     q: normalizeVaultPrefixForNamespace(search.q, namespace),
     namespace,
+    ref,
     view: parseListingView(search.view),
   };
 }

--- a/web/src/systems/vault/routes/vault-page.tsx
+++ b/web/src/systems/vault/routes/vault-page.tsx
@@ -127,7 +127,14 @@ export function VaultPage({ search = {} }: { search?: VaultRouteSearch }) {
         <span data-testid="vault-page-providers">{page.counts.providers} provider-scoped</span>
       </p>
 
-      {page.queryError && page.secrets.length === 0 ? (
+      {page.selectionError ? (
+        <Empty
+          data-testid="vault-page-selection-error"
+          description="The requested secret was deleted or is unavailable."
+          icon={AlertCircle}
+          title={page.selectionError}
+        />
+      ) : page.queryError && page.secrets.length === 0 ? (
         <Empty
           action={
             <Button


### PR DESCRIPTION
## Summary

Linear ENG-131: `[Web] Command palette actions should go direct`.

Concrete rows in the OS command palette now open the entity's identity-bearing detail/action target in one selection. Catalog commands remain catalog commands, while root search and pushed domain views share the same landing behavior.

## Root cause

Most domain row seeds used `searchRoute` or `tasksRoute`, which produced a catalog pathname with a `q`/`query` filter. The row therefore discarded the entity identity and made the operator select the same entity again. The two palette openers also had separate behavior, and foreign-workspace rows could be opened before the window-manager workspace fence was ready.

## Implementation

- Replaced catalog-plus-filter entity routes with explicit routes for Tasks, Loops, Jobs, Triggers, Bridges, Agents, Marketplace entries, Knowledge, Network channels, and existing session/tab targets.
- Removed the obsolete `searchRoute` and `tasksRoute` helpers.
- Added explicit row ownership and identifiers instead of parsing IDs back out of row keys.
- Added a shared root-owned domain opener used by both root and pushed views. It waits until the runtime workspace and the live window-manager snapshot agree, switches to the owning workspace for global rows, and reports refused/unreachable opens instead of silently falling back.
- Kept Worktree rows on the canonical scope-selection action, including the owning workspace.
- Added Vault `ref` route state so a concrete secret opens in the existing master/detail surface and missing or rejected inventory resolution is shown as an unavailable target.
- Routed installed Extensions through the existing Marketplace detail surface with entry and installed-name identity.
- Added the headline browser scenario and focused unit coverage for identity, similar names, global workspace ownership, stale window-manager state, pushed-view persistence, coordinator refusal, Vault selection, and Vault inventory failure.

## Review

A standalone GPT-5.6-Sol (high reasoning) review was run without the deep-review skill. All five actionable findings were addressed: root-owned pending state for pushed views, truthful QA scope, command/workspace readiness barriers, null coordinator results, and Vault rejected-inventory handling.

## Verification

Passed:

- `bunx turbo run lint typecheck --filter=compozy-web` (zero lint warnings/errors; typecheck and codegen-check passed).
- `bunx turbo run test --filter=compozy-web -- --run src/systems/os/components/__tests__/os-palette-view-stack.test.tsx src/systems/os/hooks/__tests__/use-os-palette-root.test.tsx src/systems/os/lib/__tests__/os-palette-domain-search.test.ts src/systems/vault/hooks/__tests__/use-vault-page.test.tsx src/systems/vault/lib/__tests__/vault-route-search.test.ts` (5 files, 82 tests).
- `git diff --check`.
- Isolated browser walk recorded in `docs/qa/reports/2026-08-24-eng-131-palette-direct.md`, with clean QA teardown evidence. The workspace Loop route and an independent deep link both rendered the same detail page.

`make gate` was run as requested. Its lint, typecheck, codegen, and web execution started cleanly, but the full web lane ended with one unrelated failure in `src/systems/os/hooks/__tests__/use-window-manager-stream.test.tsx` (`Should reconcile a removed workspace before opening the replacement stream`); the other 10 tests in that file passed, and the same failure reproduced in isolation. No unrelated production or test changes were made. `make verify` and `make gate-full` were intentionally not run per the task instruction; CI is expected to provide the full gate.

## Risks and follow-up

- The direct route now depends on the entity identifier and, for global rows, the owning workspace being present in the source projection. Deleted or unavailable targets show an explicit failure instead of a catalog fallback.
- The targeted QA scenario is marked pass only for the walked workspace-Loop journey; the adjacent broad palette scenarios remain explicitly untested rather than being over-claimed.
- The new E2E coverage is in `web/e2e/__tests__/os-shell.spec.ts` and will run in CI.

## Compozy Impact Audit

- **Native tools:** no impact. `compozy__cmd_palette_list`, `compozy__cmd_palette_invoke`, descriptors, schemas, capability gates, and digests are unchanged; only web row projection and routing changed.
- **Extensibility and hooks:** no runtime extension/config lifecycle change. Extension-contributed palette commands retain their existing dispatch path; installed extensions reuse the existing Marketplace detail surface. No `config.toml`, registry, hook, skill, resource, or bridge SDK changes.
- **Workspace data isolation:** in scope and covered. Global rows carry `workspaceId`; the shared opener switches to the owner and waits for both runtime and window-manager workspace identity before opening. Loop routes carry the workspace search parameter, Network/Knowledge keep their workspace parameters, and tests cover foreign-workspace routing and stale command snapshots.
- **Official Compozy skill:** no impact. No public tool ID, CLI path, hook event, capability, memory, or network contract changed, so `skills/compozy/` remains unchanged.