### PR TITLE
fix: classify settled spawned TTL cleanup correctly

### DIFF
--- a/docs/qa/reports/2026-08-24-eng-147-ttl-cleanup.md
+++ b/docs/qa/reports/2026-08-24-eng-147-ttl-cleanup.md
@@ -1,0 +1,85 @@
+# QA Run Report — 2026-08-24 — ENG-147 TTL cleanup
+
+- **Scope:** State-aware TTL cleanup for governed spawned sessions, including clean terminal projections, parent wake classification, timeout markers, lifecycle hooks, and lease/process teardown.
+- **Cadence tier:** targeted
+- **Build:** working tree after atomic-stop review · **Environment:** isolated Go lifecycle harness; no full-monorepo gate by request
+- **Started:** 2026-08-24T22:08:00-03:00 · **Status:** ready with blocked public-surface verification
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Ada | Power User | desktop / wifi-fast / en-US | CH-018 |
+
+## Flows in Scope
+
+- `J-15` — An agent drives and reads sessions deterministically over CLI, HTTP, or UDS (`../journeys/J-15-operate-session-via-cli-api.md`).
+- `RT-spawn-ttl-cleanup` — Reap settled and in-flight governed children with truthful terminal projections (`../scenarios/RT-spawn-ttl-cleanup.md`).
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-018 | J-15 / RT-spawn-ttl-cleanup | Ada | Feature Tour | Blocked (needs human verify) | Isolated ACP provider required for a public CLI/HTTP/UDS walk | |
+| 2 | CH-018 | J-respond-to-agent-attention / RT-session-spawn-wake | Ada | Feature Tour | Blocked (needs human verify) | Same provider-backed stopped-child wake walk required after TTL classification change | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-018 — Ada
+
+- **Ran:** focused automated lifecycle walk · **box respected:** yes
+- **Findings:** settled TTL cleanup classified as completed; active prompt classified as timeout; the
+  lifecycle contract recorded one stopped notifier and one clean parent wake with no timeout marker.
+- **Bugs filed/updated:** none
+- **Scenarios settled:** blocked-verify for both public-surface legs; automated evidence is recorded below
+- **Paper cuts:** none observed yet
+- **Surprises:** the runtime session manager can classify the TTL cause atomically under its lifecycle lock;
+  transport-only adapters conservatively retain timeout classification when prompt state is unknown.
+- **Suggested next charter:** supply an isolated ACP provider and re-walk `RT-spawn-ttl-cleanup` plus
+  `RT-session-spawn-wake` through CLI, HTTP, and UDS.
+
+## What Was Fixed
+
+### ENG-147: Settled child TTL cleanup was reported as a prompt timeout
+
+- **Symptom:** a child that had already settled was shown as failed and woke its parent with a failed outcome when TTL cleanup ran.
+- **Root cause:** the reaper treated every `ttl_expired` reason as `CauseTimeout`, regardless of the live prompt state.
+- **Fix:** classify TTL cleanup atomically at the session stop transition: a settled prompt maps to
+  completed, an in-flight prompt maps to timeout, and transport-only adapters use a conservative
+  timeout fallback; preserve the reaper origin on clean completion.
+- **Regression test:** `internal/daemon/spawn_reaper_test.go`; `internal/session/stop_reason_test.go`; `internal/session/manager_lifecycle_contract_test.go`
+- **Retested:** review findings addressed; focused daemon/session lifecycle tests pass.
+
+## Paper Cuts
+
+| Persona | Where (journey/step) | Felt | Sharpness | Outcome |
+|---|---|---|---|---|
+| Ada | J-15 / TTL cleanup | Structured lifecycle output must distinguish a clean TTL stop from a timeout without requiring transcript inspection. | dull | watching |
+
+## Runtime Errors Observed
+
+- None in focused lifecycle tests; public-surface walk pending.
+
+## Human Verifications Needed
+
+- [ ] Run a live provider-backed CLI/HTTP/UDS walk for both a settled `done`/`end_turn` child and a
+  genuinely in-flight prompt at TTL. Confirm list/status/events, parent wake badge, timeout marker,
+  lease release, process teardown, and exactly-once lifecycle hooks. This requires an isolated ACP
+  provider and a human operator; no provider-backed public surface was available in this review run.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- TTL expiry is a cleanup reason, not a failure classification by itself; prompt activity is the deciding runtime fact.
+
+## Final Status
+
+- **Exit gate (focused automated suite):** pass — `go test -race ./internal/daemon -run 'TestSpawnReaper' -count=1` (9 passed); `go test -race ./internal/session -run 'Test(ClassifyStopReason|SpawnTTLStopCauseUsesPromptStateAtLifecycleTransition|CompletedSpawnReapKeepsCleanTerminalProjection|PromptActivitySupervisorTimeoutCancelsThenStopsSession)$' -count=1` (22 passed); new-code golangci-lint (`--new-from-rev origin/main`) reported 0 issues. Full-monorepo gates were not run per the ENG-147 request.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 0/2 public journeys walked; both are `blocked-verify` with exact provider-backed instructions. Automated lifecycle evidence covers the runtime invariant.
+- **Verdict:** ready with blocked public-surface verification — do not treat the blocked rows as a provider-backed pass.

--- a/docs/qa/scenarios/RT-session-spawn-wake.md
+++ b/docs/qa/scenarios/RT-session-spawn-wake.md
@@ -6,13 +6,13 @@ persona: Cora
 journey: J-respond-to-agent-attention
 expected: A governed child that stops, fails, or enters a needs-you state queues one sanitized synthetic turn on its live parent by default, never interrupts an active parent prompt, and explicit notify_creator false suppresses only that child's wake with an auditable reason.
 entry_points: compozy spawn --no-notify-creator; POST /api/agent/spawn over HTTP and UDS; compozy__session_spawn; parent session transcript
-qa_status: pass
+qa_status: blocked-verify
 bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence: docs/qa/reports/2026-08-16-herdr-parity.md; /Users/pedronauck/dev/qa-labs/compozy-northstar-pay-20260816-141901-835450-lab/qa-artifacts/qa/screenshots/herdr-cross-workspace-needs-you-fixed.png; /Users/pedronauck/dev/qa-labs/compozy-northstar-pay-20260816-141901-835450-lab/qa-artifacts/qa/screenshots/herdr-attention-all-quiet-cleared.png; .compozy/tasks/herdr-parity/evidence/visual/task_03
-last_report: docs/qa/reports/2026-08-16-herdr-parity.md
+evidence: docs/qa/reports/2026-08-16-herdr-parity.md; internal/session/manager_lifecycle_contract_test.go
+last_report: docs/qa/reports/2026-08-24-eng-147-ttl-cleanup.md
 overlaps: RT-session-wait-state; RT-session-done-presence
 ---
 
@@ -24,5 +24,9 @@ disabled notification, self-wake, dead parent, and failed delivery.
 
 QA impact 2026-08-16: Task 04 added the default-on governed-child wake bridge and presence-aware
 opt-out on every spawn surface. Flag only; task_08 owns execution.
+
+QA impact 2026-08-24: ENG-147 changes the stopped-child wake classification for settled TTL
+cleanup. The focused lifecycle contract verifies one clean stopped wake; a provider-backed
+public-surface walk remains blocked pending an isolated ACP provider and human verification.
 
 QA 2026-08-16 Herdr parity: The isolated browser journey, focused attention Playwright lane, and full Web E2E exercised cross-workspace landing, permission resolution, counts, channel suppression, task canary, catalog scope/order, finished presence clearing, and honest quiet/stale states. The lab browser exposed its real notification capability; deterministic granted and denied branches ran in the canonical browser suite.

--- a/docs/qa/scenarios/RT-spawn-ttl-cleanup.md
+++ b/docs/qa/scenarios/RT-spawn-ttl-cleanup.md
@@ -1,0 +1,28 @@
+---
+id: RT-spawn-ttl-cleanup
+area: RT
+title: Reap a settled child without timeout noise
+persona: Ada
+journey: J-15
+expected: When a governed child reaches its TTL, a settled prompt is shown as a clean stopped session with the spawn origin and one stopped parent wake, while an in-flight prompt is shown as a timeout with one failure wake and one timeout marker.
+entry_points: compozy spawn; POST /api/agent/spawn; compozy__session_spawn; compozy session list/status/events
+qa_status: blocked-verify
+bug_ids:
+fix_status:
+retest_status:
+fix_commits:
+evidence: internal/daemon/spawn_reaper_test.go; internal/session/stop_reason_test.go; internal/session/manager_lifecycle_contract_test.go
+last_report: docs/qa/reports/2026-08-24-eng-147-ttl-cleanup.md
+overlaps: RT-session-spawn-wake; RT-session-done-presence
+---
+
+Create a governed child through a structured surface with a short TTL. Walk one child after its
+prompt settles with `done` or `end_turn`, and one while its prompt is still active when the reaper
+deadline passes. Compare list, detail, status, transcript markers, parent wake reason, lease release,
+and lifecycle hook records. Confirm both paths retain `spawn_reaper:ttl_expired`, process teardown,
+and exactly-once `spawn.ttl_expired`, `spawn.reaped`, and session stop hooks; only the active-prompt
+path may carry a timeout failure, timeout marker, or failed parent wake.
+
+Automated lifecycle evidence covers both classifications and exact-once in-process effects. A
+provider-backed CLI/HTTP/UDS walk remains blocked until a human supplies an isolated ACP provider
+and confirms the settled and genuinely in-flight prompt paths through public surfaces.

--- a/internal/daemon/spawn_reaper.go
+++ b/internal/daemon/spawn_reaper.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 	"time"
 
-	hookspkg "github.com/compozy/compozy/internal/hooks"
-	"github.com/compozy/compozy/internal/network/participation"
 	"github.com/compozy/compozy/internal/session"
 	"github.com/compozy/compozy/internal/store"
 	taskpkg "github.com/compozy/compozy/internal/task"
@@ -31,6 +29,14 @@ type spawnLeaseReleaser interface {
 		taskpkg.ActorContext,
 	) ([]taskpkg.SessionLeaseReleaseResult, error)
 }
+
+// spawnReaperTTLStopper lets the concrete session manager classify prompt
+// state under its lifecycle lock instead of relying on a stale sweep snapshot.
+type spawnReaperTTLStopper interface {
+	StopWithSpawnTTL(context.Context, string, string) error
+}
+
+var _ spawnReaperTTLStopper = (*session.Manager)(nil)
 
 type spawnReaper struct {
 	ctx      context.Context
@@ -320,9 +326,25 @@ func (r *spawnReaper) releaseChildLeases(ctx context.Context, child *session.Inf
 	return len(results), nil
 }
 
-func (r *spawnReaper) stopChild(ctx context.Context, child *session.Info, reason string) error {
+func (r *spawnReaper) stopChild(
+	ctx context.Context,
+	child *session.Info,
+	reason string,
+) error {
+	if reason == spawnReapReasonTTLExpired {
+		if stopper, ok := r.sessions.(spawnReaperTTLStopper); ok {
+			err := stopper.StopWithSpawnTTL(ctx, child.ID, "spawn_reaper:"+reason)
+			if errors.Is(err, session.ErrSessionNotFound) {
+				return nil
+			}
+			return err
+		}
+	}
 	cause := session.CauseUserRequested
 	if reason == spawnReapReasonTTLExpired {
+		// Adapters that do not provide the atomic operation cannot prove that a
+		// prompt stayed settled through the stop transition. Preserve the
+		// historical timeout classification rather than risk a false clean stop.
 		cause = session.CauseTimeout
 	}
 	err := r.sessions.StopWithCause(ctx, child.ID, cause, "spawn_reaper:"+reason)
@@ -330,150 +352,4 @@ func (r *spawnReaper) stopChild(ctx context.Context, child *session.Info, reason
 		return nil
 	}
 	return err
-}
-
-func (r *spawnReaper) dispatchReasonHook(ctx context.Context, candidate spawnReapCandidate) {
-	payload := r.spawnLifecyclePayload(candidate, nil)
-	var err error
-	switch candidate.reason {
-	case spawnReapReasonTTLExpired:
-		payload.Event = hookspkg.HookSpawnTTLExpired
-		_, err = r.hooksOrNoop().DispatchSpawnTTLExpired(ctx, payload)
-	case spawnReapReasonParentStopped:
-		payload.Event = hookspkg.HookSpawnParentStopped
-		_, err = r.hooksOrNoop().DispatchSpawnParentStopped(ctx, payload)
-	}
-	if err != nil && r.logger != nil {
-		r.logger.Warn("daemon: spawn lifecycle hook failed", "event", payload.Event, "error", err)
-	}
-}
-
-func (r *spawnReaper) dispatchReapedHook(ctx context.Context, candidate spawnReapCandidate, reapErr error) {
-	payload := r.spawnLifecyclePayload(candidate, reapErr)
-	payload.Event = hookspkg.HookSpawnReaped
-	if _, err := r.hooksOrNoop().DispatchSpawnReaped(ctx, payload); err != nil &&
-		r.logger != nil {
-		r.logger.Warn("daemon: spawn reaped hook failed", "error", err)
-	}
-}
-
-func (r *spawnReaper) spawnLifecyclePayload(
-	candidate spawnReapCandidate,
-	reapErr error,
-) hookspkg.SpawnLifecyclePayload {
-	child := candidate.child
-	lineage := store.NormalizeSessionLineage("", nil)
-	if child != nil {
-		lineage = store.NormalizeSessionLineage(child.ID, child.Lineage)
-	}
-	payload := hookspkg.SpawnLifecyclePayload{
-		PayloadBase: hookspkg.PayloadBase{Timestamp: r.now().UTC()},
-		SpawnContext: hookspkg.SpawnContext{
-			ParentSessionID:  lineage.ParentSessionID,
-			RootSessionID:    lineage.RootSessionID,
-			SpawnDepth:       lineage.SpawnDepth,
-			SpawnRole:        lineage.SpawnRole,
-			TTLSeconds:       lineage.SpawnBudget.TTLSeconds,
-			AutoStopOnParent: lineage.AutoStopOnParent,
-		},
-		ChildPermissions: spawnReaperPermissionSet(lineage.PermissionPolicy),
-		StopReason:       candidate.reason,
-		ReapReason:       candidate.reason,
-	}
-	if candidate.parent != nil {
-		payload.ProfileID = strings.TrimSpace(candidate.parent.ProfileID)
-	}
-	if child != nil {
-		payload.ProfileID = strings.TrimSpace(child.ProfileID)
-		payload.ChildSessionID = child.ID
-		payload.AgentName = child.AgentName
-		payload.WorkspaceID = child.WorkspaceID
-		payload.Workspace = child.Workspace
-		payload.ResolvedNetworkParticipation = participation.CloneSpec(child.NetworkParticipation)
-		payload.SoulSnapshotID = child.SoulSnapshotID
-		payload.SoulDigest = child.SoulDigest
-		payload.ParentSoulDigest = child.ParentSoulDigest
-	}
-	if candidate.parent != nil {
-		if payload.ResolvedNetworkParticipation == nil {
-			payload.ResolvedNetworkParticipation = participation.CloneSpec(
-				candidate.parent.NetworkParticipation,
-			)
-		}
-		if strings.TrimSpace(payload.ParentSoulDigest) == "" {
-			payload.ParentSoulDigest = candidate.parent.SoulDigest
-		}
-		if candidate.parent.Lineage != nil {
-			payload.ParentPermissions = spawnReaperPermissionSet(candidate.parent.Lineage.PermissionPolicy)
-		}
-	}
-	if reapErr != nil {
-		payload.Error = reapErr.Error()
-	}
-	return payload
-}
-
-func (r *spawnReaper) hooksOrNoop() session.SpawnHooks {
-	if r == nil || r.hooks == nil {
-		return spawnReaperNoopHooks{}
-	}
-	return r.hooks
-}
-
-func spawnReaperPermissionSet(policy store.SessionPermissionPolicy) *hookspkg.PermissionSet {
-	normalized := store.NormalizeSessionPermissionPolicy(policy)
-	return &hookspkg.PermissionSet{
-		Tools:           append([]string(nil), normalized.Tools...),
-		Skills:          append([]string(nil), normalized.Skills...),
-		MCPServers:      append([]string(nil), normalized.MCPServers...),
-		WorkspacePaths:  append([]string(nil), normalized.WorkspacePaths...),
-		NetworkChannels: append([]string(nil), normalized.NetworkChannels...),
-		SandboxProfiles: append([]string(nil), normalized.SandboxProfiles...),
-	}
-}
-
-func spawnReaperLiveState(state session.State) bool {
-	switch state {
-	case session.StateStarting, session.StateActive, session.StateStopping:
-		return true
-	default:
-		return false
-	}
-}
-
-type spawnReaperNoopHooks struct{}
-
-func (spawnReaperNoopHooks) DispatchSpawnPreCreate(
-	_ context.Context,
-	payload hookspkg.SpawnPreCreatePayload,
-) (hookspkg.SpawnPreCreatePayload, error) {
-	return payload, nil
-}
-
-func (spawnReaperNoopHooks) DispatchSpawnCreated(
-	_ context.Context,
-	payload hookspkg.SpawnCreatedPayload,
-) (hookspkg.SpawnCreatedPayload, error) {
-	return payload, nil
-}
-
-func (spawnReaperNoopHooks) DispatchSpawnParentStopped(
-	_ context.Context,
-	payload hookspkg.SpawnParentStoppedPayload,
-) (hookspkg.SpawnParentStoppedPayload, error) {
-	return payload, nil
-}
-
-func (spawnReaperNoopHooks) DispatchSpawnTTLExpired(
-	_ context.Context,
-	payload hookspkg.SpawnTTLExpiredPayload,
-) (hookspkg.SpawnTTLExpiredPayload, error) {
-	return payload, nil
-}
-
-func (spawnReaperNoopHooks) DispatchSpawnReaped(
-	_ context.Context,
-	payload hookspkg.SpawnReapedPayload,
-) (hookspkg.SpawnReapedPayload, error) {
-	return payload, nil
 }

--- a/internal/daemon/spawn_reaper_hooks.go
+++ b/internal/daemon/spawn_reaper_hooks.go
@@ -1,0 +1,157 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+
+	hookspkg "github.com/compozy/compozy/internal/hooks"
+	"github.com/compozy/compozy/internal/network/participation"
+	"github.com/compozy/compozy/internal/session"
+	"github.com/compozy/compozy/internal/store"
+)
+
+func (r *spawnReaper) dispatchReasonHook(ctx context.Context, candidate spawnReapCandidate) {
+	payload := r.spawnLifecyclePayload(candidate, nil)
+	var err error
+	switch candidate.reason {
+	case spawnReapReasonTTLExpired:
+		payload.Event = hookspkg.HookSpawnTTLExpired
+		_, err = r.hooksOrNoop().DispatchSpawnTTLExpired(ctx, payload)
+	case spawnReapReasonParentStopped:
+		payload.Event = hookspkg.HookSpawnParentStopped
+		_, err = r.hooksOrNoop().DispatchSpawnParentStopped(ctx, payload)
+	}
+	if err != nil && r.logger != nil {
+		r.logger.Warn("daemon: spawn lifecycle hook failed", "event", payload.Event, "error", err)
+	}
+}
+
+func (r *spawnReaper) dispatchReapedHook(ctx context.Context, candidate spawnReapCandidate, reapErr error) {
+	payload := r.spawnLifecyclePayload(candidate, reapErr)
+	payload.Event = hookspkg.HookSpawnReaped
+	if _, err := r.hooksOrNoop().DispatchSpawnReaped(ctx, payload); err != nil &&
+		r.logger != nil {
+		r.logger.Warn("daemon: spawn reaped hook failed", "error", err)
+	}
+}
+
+func (r *spawnReaper) spawnLifecyclePayload(
+	candidate spawnReapCandidate,
+	reapErr error,
+) hookspkg.SpawnLifecyclePayload {
+	child := candidate.child
+	lineage := store.NormalizeSessionLineage("", nil)
+	if child != nil {
+		lineage = store.NormalizeSessionLineage(child.ID, child.Lineage)
+	}
+	payload := hookspkg.SpawnLifecyclePayload{
+		PayloadBase: hookspkg.PayloadBase{Timestamp: r.now().UTC()},
+		SpawnContext: hookspkg.SpawnContext{
+			ParentSessionID:  lineage.ParentSessionID,
+			RootSessionID:    lineage.RootSessionID,
+			SpawnDepth:       lineage.SpawnDepth,
+			SpawnRole:        lineage.SpawnRole,
+			TTLSeconds:       lineage.SpawnBudget.TTLSeconds,
+			AutoStopOnParent: lineage.AutoStopOnParent,
+		},
+		ChildPermissions: spawnReaperPermissionSet(lineage.PermissionPolicy),
+		StopReason:       candidate.reason,
+		ReapReason:       candidate.reason,
+	}
+	if candidate.parent != nil {
+		payload.ProfileID = strings.TrimSpace(candidate.parent.ProfileID)
+	}
+	if child != nil {
+		payload.ProfileID = strings.TrimSpace(child.ProfileID)
+		payload.ChildSessionID = child.ID
+		payload.AgentName = child.AgentName
+		payload.WorkspaceID = child.WorkspaceID
+		payload.Workspace = child.Workspace
+		payload.ResolvedNetworkParticipation = participation.CloneSpec(child.NetworkParticipation)
+		payload.SoulSnapshotID = child.SoulSnapshotID
+		payload.SoulDigest = child.SoulDigest
+		payload.ParentSoulDigest = child.ParentSoulDigest
+	}
+	if candidate.parent != nil {
+		if payload.ResolvedNetworkParticipation == nil {
+			payload.ResolvedNetworkParticipation = participation.CloneSpec(
+				candidate.parent.NetworkParticipation,
+			)
+		}
+		if strings.TrimSpace(payload.ParentSoulDigest) == "" {
+			payload.ParentSoulDigest = candidate.parent.SoulDigest
+		}
+		if candidate.parent.Lineage != nil {
+			payload.ParentPermissions = spawnReaperPermissionSet(candidate.parent.Lineage.PermissionPolicy)
+		}
+	}
+	if reapErr != nil {
+		payload.Error = reapErr.Error()
+	}
+	return payload
+}
+
+func (r *spawnReaper) hooksOrNoop() session.SpawnHooks {
+	if r == nil || r.hooks == nil {
+		return spawnReaperNoopHooks{}
+	}
+	return r.hooks
+}
+
+func spawnReaperPermissionSet(policy store.SessionPermissionPolicy) *hookspkg.PermissionSet {
+	normalized := store.NormalizeSessionPermissionPolicy(policy)
+	return &hookspkg.PermissionSet{
+		Tools:           append([]string(nil), normalized.Tools...),
+		Skills:          append([]string(nil), normalized.Skills...),
+		MCPServers:      append([]string(nil), normalized.MCPServers...),
+		WorkspacePaths:  append([]string(nil), normalized.WorkspacePaths...),
+		NetworkChannels: append([]string(nil), normalized.NetworkChannels...),
+		SandboxProfiles: append([]string(nil), normalized.SandboxProfiles...),
+	}
+}
+
+func spawnReaperLiveState(state session.State) bool {
+	switch state {
+	case session.StateStarting, session.StateActive, session.StateStopping:
+		return true
+	default:
+		return false
+	}
+}
+
+type spawnReaperNoopHooks struct{}
+
+func (spawnReaperNoopHooks) DispatchSpawnPreCreate(
+	_ context.Context,
+	payload hookspkg.SpawnPreCreatePayload,
+) (hookspkg.SpawnPreCreatePayload, error) {
+	return payload, nil
+}
+
+func (spawnReaperNoopHooks) DispatchSpawnCreated(
+	_ context.Context,
+	payload hookspkg.SpawnCreatedPayload,
+) (hookspkg.SpawnCreatedPayload, error) {
+	return payload, nil
+}
+
+func (spawnReaperNoopHooks) DispatchSpawnParentStopped(
+	_ context.Context,
+	payload hookspkg.SpawnParentStoppedPayload,
+) (hookspkg.SpawnParentStoppedPayload, error) {
+	return payload, nil
+}
+
+func (spawnReaperNoopHooks) DispatchSpawnTTLExpired(
+	_ context.Context,
+	payload hookspkg.SpawnTTLExpiredPayload,
+) (hookspkg.SpawnTTLExpiredPayload, error) {
+	return payload, nil
+}
+
+func (spawnReaperNoopHooks) DispatchSpawnReaped(
+	_ context.Context,
+	payload hookspkg.SpawnReapedPayload,
+) (hookspkg.SpawnReapedPayload, error) {
+	return payload, nil
+}

--- a/internal/daemon/spawn_reaper_test.go
+++ b/internal/daemon/spawn_reaper_test.go
@@ -13,104 +13,107 @@ import (
 
 func TestSpawnReaperSweepClassifiesReasonsReleasesLeasesAndStopsChildren(t *testing.T) {
 	t.Parallel()
+	t.Run("Should classify reasons, release leases, and stop children", func(t *testing.T) {
+		t.Parallel()
 
-	now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
-	expired := now.Add(-time.Minute)
-	future := now.Add(time.Hour)
-	sequence := make([]string, 0)
-	sessions := &fakeSessionManager{
-		infos: []*session.Info{
-			rootReaperInfo("parent-live", session.StateActive),
-			rootReaperInfo("parent-stopped", session.StateStopped),
-			spawnedReaperInfo("child-ttl", "parent-live", expired, true),
-			spawnedReaperInfo("child-parent", "parent-stopped", future, true),
-			spawnedReaperInfo("child-orphan", "missing-parent", future, true),
-			rootReaperInfo("manual", session.StateActive),
-			provenanceReaperInfo("provenance-child", "parent-stopped"),
-			provenanceReaperInfo("provenance-orphan", "missing-parent"),
-		},
-		stopWithCauseErr: func(id string, _ session.StopCause, _ string) error {
-			sequence = append(sequence, "stop:"+id)
-			return nil
-		},
-	}
-	leases := &fakeSpawnLeaseReleaser{
-		resultCountBySession: map[string]int{
-			"child-ttl":    2,
-			"child-parent": 1,
-		},
-		sequence: &sequence,
-	}
-	hooks := &recordingSpawnHooks{}
+		now := time.Date(2026, 4, 26, 12, 0, 0, 0, time.UTC)
+		expired := now.Add(-time.Minute)
+		future := now.Add(time.Hour)
+		sequence := make([]string, 0)
+		sessions := &fakeSessionManager{
+			infos: []*session.Info{
+				rootReaperInfo("parent-live", session.StateActive),
+				rootReaperInfo("parent-stopped", session.StateStopped),
+				spawnedReaperInfo("child-ttl", "parent-live", expired, true),
+				spawnedReaperInfo("child-parent", "parent-stopped", future, true),
+				spawnedReaperInfo("child-orphan", "missing-parent", future, true),
+				rootReaperInfo("manual", session.StateActive),
+				provenanceReaperInfo("provenance-child", "parent-stopped"),
+				provenanceReaperInfo("provenance-orphan", "missing-parent"),
+			},
+			stopWithCauseErr: func(id string, _ session.StopCause, _ string) error {
+				sequence = append(sequence, "stop:"+id)
+				return nil
+			},
+		}
+		leases := &fakeSpawnLeaseReleaser{
+			resultCountBySession: map[string]int{
+				"child-ttl":    2,
+				"child-parent": 1,
+			},
+			sequence: &sequence,
+		}
+		hooks := &recordingSpawnHooks{}
 
-	reaper, err := newSpawnReaper(
-		context.Background(),
-		sessions,
-		leases,
-		hooks,
-		discardLogger(),
-		func() time.Time { return now },
-		time.Hour,
-	)
-	if err != nil {
-		t.Fatalf("newSpawnReaper() error = %v", err)
-	}
-
-	report, err := reaper.Sweep(context.Background())
-	if err != nil {
-		t.Fatalf("Sweep() error = %v", err)
-	}
-	if report.Checked != 3 ||
-		report.Reaped != 3 ||
-		report.ReleasedLeases != 3 ||
-		report.TTLExpired != 1 ||
-		report.ParentStopped != 1 ||
-		report.Orphaned != 1 {
-		t.Fatalf("report = %#v, want three classified reaps and three released leases", report)
-	}
-	if len(sessions.stopWithCauseCalls) != 3 {
-		t.Fatalf(
-			"stop calls = %#v, want only spawned children reaped and provenance user sessions left alone",
-			sessions.stopWithCauseCalls,
+		reaper, err := newSpawnReaper(
+			context.Background(),
+			sessions,
+			leases,
+			hooks,
+			discardLogger(),
+			func() time.Time { return now },
+			time.Hour,
 		)
-	}
-	assertStopWithCause(t, sessions.stopWithCauseCalls, "child-ttl", session.CauseTimeout, "spawn_reaper:ttl_expired")
-	assertStopWithCause(
-		t,
-		sessions.stopWithCauseCalls,
-		"child-parent",
-		session.CauseUserRequested,
-		"spawn_reaper:parent_stopped",
-	)
-	assertStopWithCause(
-		t,
-		sessions.stopWithCauseCalls,
-		"child-orphan",
-		session.CauseUserRequested,
-		"spawn_reaper:orphaned",
-	)
-	if got, want := sequence, []string{
-		"release:child-ttl",
-		"stop:child-ttl",
-		"release:child-parent",
-		"stop:child-parent",
-		"release:child-orphan",
-		"stop:child-orphan",
-	}; !equalStrings(got, want) {
-		t.Fatalf("sequence = %#v, want release before stop for each child %#v", got, want)
-	}
-	assertReleaseReason(t, leases.releases, "child-ttl", spawnReapReasonTTLExpired)
-	assertReleaseReason(t, leases.releases, "child-parent", spawnReapReasonParentStopped)
-	assertReleaseReason(t, leases.releases, "child-orphan", spawnReapReasonOrphaned)
-	if len(hooks.ttlExpired) != 1 || hooks.ttlExpired[0].ChildSessionID != "child-ttl" {
-		t.Fatalf("ttl hooks = %#v, want child-ttl", hooks.ttlExpired)
-	}
-	if len(hooks.parentStopped) != 1 || hooks.parentStopped[0].ChildSessionID != "child-parent" {
-		t.Fatalf("parent stopped hooks = %#v, want child-parent", hooks.parentStopped)
-	}
-	if len(hooks.reaped) != 3 {
-		t.Fatalf("reaped hooks = %#v, want three", hooks.reaped)
-	}
+		if err != nil {
+			t.Fatalf("newSpawnReaper() error = %v", err)
+		}
+
+		report, err := reaper.Sweep(context.Background())
+		if err != nil {
+			t.Fatalf("Sweep() error = %v", err)
+		}
+		if report.Checked != 3 ||
+			report.Reaped != 3 ||
+			report.ReleasedLeases != 3 ||
+			report.TTLExpired != 1 ||
+			report.ParentStopped != 1 ||
+			report.Orphaned != 1 {
+			t.Fatalf("report = %#v, want three classified reaps and three released leases", report)
+		}
+		if len(sessions.stopWithCauseCalls) != 3 {
+			t.Fatalf(
+				"stop calls = %#v, want only spawned children reaped and provenance user sessions left alone",
+				sessions.stopWithCauseCalls,
+			)
+		}
+		assertStopWithCause(t, sessions.stopWithCauseCalls, "child-ttl", session.CauseTimeout, "spawn_reaper:ttl_expired")
+		assertStopWithCause(
+			t,
+			sessions.stopWithCauseCalls,
+			"child-parent",
+			session.CauseUserRequested,
+			"spawn_reaper:parent_stopped",
+		)
+		assertStopWithCause(
+			t,
+			sessions.stopWithCauseCalls,
+			"child-orphan",
+			session.CauseUserRequested,
+			"spawn_reaper:orphaned",
+		)
+		if got, want := sequence, []string{
+			"release:child-ttl",
+			"stop:child-ttl",
+			"release:child-parent",
+			"stop:child-parent",
+			"release:child-orphan",
+			"stop:child-orphan",
+		}; !equalStrings(got, want) {
+			t.Fatalf("sequence = %#v, want release before stop for each child %#v", got, want)
+		}
+		assertReleaseReason(t, leases.releases, "child-ttl", spawnReapReasonTTLExpired)
+		assertReleaseReason(t, leases.releases, "child-parent", spawnReapReasonParentStopped)
+		assertReleaseReason(t, leases.releases, "child-orphan", spawnReapReasonOrphaned)
+		if len(hooks.ttlExpired) != 1 || hooks.ttlExpired[0].ChildSessionID != "child-ttl" {
+			t.Fatalf("ttl hooks = %#v, want child-ttl", hooks.ttlExpired)
+		}
+		if len(hooks.parentStopped) != 1 || hooks.parentStopped[0].ChildSessionID != "child-parent" {
+			t.Fatalf("parent stopped hooks = %#v, want child-parent", hooks.parentStopped)
+		}
+		if len(hooks.reaped) != 3 {
+			t.Fatalf("reaped hooks = %#v, want three", hooks.reaped)
+		}
+	})
 }
 
 func TestSpawnReaperReapsTTLExpiredStarvationWorkers(t *testing.T) {
@@ -161,6 +164,136 @@ func TestSpawnReaperReapsTTLExpiredStarvationWorkers(t *testing.T) {
 			"spawn_reaper:ttl_expired",
 		)
 	})
+}
+
+func TestSpawnReaperTTLClassification(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		prompting bool
+		wantCause session.StopCause
+	}{
+		{
+			name:      "Should reap a settled child as completed",
+			wantCause: session.CauseCompleted,
+		},
+		{
+			name:      "Should keep an in-flight prompt as a timeout",
+			prompting: true,
+			wantCause: session.CauseTimeout,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hooks := &recordingSpawnHooks{}
+			leases := &fakeSpawnLeaseReleaser{resultCountBySession: map[string]int{"child": 1}}
+			sessions := &spawnReaperAtomicSessionManager{
+				fakeSessionManager: &fakeSessionManager{
+					infos: []*session.Info{
+						rootReaperInfo("parent", session.StateActive),
+						spawnedReaperInfo("child", "parent", now.Add(-time.Minute), true),
+					},
+				},
+				prompting: map[string]bool{"child": tt.prompting},
+			}
+			reaper, err := newSpawnReaper(
+				context.Background(),
+				sessions,
+				leases,
+				hooks,
+				discardLogger(),
+				func() time.Time { return now },
+				time.Hour,
+			)
+			if err != nil {
+				t.Fatalf("newSpawnReaper() error = %v", err)
+			}
+
+			if _, err := reaper.Sweep(context.Background()); err != nil {
+				t.Fatalf("Sweep() error = %v", err)
+			}
+			assertStopWithCause(
+				t,
+				sessions.ttlStopCalls,
+				"child",
+				tt.wantCause,
+				"spawn_reaper:ttl_expired",
+			)
+			if got := len(sessions.ttlStopCalls); got != 1 {
+				t.Fatalf("atomic TTL stop calls = %d, want exactly one", got)
+			}
+			if got := len(sessions.stopWithCauseCalls); got != 0 {
+				t.Fatalf("fallback stop calls = %d, want zero when atomic TTL stop is available", got)
+			}
+			if got := len(leases.releases); got != 1 {
+				t.Fatalf("lease releases = %d, want exactly one", got)
+			}
+			assertReleaseReason(t, leases.releases, "child", spawnReapReasonTTLExpired)
+			if len(hooks.ttlExpired) != 1 || len(hooks.reaped) != 1 {
+				t.Fatalf("lifecycle hooks = ttl=%d reaped=%d, want one each", len(hooks.ttlExpired), len(hooks.reaped))
+			}
+		})
+	}
+}
+
+func TestSpawnReaperTTLWithoutAtomicStopperUsesTimeoutFallback(t *testing.T) {
+	t.Parallel()
+	t.Run("Should preserve timeout classification without atomic stop", func(t *testing.T) {
+		t.Parallel()
+
+		now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+		sessions := &fakeSessionManager{infos: []*session.Info{
+			rootReaperInfo("parent", session.StateActive),
+			spawnedReaperInfo("child", "parent", now.Add(-time.Minute), true),
+		}}
+		reaper, err := newSpawnReaper(
+			context.Background(),
+			sessions,
+			&fakeSpawnLeaseReleaser{},
+			&recordingSpawnHooks{},
+			discardLogger(),
+			func() time.Time { return now },
+			time.Hour,
+		)
+		if err != nil {
+			t.Fatalf("newSpawnReaper() error = %v", err)
+		}
+		if _, err := reaper.Sweep(context.Background()); err != nil {
+			t.Fatalf("Sweep() error = %v", err)
+		}
+		assertStopWithCause(
+			t,
+			sessions.stopWithCauseCalls,
+			"child",
+			session.CauseTimeout,
+			"spawn_reaper:ttl_expired",
+		)
+	})
+}
+
+type spawnReaperAtomicSessionManager struct {
+	*fakeSessionManager
+	prompting    map[string]bool
+	ttlStopCalls []fakeStopWithCauseCall
+}
+
+func (m *spawnReaperAtomicSessionManager) StopWithSpawnTTL(
+	_ context.Context,
+	id string,
+	detail string,
+) error {
+	cause := session.CauseCompleted
+	if m.prompting[id] {
+		cause = session.CauseTimeout
+	}
+	m.ttlStopCalls = append(m.ttlStopCalls, fakeStopWithCauseCall{
+		id: id, cause: cause, detail: detail,
+	})
+	return nil
 }
 
 func starvationReaperInfo(id string, ttl time.Time) *session.Info {

--- a/internal/daemon/spawn_reaper_test.go
+++ b/internal/daemon/spawn_reaper_test.go
@@ -76,7 +76,13 @@ func TestSpawnReaperSweepClassifiesReasonsReleasesLeasesAndStopsChildren(t *test
 				sessions.stopWithCauseCalls,
 			)
 		}
-		assertStopWithCause(t, sessions.stopWithCauseCalls, "child-ttl", session.CauseTimeout, "spawn_reaper:ttl_expired")
+		assertStopWithCause(
+			t,
+			sessions.stopWithCauseCalls,
+			"child-ttl",
+			session.CauseTimeout,
+			"spawn_reaper:ttl_expired",
+		)
 		assertStopWithCause(
 			t,
 			sessions.stopWithCauseCalls,

--- a/internal/session/manager_lifecycle_contract_test.go
+++ b/internal/session/manager_lifecycle_contract_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/compozy/compozy/internal/store"
 	"github.com/compozy/compozy/internal/store/sessiondb"
 	"github.com/compozy/compozy/internal/testutil"
+	"github.com/compozy/compozy/internal/transcript"
 )
 
 func TestStopTransitionsToStoppedAndNotifies(t *testing.T) {
@@ -54,6 +55,59 @@ func TestStopTransitionsToStoppedAndNotifies(t *testing.T) {
 	if got, want := stopPayload["stop_reason"], string(store.StopUserCanceled); got != want {
 		t.Fatalf("session_stopped stop_reason = %v, want %q", got, want)
 	}
+}
+
+func TestCompletedSpawnReapKeepsCleanTerminalProjection(t *testing.T) {
+	t.Parallel()
+	t.Run("Should keep a settled TTL reap clean across lifecycle projections", func(t *testing.T) {
+		t.Parallel()
+
+		wakeNotifier := &recordingSpawnWakeNotifier{}
+		h := newHarness(t, WithSpawnWakeNotifier(wakeNotifier), WithSessionCatalog(newRecordingSessionCatalog()))
+		parent := createSession(t, h)
+		child, err := h.manager.Spawn(testutil.Context(t), SpawnOpts{
+			ParentSessionID: parent.ID,
+			AgentName:       "coder",
+			Name:            "spawned-child",
+			TTL:             time.Minute,
+		})
+		if err != nil {
+			t.Fatalf("Spawn() error = %v", err)
+		}
+
+		if err := h.manager.StopWithSpawnTTL(
+			testutil.Context(t),
+			child.ID,
+			"spawn_reaper:ttl_expired",
+		); err != nil {
+			t.Fatalf("StopWithSpawnTTL() error = %v", err)
+		}
+
+		meta := readMeta(t, child.MetaPath())
+		if meta.StopReason == nil || *meta.StopReason != store.StopCompleted {
+			t.Fatalf("meta.StopReason = %#v, want %q", meta.StopReason, store.StopCompleted)
+		}
+		if got, want := meta.StopDetail, "spawn_reaper:ttl_expired"; got != want {
+			t.Fatalf("meta.StopDetail = %q, want %q", got, want)
+		}
+		if meta.Failure != nil {
+			t.Fatalf("meta.Failure = %#v, want nil for clean TTL reap", meta.Failure)
+		}
+		if got := countTranscriptMarkers(t, h.manager, child.ID, transcript.MarkerPromptTimeout); got != 0 {
+			t.Fatalf("prompt timeout markers = %d, want 0 for clean TTL reap", got)
+		}
+		if got := h.notifier.stoppedCount(); got != 1 {
+			t.Fatalf("stopped notifications = %d, want 1", got)
+		}
+		parents, events := wakeNotifier.calls()
+		if len(events) != 1 || len(parents) != 1 {
+			t.Fatalf("spawn wakes = parents %#v events %#v, want one clean wake", parents, events)
+		}
+		if parents[0] != parent.ID || events[0].Reason != SpawnWakeReasonStopped ||
+			events[0].Badge != BadgeStopped {
+			t.Fatalf("spawn wake = parents %#v events %#v, want stopped wake", parents, events)
+		}
+	})
 }
 
 func TestActivateAndWatchUpdatesStateAndStartsWatcher(t *testing.T) {

--- a/internal/session/session_stop_state.go
+++ b/internal/session/session_stop_state.go
@@ -130,6 +130,7 @@ func (s *Session) prepareStop(now time.Time, cause StopCause, detail string) (bo
 	if s.promptSetupDone == nil {
 		s.promptSetupDone = closedSignalChan()
 	}
+	cause = s.resolveSpawnTTLStopCauseLocked(cause)
 
 	switch s.State {
 	case StateStopped:
@@ -151,6 +152,19 @@ func (s *Session) prepareStop(now time.Time, cause StopCause, detail string) (bo
 	default:
 		return false, nil, fmt.Errorf("%w: %s -> %s", ErrInvalidStateTransition, s.State, StateStopping)
 	}
+}
+
+// resolveSpawnTTLStopCauseLocked classifies an expired child at the same
+// lifecycle lock that transitions it to stopping. This prevents a new prompt
+// from being admitted between a reaper snapshot and the stop decision.
+func (s *Session) resolveSpawnTTLStopCauseLocked(cause StopCause) StopCause {
+	if cause != CauseSpawnTTLExpired {
+		return cause
+	}
+	if s.promptSetupCount > 0 || s.currentTurnSource != "" || s.currentTurnID != "" {
+		return CauseTimeout
+	}
+	return CauseCompleted
 }
 
 func (s *Session) setStopCause(cause StopCause) {

--- a/internal/session/stop_cause.go
+++ b/internal/session/stop_cause.go
@@ -14,4 +14,8 @@ const (
 	CauseTimeout
 	CauseClearConversation
 	CauseConversationRewind
+	// CauseSpawnTTLExpired asks the session manager to classify the stop while
+	// holding the session lifecycle lock, so prompt admission cannot race the
+	// TTL decision.
+	CauseSpawnTTLExpired
 )

--- a/internal/session/stop_reason.go
+++ b/internal/session/stop_reason.go
@@ -55,7 +55,7 @@ func classifyStopReason(cause StopCause, waitErr error, detail string) (store.St
 		}
 		return store.StopCompleted, trimmedDetail
 	case CauseCompleted:
-		return store.StopCompleted, ""
+		return store.StopCompleted, trimmedDetail
 	case CauseFailed:
 		return store.StopError, trimmedDetail
 	default:
@@ -199,6 +199,12 @@ func (m *Manager) StopWithCause(ctx context.Context, id string, cause StopCause,
 		return errors.Join(stopErr, finalizeErr)
 	}
 	return nil
+}
+
+// StopWithSpawnTTL stops a spawned session and classifies its prompt state
+// atomically with the lifecycle transition.
+func (m *Manager) StopWithSpawnTTL(ctx context.Context, id string, detail string) error {
+	return m.StopWithCause(ctx, id, CauseSpawnTTLExpired, detail)
 }
 
 func (m *Manager) prepareStopWithCause(

--- a/internal/session/stop_reason_test.go
+++ b/internal/session/stop_reason_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	hookspkg "github.com/compozy/compozy/internal/hooks"
 	"github.com/compozy/compozy/internal/store"
@@ -83,6 +84,13 @@ func TestClassifyStopReason(t *testing.T) {
 			wantReason: store.StopCompleted,
 		},
 		{
+			name:       "Should preserve the spawn reaper origin for clean completion",
+			cause:      CauseCompleted,
+			detail:     "spawn_reaper:ttl_expired",
+			wantReason: store.StopCompleted,
+			wantDetail: "spawn_reaper:ttl_expired",
+		},
+		{
 			name:       "Should classify clear conversation as completed with detail",
 			cause:      CauseClearConversation,
 			wantReason: store.StopCompleted,
@@ -124,6 +132,59 @@ func TestClassifyStopReason(t *testing.T) {
 			}
 			if gotDetail != tc.wantDetail {
 				t.Fatalf("classifyStopReason() detail = %q, want %q", gotDetail, tc.wantDetail)
+			}
+		})
+	}
+}
+
+func TestSpawnTTLStopCauseUsesPromptStateAtLifecycleTransition(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		prompting bool
+		wantCause StopCause
+	}{
+		{
+			name:      "Should classify a settled child as completed",
+			wantCause: CauseCompleted,
+		},
+		{
+			name:      "Should classify an active prompt as timeout",
+			prompting: true,
+			wantCause: CauseTimeout,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			promptSetupDone := closedSignalChan()
+			s := &Session{
+				ID:              "child",
+				State:           StateActive,
+				promptSetupDone: promptSetupDone,
+			}
+			if tc.prompting {
+				s.promptSetupDone = make(chan struct{})
+				s.promptSetupCount = 1
+				s.currentTurnID = "turn-1"
+			}
+
+			stopAt := time.Unix(0, 0).UTC()
+			if _, _, err := s.prepareStop(
+				stopAt,
+				CauseSpawnTTLExpired,
+				"spawn_reaper:ttl_expired",
+			); err != nil {
+				t.Fatalf("prepareStop() error = %v", err)
+			}
+			cause, detail := s.stopCauseDetail()
+			if cause != tc.wantCause {
+				t.Fatalf("stop cause = %v, want %v", cause, tc.wantCause)
+			}
+			if detail != "spawn_reaper:ttl_expired" {
+				t.Fatalf("stop detail = %q, want spawn_reaper:ttl_expired", detail)
 			}
 		})
 	}

--- a/skills/compozy/references/runtime-operations.md
+++ b/skills/compozy/references/runtime-operations.md
@@ -406,6 +406,10 @@ fails, or enters a needs-you state. This `notify_creator` behavior defaults to o
 `config.toml` key. Use `--no-notify-creator` in the CLI or explicit `notify_creator: false` in the
 HTTP/UDS or native-tool request to opt out for that child.
 
+TTL cleanup checks the child runtime before classifying the stop: a child whose prompt has already
+settled with `done` or `end_turn` is reaped as completed, while a prompt still in flight is reaped
+as a timeout. Both paths retain the `spawn_reaper:ttl_expired` stop origin.
+
 Loop Goal sessions also record the session that started the Loop as internal creation provenance when that origin is available. They remain `type=system`: the parent/root/depth fields are informational and do not grant safe-spawn policy, caps, TTL, or parent-stop cleanup. If the origin was deleted before Goal creation, the Goal is created as its own root; deleting an origin after creation preserves the Goal and its recorded lineage.
 
 ## MCP Serve


### PR DESCRIPTION
## Summary

Closes ENG-147.

This change makes spawned-session TTL cleanup state-aware. A child whose prompt has already settled is now reaped as a clean completed session, while a prompt that is still in flight at the stop transition remains a timeout failure.

The existing cleanup lifecycle remains intact: lease release, process teardown, spawn.ttl_expired, spawn.reaped, session stop hooks, durable stop origin, and creator wake delivery continue to use their existing paths and exact-once success semantics.

## Root cause

The spawn reaper previously mapped every ttl_expired candidate to session.CauseTimeout. That cleanup reason was therefore indistinguishable from an active prompt timeout.

The session lifecycle then projected the stop as:

- StopTimeout
- a timeout failure payload
- a transcript.MarkerPromptTimeout
- a failed parent wake/badge

even when the child had already received a durable done or end_turn event and had no active prompt.

## Design

- Added an internal CauseSpawnTTLExpired request and Manager.StopWithSpawnTTL operation.
- The concrete session manager resolves that request under the session lifecycle lock, at the same transition that changes the session to stopping.
  - Active prompt setup/turn state becomes CauseTimeout.
  - Settled prompt state becomes CauseCompleted.
  - A prompt admitted after the lifecycle lock is rejected by the stopping state instead of racing into a clean classification.
- The clean path preserves spawn_reaper:ttl_expired as the durable stop detail.
- Transport-only session adapters that do not expose the atomic operation conservatively retain the historical timeout classification; they cannot prove that a prompt stayed settled through the stop transition.
- Hook/payload helpers were split into spawn_reaper_hooks.go so production files remain below the repository's 500-line cap.

## Changed surfaces

- Runtime daemon spawn reaper classification and atomic TTL stop dispatch.
- Session stop-cause resolution and clean stop-detail persistence.
- Lifecycle projections covering failure absence, timeout-marker absence, stopped notifier, and parent wake badge.
- Daemon reaper tests for settled, in-flight, atomic-adapter, and conservative-fallback paths.
- Session stop-reason and lifecycle contract tests.
- skills/compozy/references/runtime-operations.md now documents the settled-versus-in-flight TTL behavior.
- QA tracker:
  - added RT-spawn-ttl-cleanup
  - reset the affected RT-session-spawn-wake scenario
  - recorded focused evidence and explicit provider-backed blocked-verify instructions in docs/qa/reports/2026-08-24-eng-147-ttl-cleanup.md

## Lifecycle and exactly-once behavior

The change does not reorder or duplicate the existing reaper sequence:

1. dispatch the reason hook;
2. release child run leases with spawn_reaper:ttl_expired;
3. stop the child through the session lifecycle;
4. dispatch spawn.reaped;
5. let the existing session finalization path emit one stopped notification and one creator wake.

The clean branch only changes the stop classification. It does not suppress process teardown, lease release, hooks, or creator wake. Existing failure-path ordering and error reporting are intentionally unchanged because durable retry/idempotency semantics would be a separate design.

## Tests and focused verification

Passing focused checks:

- go test -race ./internal/daemon -run 'TestSpawnReaper' -count=1 — 9 tests passed.
- go test -race ./internal/session -run 'Test(ClassifyStopReason|SpawnTTLStopCauseUsesPromptStateAtLifecycleTransition|CompletedSpawnReapKeepsCleanTerminalProjection|PromptActivitySupervisorTimeoutCancelsThenStopsSession)$' -count=1 — 22 tests passed.
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run --new-from-rev origin/main --timeout 10m --concurrency 8 ./internal/daemon/... ./internal/session/... — 0 new issues.
- git diff --check — passed.
- Compozy test-shape checks for internal/daemon/spawn_reaper_test.go and internal/session/stop_reason_test.go — passed.

make gate was attempted as the focused repository gate. It reached the scoped Go packages but is currently blocked by 56 pre-existing lint findings elsewhere in internal/daemon/... and internal/session/... (goconst/gocritic baseline findings); no new-code findings remain. Per the ENG-147 request, make gate-full, make verify, and other full-monorepo gates were not run.

A provider-backed CLI/HTTP/UDS QA walk is recorded as blocked-verify because this review environment has no isolated ACP provider. The automated lifecycle evidence is committed, with exact human walk instructions in the QA report.

## Risks and trade-offs

- The clean TTL path is available only when the concrete session manager can make the atomic decision. Unknown prompt state in a transport-only adapter remains a timeout for safety.
- The stop-origin detail is now retained for clean completion, which improves public diagnosis without changing the stop reason enum.
- No schema, migration, config, provider, or native tool contract changes are required.

## Compozy Impact Audit

- Native tools: no compozy__* tool IDs, toolsets, descriptors, schemas, digests, risk flags, capability gates, or CLI/API fallbacks changed; checked the session-spawn and session-status projection surfaces.
- Extensibility and hooks: no extension registry or config lifecycle changes; existing spawn.ttl_expired, spawn.reaped, session stop hooks, lease release, and creator wake hooks remain wired exactly once on the success path; the official runtime-operations skill reference was updated.
- Workspace data isolation: no new datum or scope was introduced; stop cause/detail remain session-scoped, and parent wake resolution continues through the existing child lineage/workspace path without cross-workspace reads.
- Official Compozy skill: updated skills/compozy/references/runtime-operations.md with the state-aware TTL cleanup rule.

## Review resolution

The required GPT-5.6-Sol high-reasoning review identified a possible snapshot race and an unsafe adapter fallback. Both are addressed by the atomic StopWithSpawnTTL lifecycle operation and conservative timeout fallback. The review also examined lease/hook behavior on partial failures; that ordering is unchanged from the base branch and is intentionally outside this classification fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spawn session expiration handling by distinguishing completed sessions from sessions interrupted during an active prompt or turn.
  * Preserved clean completion details and terminal status for sessions that finish before expiration.
  * Added lifecycle notifications for session stops and reaping events.
  * Improved cleanup and lease release behavior after expired sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->