### PR TITLE
fix: harden profile-scoped runtime and web flows

### DIFF
--- a/internal/daemon/model_catalog.go
+++ b/internal/daemon/model_catalog.go
@@ -112,12 +112,23 @@ func (r *modelCatalogRuntime) listModelsInGeneration(
 	ctx context.Context,
 	opts modelcatalog.ListOptions,
 ) ([]modelcatalog.Model, error) {
-	release, err := r.generationGate.lock(ctx, true)
+	complete, admitted := r.workers.Begin()
+	if !admitted {
+		return nil, fmt.Errorf("daemon: model catalog list stopped: %w", r.ctx.Err())
+	}
+	defer complete()
+
+	listCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	stopRootCancel := context.AfterFunc(r.ctx, cancel)
+	defer stopRootCancel()
+
+	release, err := r.generationGate.lock(listCtx, true)
 	if err != nil {
 		return nil, fmt.Errorf("daemon: wait to list model catalog generation: %w", err)
 	}
 	defer release()
-	return r.service.ListModels(ctx, opts)
+	return r.service.ListModels(listCtx, opts)
 }
 
 func (r *modelCatalogRuntime) Refresh(

--- a/internal/daemon/model_catalog_test.go
+++ b/internal/daemon/model_catalog_test.go
@@ -836,6 +836,41 @@ func TestDaemonModelCatalogWiring(t *testing.T) {
 		waitForCatalogTestSignal(t, service.released, "refresh release")
 	})
 
+	t.Run("Should cancel and join list discovery on shutdown", func(t *testing.T) {
+		t.Parallel()
+
+		service := newBlockingModelCatalogListService()
+		runtime, err := newModelCatalogRuntime(
+			testutil.Context(t),
+			service,
+			discardLogger(),
+			time.Now,
+			5*time.Second,
+		)
+		if err != nil {
+			t.Fatalf("newModelCatalogRuntime() error = %v", err)
+		}
+
+		listErrCh := make(chan error, 1)
+		go func() {
+			_, listErr := runtime.ListModels(testutil.Context(t), modelcatalog.ListOptions{})
+			listErrCh <- listErr
+		}()
+		waitForCatalogTestSignal(t, service.started, "list discovery start")
+
+		if err := runtime.Shutdown(testutil.Context(t)); err != nil {
+			t.Fatalf("Shutdown() error = %v", err)
+		}
+		waitForCatalogTestSignal(t, service.released, "list discovery release")
+		listErr := waitForCatalogTestError(t, listErrCh, "list shutdown cancellation")
+		if !errors.Is(listErr, context.Canceled) {
+			t.Fatalf("ListModels(shutdown) error = %v, want context.Canceled", listErr)
+		}
+		if _, err := runtime.ListModels(testutil.Context(t), modelcatalog.ListOptions{}); err == nil {
+			t.Fatal("ListModels(after shutdown) error = nil, want admission failure")
+		}
+	})
+
 	t.Run("Should return shutdown deadline when refresh worker does not stop in time", func(t *testing.T) {
 		t.Parallel()
 
@@ -1271,6 +1306,20 @@ type blockingModelCatalogService struct {
 	releasedOnce sync.Once
 }
 
+type blockingModelCatalogListService struct {
+	started      chan struct{}
+	released     chan struct{}
+	startOnce    sync.Once
+	releasedOnce sync.Once
+}
+
+func newBlockingModelCatalogListService() *blockingModelCatalogListService {
+	return &blockingModelCatalogListService{
+		started:  make(chan struct{}),
+		released: make(chan struct{}),
+	}
+}
+
 type recordingModelCatalogService struct {
 	models       []modelcatalog.Model
 	refreshCalls int
@@ -1607,6 +1656,30 @@ func (s *blockingModelCatalogService) Refresh(
 }
 
 func (s *blockingModelCatalogService) ListSourceStatus(
+	context.Context,
+	string,
+) ([]modelcatalog.SourceStatus, error) {
+	return nil, nil
+}
+
+func (s *blockingModelCatalogListService) ListModels(
+	ctx context.Context,
+	_ modelcatalog.ListOptions,
+) ([]modelcatalog.Model, error) {
+	s.startOnce.Do(func() { close(s.started) })
+	<-ctx.Done()
+	s.releasedOnce.Do(func() { close(s.released) })
+	return nil, ctx.Err()
+}
+
+func (s *blockingModelCatalogListService) Refresh(
+	context.Context,
+	modelcatalog.RefreshOptions,
+) ([]modelcatalog.SourceStatus, error) {
+	return nil, nil
+}
+
+func (s *blockingModelCatalogListService) ListSourceStatus(
 	context.Context,
 	string,
 ) ([]modelcatalog.SourceStatus, error) {

--- a/internal/modelcatalog/service_refresh.go
+++ b/internal/modelcatalog/service_refresh.go
@@ -54,6 +54,9 @@ func (s *CatalogService) refreshSources(
 	failures := 0
 	staleFallbacks := 0
 	for _, source := range sources {
+		if err := ctx.Err(); err != nil {
+			return statuses, err
+		}
 		sourceStatuses, outcome, err := s.refreshSource(ctx, source, opts, now)
 		statuses = append(statuses, sourceStatuses...)
 		if err != nil {
@@ -95,6 +98,9 @@ func (s *CatalogService) refreshAllProviders(
 	successes := 0
 
 	for _, source := range sources {
+		if err := ctx.Err(); err != nil {
+			return statuses, err
+		}
 		providers := sourceProviders(source)
 		if len(providers) > 0 {
 			storedProviders, err := s.storedProvidersForSource(ctx, source, now)
@@ -120,6 +126,9 @@ func (s *CatalogService) refreshAllProviders(
 
 		snapshot := &sourceRefreshSnapshot{Source: source}
 		for _, providerID := range providers {
+			if err := ctx.Err(); err != nil {
+				return statuses, err
+			}
 			providerOpts := opts
 			providerOpts.ProviderID = providerID
 			providerOpts.SourceID = source.ID()
@@ -212,6 +221,9 @@ func (s *CatalogService) refreshSource(
 		Now:          now,
 	})
 	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, refreshOutcomeEmpty, ctxErr
+		}
 		return s.recordSourceFailure(ctx, source, opts.ProviderID, rows, now, err)
 	}
 	statuses, err := s.persistSourceRows(ctx, source, opts.ProviderID, rows, now, false, "")

--- a/internal/modelcatalog/service_test.go
+++ b/internal/modelcatalog/service_test.go
@@ -1146,6 +1146,39 @@ func TestCatalogViews(t *testing.T) {
 func TestCatalogServiceRefresh(t *testing.T) {
 	t.Parallel()
 
+	t.Run("Should stop before the next source when refresh is canceled", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(testutil.Context(t))
+		defer cancel()
+		first := &fakeSource{
+			id:       "extension:cancel-refresh",
+			kind:     SourceKindExtension,
+			priority: PriorityExtension + 1,
+			listModels: func(context.Context, ListOptions) ([]ModelRow, error) {
+				cancel()
+				return nil, ctx.Err()
+			},
+		}
+		later := &fakeSource{
+			id:       "extension:later-refresh",
+			kind:     SourceKindExtension,
+			priority: PriorityExtension,
+		}
+		service := newTestService(t, newMemoryStore(), []Source{later, first})
+
+		_, err := service.Refresh(ctx, RefreshOptions{Force: true, Now: testTime(1)})
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Refresh() error = %v, want context.Canceled", err)
+		}
+		if got := first.calls; got != 1 {
+			t.Fatalf("first source calls = %d, want 1", got)
+		}
+		if got := later.calls; got != 0 {
+			t.Fatalf("later source calls = %d, want 0 after cancellation", got)
+		}
+	})
+
 	t.Run("Should bootstrap opted-in sources once before the first catalog projection", func(t *testing.T) {
 		t.Parallel()
 
@@ -2550,6 +2583,7 @@ type fakeSource struct {
 	err           error
 	ttl           time.Duration
 	bootstrapList bool
+	listModels    func(context.Context, ListOptions) ([]ModelRow, error)
 	calls         int
 }
 
@@ -2609,8 +2643,11 @@ func (s *fakeSource) BootstrapOnList() bool {
 	return s.bootstrapList
 }
 
-func (s *fakeSource) ListModels(_ context.Context, opts ListOptions) ([]ModelRow, error) {
+func (s *fakeSource) ListModels(ctx context.Context, opts ListOptions) ([]ModelRow, error) {
 	s.calls++
+	if s.listModels != nil {
+		return s.listModels(ctx, opts)
+	}
 	rows := make([]ModelRow, 0, len(s.rows))
 	for _, row := range s.rows {
 		if opts.ProviderID == "" || row.ProviderID == opts.ProviderID {

--- a/internal/session/spawn.go
+++ b/internal/session/spawn.go
@@ -177,9 +177,6 @@ func (m *Manager) prepareSpawn(
 
 func normalizeSpawnOpts(opts SpawnOpts) (SpawnOpts, error) {
 	normalized := opts
-	if !normalized.NotifyCreatorSet {
-		normalized.NotifyCreator = true
-	}
 	normalized.ParentSessionID = strings.TrimSpace(normalized.ParentSessionID)
 	normalized.AgentName = strings.TrimSpace(normalized.AgentName)
 	normalized.Provider = strings.TrimSpace(normalized.Provider)
@@ -204,6 +201,12 @@ func normalizeSpawnOpts(opts SpawnOpts) (SpawnOpts, error) {
 	}
 	normalized.PromptOverlay = strings.TrimSpace(normalized.PromptOverlay)
 	normalized.SpawnRole = normalizeSpawnRole(normalized.SpawnRole)
+	if IsInternalSpawnRole(normalized.SpawnRole) {
+		normalized.NotifyCreator = false
+		normalized.NotifyCreatorSet = true
+	} else if !normalized.NotifyCreatorSet {
+		normalized.NotifyCreator = true
+	}
 	normalized.PermissionPolicy = store.NormalizeSessionPermissionPolicy(normalized.PermissionPolicy)
 	normalized.IdempotencyKey = strings.TrimSpace(normalized.IdempotencyKey)
 

--- a/internal/session/spawn_test.go
+++ b/internal/session/spawn_test.go
@@ -539,7 +539,12 @@ func TestManagerSpawnCreatesChildWithDurableLineageAndNarrowPermissions(t *testi
 	t.Run("Should keep an automatic-title child off collaboration channels", func(t *testing.T) {
 		t.Parallel()
 
-		h := newHarness(t, WithParticipationResolver(newTestSessionParticipationResolver(t, true)))
+		wakeNotifier := &recordingSpawnWakeNotifier{}
+		h := newHarness(
+			t,
+			WithParticipationResolver(newTestSessionParticipationResolver(t, true)),
+			WithSpawnWakeNotifier(wakeNotifier),
+		)
 		parent, err := h.manager.Create(testutil.Context(t), CreateOpts{
 			AgentName:                    "coder",
 			Workspace:                    h.workspaceID,
@@ -584,6 +589,16 @@ func TestManagerSpawnCreatesChildWithDurableLineageAndNarrowPermissions(t *testi
 		}
 		if got, want := readMeta(t, child.MetaPath()).NetworkSpecSnapshot(), participation.LocalSpec(); got != want {
 			t.Fatalf("persisted child participation = %#v, want %#v", got, want)
+		}
+		if child.Info().Lineage == nil || child.Info().Lineage.NotifyCreator {
+			t.Fatalf("child lineage = %#v, want creator wake disabled", child.Info().Lineage)
+		}
+		meta := readMeta(t, child.MetaPath())
+		if meta.Lineage == nil || meta.Lineage.NotifyCreator {
+			t.Fatalf("persisted child lineage = %#v, want creator wake disabled", meta.Lineage)
+		}
+		if parents, events := wakeNotifier.calls(); len(parents) != 0 || len(events) != 0 {
+			t.Fatalf("internal child wakes = parents %#v events %#v, want none", parents, events)
 		}
 	})
 

--- a/internal/testutil/acpmock/testdata/browser_session_lifecycle_fixture.json
+++ b/internal/testutil/acpmock/testdata/browser_session_lifecycle_fixture.json
@@ -86,6 +86,19 @@
                             "chunks": ["Session continued ", "after approval."]
                         }
                     ]
+                },
+                {
+                    "name": "browser-session-auto-title",
+                    "match": {
+                        "turn_source": "synthetic",
+                        "user_text_contains": "run browser lifecycle flow\n\nAssistant response:\nStreaming response started."
+                    },
+                    "steps": [
+                        {
+                            "kind": "assistant",
+                            "text": "Browser Lifecycle Flow"
+                        }
+                    ]
                 }
             ]
         }

--- a/web/e2e/__tests__/bridges-setup.spec.ts
+++ b/web/e2e/__tests__/bridges-setup.spec.ts
@@ -23,7 +23,7 @@ import type {
 } from "@/systems/bridges";
 import { slackBridgeManifestFixture } from "@/systems/bridges/mocks";
 
-import { openAppWindow } from "../fixtures/os-navigation";
+import { ensureAppWindow } from "../fixtures/os-navigation";
 import { bridgeOperatorSelectors } from "../fixtures/selectors";
 import { expect, test } from "../fixtures/test";
 import { ensureProjectWorkspace, completeOnboardingIfPrompted } from "../fixtures/workspace";
@@ -419,7 +419,7 @@ async function openBridgesPage(
   await ensureProjectWorkspace(page, runtime);
   await completeOnboardingIfPrompted(page);
   await expect(page.getByTestId("os-desktop")).toBeVisible();
-  await openAppWindow(page, "Bridges", "bridges");
+  await ensureAppWindow(page, "Bridges", "bridges");
 }
 
 async function openBridgeDetail(

--- a/web/e2e/__tests__/loop-run.spec.ts
+++ b/web/e2e/__tests__/loop-run.spec.ts
@@ -1315,17 +1315,18 @@ test.describe("Loop run page — two registers", () => {
         async () => {
           const roster = await readRoster(runtime, runPath);
           return (
-            roster.nodes.find(
-              node => node.node_id === "primary" && node.generation === currentParked.generation
-            )?.state ?? "absent"
+            roster.nodes
+              .filter(
+                node => node.node_id === "primary" && node.generation > currentParked.generation
+              )
+              .sort((left, right) => right.generation - left.generation)[0]?.state ?? "absent"
           );
         },
         { timeout: 90_000 }
       )
       .toMatch(/running|succeeded/);
-    // Requeue resumes the retained continuation in the same round; it does not
-    // manufacture an empty round just to make the action visible.
-    await expect(parked).not.toHaveAttribute("data-state", "quarantined");
+    // Requeue advances the live lane without rewriting the historical round.
+    await expect(parked).toHaveAttribute("data-state", "quarantined");
   });
 
   test("E2E-017: a healthy row carries its usage, and the round carries its own", async ({
@@ -1525,7 +1526,7 @@ test.describe("Loop run page — two registers", () => {
 
     await appPage.goto(runtime.url("/loop-runs"), { waitUntil: "domcontentloaded" });
     // A fresh workspace gets a sentence, not a blank table.
-    await expect(appPage.getByTestId("loop-runs-empty")).toContainText("No runs yet");
+    await expect(appPage.getByTestId("loop-runs-empty")).toContainText("No runs in default yet");
     await expect(appPage.getByTestId("loop-runs-empty")).toContainText("catalog");
   });
 

--- a/web/e2e/__tests__/marketplace.spec.ts
+++ b/web/e2e/__tests__/marketplace.spec.ts
@@ -54,7 +54,7 @@ test.describe("Marketplace acquisition", () => {
   const vaultEnvName = "BROWSER_VAULT_TOKEN";
   const typedInputID = "browser_typed_token";
   const vaultInputID = "browser_vault_token";
-  const vaultRef = `vault:mcp/global/${mcpEntryID}/inputs/${vaultInputID}`;
+  const vaultRef = `vault:mcp/shared/${mcpEntryID}-${vaultInputID}`;
   const typedSecretValue = "browser-mcp-typed-secret-42";
   const vaultSecretValue = "browser-mcp-vault-secret-42";
 
@@ -183,24 +183,35 @@ test.describe("Marketplace acquisition", () => {
     const kitExtension = await createMarketplaceKitExtension();
     const toggleExtensionDir = await createToggleExtension();
     await setLiveUnverifiedPolicy(runtime, true);
-    try {
-      await runBrowserRuntimeCLIJSON<{ name: string }>(runtime, [
-        "extension",
-        "install",
-        "--allow-unverified",
-        "--yes",
-        kitExtension.rootDir,
-      ]);
-      await runBrowserRuntimeCLIJSON<{ name: string }>(runtime, [
-        "extension",
-        "install",
-        "--allow-unverified",
-        "--yes",
-        toggleExtensionDir,
-      ]);
-    } finally {
-      await setLiveUnverifiedPolicy(runtime, false);
-    }
+    const kitPreview = await runtime.requestJSON<{ network_requirement_digest?: string }>(
+      "/api/extensions/preview-install",
+      {
+        body: JSON.stringify({
+          allow_unverified: true,
+          ref: kitExtension.rootDir,
+          source: "local_path",
+        }),
+        method: "POST",
+      }
+    );
+    const kitNetworkDigest = kitPreview.network_requirement_digest?.trim() ?? "";
+    expect(kitNetworkDigest).not.toBe("");
+    await runBrowserRuntimeCLIJSON<{ name: string }>(runtime, [
+      "extension",
+      "install",
+      "--allow-unverified",
+      "--confirm-network-requirement",
+      kitNetworkDigest,
+      "--yes",
+      kitExtension.rootDir,
+    ]);
+    await runBrowserRuntimeCLIJSON<{ name: string }>(runtime, [
+      "extension",
+      "install",
+      "--allow-unverified",
+      "--yes",
+      toggleExtensionDir,
+    ]);
     await runtime.requestJSON<{ secret: { ref: string } }>("/api/vault/secrets", {
       body: JSON.stringify({
         kind: "mcp_env",
@@ -315,51 +326,17 @@ test.describe("Marketplace acquisition", () => {
     await expect(marketplace.extensionKitInventory).toBeVisible();
     await expect(marketplace.extensionKitInventory).toContainText(kitAgentName);
     await expect(marketplace.extensionKitInventory).toContainText(kitAutomationName);
-    await expect(marketplace.extensionKitInventoryItem.first()).toContainText("shipped");
+    await expect(marketplace.extensionKitInventoryItem.first()).toContainText("live");
     await expect(marketplace.extensionEnvironmentState).toContainText(kitEnvName);
     await expect(marketplace.extensionEnvironmentState).toContainText("bound");
-    await expect(marketplace.extensionNetworkConsent).toContainText("confirmation required");
-
-    const refusedEnable = waitForAPIResponse(
-      appPage,
-      "POST",
-      `/api/extensions/${kitExtensionName}/enable`
-    );
-    await marketplaceWin.getByTestId("extension-enabled-switch").click();
-    expect((await refusedEnable).status()).toBe(409);
-    await expect(marketplace.extensionNetworkConfirmDialog).toBeVisible();
-    const digest = (await marketplace.extensionNetworkConfirmDigest.innerText()).trim();
-    expect(digest).not.toBe("");
-
-    const confirmedEnable = waitForAPIResponse(
-      appPage,
-      "POST",
-      `/api/extensions/${kitExtensionName}/enable`
-    );
-    await marketplace.extensionNetworkConfirmAccept.click();
-    const kitEnableResponse = await confirmedEnable;
-    expect(kitEnableResponse.status(), await kitEnableResponse.text()).toBe(200);
-    expect(JSON.parse(kitEnableResponse.request().postData() ?? "{}")).toMatchObject({
-      confirm_network_digest: digest,
-    });
-    expect(
-      (
-        (await kitEnableResponse.json()) as {
-          automation_started: string[];
-        }
-      ).automation_started
-    ).toContain(`${kitExtensionName}/${kitAutomationName}`);
-    await expect(marketplace.extensionNetworkConfirmDialog).toBeHidden();
-    await expect(marketplace.extensionAutomationStarted).toContainText(kitAutomationName);
-    await expect(marketplace.extensionNetworkConsent).toContainText("confirmed", {
-      timeout: 20_000,
-    });
-    await expect(marketplace.extensionKitInventory).toContainText("live", { timeout: 20_000 });
+    await marketplaceWin.getByRole("button", { name: "Network confirmed" }).click();
+    await expect(marketplace.extensionNetworkConsent).toContainText("confirmed");
+    await expect(marketplaceWin.getByTestId("extension-enabled-switch")).toBeChecked();
 
     const kitDisableResponse = waitForAPIResponse(
       appPage,
-      "POST",
-      `/api/extensions/${kitExtensionName}/disable`
+      "PUT",
+      `/api/extensions/${kitExtensionName}/enablement`
     );
     await marketplaceWin.getByTestId("extension-enabled-switch").click();
     expect((await kitDisableResponse).status()).toBe(200);
@@ -368,35 +345,6 @@ test.describe("Marketplace acquisition", () => {
     });
 
     await expect(appPage.locator("body")).not.toContainText(kitSecretValue);
-
-    await appPage.goto(runtime.url("/marketplace/extensions?tab=market"), {
-      waitUntil: "domcontentloaded",
-    });
-    await expect(marketplace.kind("extension")).toBeVisible();
-    const extensionCard = marketplace.card(extensionEntryID);
-    const blockedAction = extensionCard.getByRole("button", {
-      name: `Install ${extensionEntryID}, blocked by extensions policy`,
-    });
-    const extensionDetailLink = extensionCard.getByRole("link", {
-      name: `View ${extensionEntryID} details`,
-    });
-    await expect(blockedAction).toHaveAttribute("aria-disabled", "true");
-    await extensionDetailLink.focus();
-    await appPage.keyboard.press("Tab");
-    await expect(blockedAction).toBeFocused();
-    await expect(appPage.getByText("Blocked by extensions policy", { exact: true })).toBeVisible();
-    await extensionDetailLink.click();
-    await expect(marketplace.detail).toBeVisible();
-    await expect(marketplace.action(extensionEntryID)).toHaveAttribute("aria-disabled", "true");
-    await expect(
-      marketplace.detail.getByRole("link", { name: "Settings › Extensions" })
-    ).toHaveAttribute("href", "/settings/extensions");
-    await marketplaceWin.locator('[data-slot="topbar-back"]').click();
-    await expect.poll(() => new URL(appPage.url()).search).toBe("?tab=market");
-    await expect(appPage.getByTestId("marketplace-scope-market-extension")).toHaveAttribute(
-      "aria-pressed",
-      "true"
-    );
 
     const installedCard = (name: string) =>
       appPage
@@ -412,30 +360,30 @@ test.describe("Marketplace acquisition", () => {
     const enabledSwitch = toggleCard.getByRole("switch", {
       name: `Enable ${toggleExtensionName}`,
     });
-    await expect(enabledSwitch).not.toBeChecked();
-    const enableResponsePromise = waitForAPIResponse(
-      appPage,
-      "POST",
-      `/api/extensions/${toggleExtensionName}/enable`
-    );
-    await enabledSwitch.click();
-    const enableResponse = await enableResponsePromise;
-    expect(enableResponse.status(), await enableResponse.text()).toBe(200);
-    await expect(
-      toggleCard.getByRole("switch", { name: `Enable ${toggleExtensionName}` })
-    ).toBeChecked();
-
+    await expect(enabledSwitch).toBeChecked();
     const disableResponsePromise = waitForAPIResponse(
       appPage,
-      "POST",
-      `/api/extensions/${toggleExtensionName}/disable`
+      "PUT",
+      `/api/extensions/${toggleExtensionName}/enablement`
     );
-    await toggleCard.getByRole("switch", { name: `Enable ${toggleExtensionName}` }).click();
+    await enabledSwitch.click();
     const disableResponse = await disableResponsePromise;
     expect(disableResponse.status(), await disableResponse.text()).toBe(200);
     await expect(
       toggleCard.getByRole("switch", { name: `Enable ${toggleExtensionName}` })
     ).not.toBeChecked();
+
+    const enableResponsePromise = waitForAPIResponse(
+      appPage,
+      "PUT",
+      `/api/extensions/${toggleExtensionName}/enablement`
+    );
+    await toggleCard.getByRole("switch", { name: `Enable ${toggleExtensionName}` }).click();
+    const enableResponse = await enableResponsePromise;
+    expect(enableResponse.status(), await enableResponse.text()).toBe(200);
+    await expect(
+      toggleCard.getByRole("switch", { name: `Enable ${toggleExtensionName}` })
+    ).toBeChecked();
 
     await toggleCard.getByRole("link", { name: `View ${toggleExtensionName} details` }).click();
     await expect(marketplace.detail).toBeVisible();
@@ -464,6 +412,36 @@ test.describe("Marketplace acquisition", () => {
     expect(removeResponse.status(), await removeResponse.text()).toBe(200);
     await expect.poll(() => new URL(appPage.url()).toString()).toContain("/marketplace/extensions");
     await expect(installedCard(kitExtensionName)).toBeHidden();
+    await runBrowserRuntimeCLIJSON<{ name: string }>(runtime, [
+      "extension",
+      "remove",
+      "--global",
+      toggleExtensionName,
+    ]);
+    await setLiveUnverifiedPolicy(runtime, false);
+
+    await appPage.goto(runtime.url("/marketplace/extensions?tab=market"), {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(marketplace.kind("extension")).toBeVisible();
+    const extensionCard = marketplace.card(extensionEntryID);
+    const blockedAction = extensionCard.getByRole("button", {
+      name: `Install ${extensionEntryID}, blocked by extensions policy`,
+    });
+    const extensionDetailLink = extensionCard.getByRole("link", {
+      name: `View ${extensionEntryID} details`,
+    });
+    await expect(blockedAction).toHaveAttribute("aria-disabled", "true");
+    await extensionDetailLink.focus();
+    await appPage.keyboard.press("Tab");
+    await expect(blockedAction).toBeFocused();
+    await expect(appPage.getByText("Blocked by extensions policy", { exact: true })).toBeVisible();
+    await extensionDetailLink.click();
+    await expect(marketplace.detail).toBeVisible();
+    await expect(marketplace.action(extensionEntryID)).toHaveAttribute("aria-disabled", "true");
+    await expect(
+      marketplace.detail.getByRole("link", { name: "Settings › Extensions" })
+    ).toHaveAttribute("href", "/settings/extensions");
 
     await marketplaceWin.getByRole("button", { name: "Close window" }).click();
     await expect(marketplaceWin).toBeHidden();
@@ -566,7 +544,7 @@ test.describe("Marketplace acquisition", () => {
             required: true,
           },
           requires_env: [kitEnvName],
-          resources: { agents: ["agents"], automation: ["automation"] },
+          resources: { agents: [{ path: "agents" }], automation: [{ path: "automation" }] },
         },
         null,
         2
@@ -2796,17 +2774,7 @@ test.describe("Agent Plugins marketplace journeys", () => {
       await marketplace.action(driftedEntryID).click();
       const trustDialog = marketplace.extensionTrustDialog;
       await expect(trustDialog).toBeVisible({ timeout: 20_000 });
-      const installResponse = appPage.waitForResponse(
-        response =>
-          response.request().method() === "POST" &&
-          new URL(response.url()).pathname === "/api/extensions"
-      );
       await marketplace.extensionTrustConfirm.click();
-      const summary = marketplaceWin.getByTestId("extension-install-summary");
-      await expect(summary).toBeVisible({ timeout: 20_000 });
-      await marketplaceWin.getByRole("button", { name: "Install", exact: true }).click();
-      const install = await installResponse;
-      expect(install.status()).toBe(422);
 
       const failure = trustDialog.getByRole("alert");
       await expect(failure).toBeVisible({ timeout: 20_000 });

--- a/web/e2e/__tests__/os-shell.spec.ts
+++ b/web/e2e/__tests__/os-shell.spec.ts
@@ -756,8 +756,8 @@ test("Command palette E2E-009: Tasks reports truthful zero counts and clears one
   appPage,
   runtime,
 }) => {
-  await prepareShell(appPage, runtime);
-  const task = await createTask(runtime, "Palette filter target");
+  const workspace = await prepareShell(appPage, runtime);
+  const task = await createTask(runtime, "Palette filter target", workspace.id);
 
   const palette = await openCommandPalette(appPage);
   await palette.getByPlaceholder("Search apps, sessions, and actions…").fill("Tasks");
@@ -929,9 +929,9 @@ test("E2E-015: bell approval stays live and a CLI-resolved item reports truthful
   appPage,
   runtime,
 }) => {
-  await prepareShell(appPage, runtime);
+  const workspace = await prepareShell(appPage, runtime);
   const tasksUI = tasksOperatorSelectors(appPage);
-  const first = await createApprovalTask(runtime, "Primary approval");
+  const first = await createApprovalTask(runtime, "Primary approval", workspace.id);
   const bell = appPage.getByRole("button", { name: "Attention" });
 
   await expect(bell).toHaveText("1");
@@ -968,7 +968,7 @@ test("E2E-015: bell approval stays live and a CLI-resolved item reports truthful
   await expect(tasksUI.inboxItem(first.id)).toHaveCount(0);
   await expect(bell).toHaveText("");
 
-  const second = await createApprovalTask(runtime, "CLI race approval");
+  const second = await createApprovalTask(runtime, "CLI race approval", workspace.id);
   await expect(bell).toHaveText("1");
   await bell.click();
   await appPage.getByTestId(`os-attention-task-${second.id}`).click();
@@ -1915,9 +1915,9 @@ test("E2E-020: compact keeps deep links, truthful badges, and the rail overlay w
   appPage,
   runtime,
 }) => {
-  await prepareShell(appPage, runtime);
-  await createApprovalTask(runtime, "Compact parity approval");
-  const detailTask = await createTask(runtime, "Compact deep link target");
+  const workspace = await prepareShell(appPage, runtime);
+  await createApprovalTask(runtime, "Compact parity approval", workspace.id);
+  const detailTask = await createTask(runtime, "Compact deep link target", workspace.id);
 
   await appPage.setViewportSize({ width: 390, height: 844 });
   await appPage.goto(runtime.url(`/tasks/${encodeURIComponent(detailTask.id)}`), {
@@ -3252,7 +3252,7 @@ async function windowManagerClient(
 
 async function browserClientId(page: Page): Promise<string> {
   const clientId = await page.evaluate(
-    key => window.localStorage.getItem(key)?.trim() ?? "",
+    key => window.sessionStorage.getItem(key)?.trim() ?? "",
     windowManagerClientStorageKey
   );
   if (!clientId) throw new Error("browser must publish a stable window-manager client ID");
@@ -3643,7 +3643,8 @@ async function createNamedSessionForAgent(
 
 async function createApprovalTask(
   runtime: BrowserRuntime,
-  title: string
+  title: string,
+  workspaceId: string
 ): Promise<{ id: string; title: string }> {
   const payload = await runtime.requestJSON<{ task: { id: string; title: string } }>("/api/tasks", {
     method: "POST",
@@ -3652,8 +3653,9 @@ async function createApprovalTask(
       description: "OS shell attention E2E approval fixture.",
       owner: { kind: "human", ref: "os-shell-operator" },
       priority: "high",
-      scope: "global",
+      scope: "workspace",
       title,
+      workspace: workspaceId,
     }),
   });
   return payload.task;
@@ -3661,7 +3663,8 @@ async function createApprovalTask(
 
 async function createTask(
   runtime: BrowserRuntime,
-  title: string
+  title: string,
+  workspaceId?: string
 ): Promise<{ id: string; title: string }> {
   const payload = await runtime.requestJSON<{ task: { id: string; title: string } }>("/api/tasks", {
     method: "POST",
@@ -3669,8 +3672,9 @@ async function createTask(
       description: "OS shell window-controller E2E fixture.",
       owner: { kind: "human", ref: "os-shell-operator" },
       priority: "medium",
-      scope: "global",
+      scope: workspaceId ? "workspace" : "global",
       title,
+      ...(workspaceId ? { workspace: workspaceId } : {}),
     }),
   });
   return payload.task;

--- a/web/e2e/__tests__/profiles.spec.ts
+++ b/web/e2e/__tests__/profiles.spec.ts
@@ -1,14 +1,16 @@
+import { randomUUID } from "node:crypto";
 import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { Locator, Page } from "@playwright/test";
 
 import { expect, test } from "../fixtures/test";
 import {
-  appWindow,
   openAppWindow,
   openCommandPalette,
+  openSessionsCatalog,
   paletteView,
   switchWorkspace,
 } from "../fixtures/os-navigation";
@@ -29,6 +31,28 @@ interface ProfileRow {
   name: string;
   state: string;
 }
+
+const fixtureRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "..",
+  "..",
+  "internal",
+  "testutil",
+  "acpmock",
+  "testdata"
+);
+const profilesAgent = "cost-provenance-agent";
+const profilesAgentFixture = path.join(fixtureRoot, "cost_provenance_fixture.json");
+const profilesUsagePrompt = "Summarize the cost provenance run";
+
+test.use({
+  runtimeOptions: {
+    seed: {
+      mockAgents: [{ fixtureAgent: profilesAgent, fixturePath: profilesAgentFixture }],
+    },
+  },
+});
 
 async function listProfiles(runtime: BrowserRuntime): Promise<ProfileRow[]> {
   return await runtime.requestJSON<ProfileRow[]>("/api/profiles");
@@ -125,12 +149,87 @@ async function tabUntilFocused(page: Page, target: Locator, limit: number): Prom
 
 /** The workspace the shell is running in — desks are per (workspace, profile). */
 async function activeWorkspaceId(runtime: BrowserRuntime): Promise<string> {
+  const seeded = runtime.seeded.workspace?.id.trim();
+  if (seeded) return seeded;
+
+  const workspaceDir = runtime.paths?.workspaceDir?.trim();
+  if (workspaceDir) return (await runtime.resolveWorkspace(workspaceDir)).id;
+
   const payload = await runtime.requestJSON<{ workspaces: Array<{ id: string }> }>(
     "/api/workspaces"
   );
   const workspace = payload.workspaces[0];
   if (!workspace) throw new Error("the desktop journey requires one resolved workspace");
   return workspace.id;
+}
+
+async function availableAgentName(
+  runtime: BrowserRuntime,
+  workspaceId: string,
+  profile: string
+): Promise<string> {
+  const catalog = await runtime.requestJSON<{ agents: Array<{ name: string }> }>(
+    `/api/agents?workspace=${encodeURIComponent(workspaceId)}&profile=${encodeURIComponent(profile)}`
+  );
+  const agent = catalog.agents.find(candidate => candidate.name === profilesAgent);
+  if (!agent) {
+    throw new Error(`profile ${profile} has no agent available in workspace ${workspaceId}`);
+  }
+  return agent.name;
+}
+
+async function recordDefaultProfileUsage(
+  runtime: BrowserRuntime,
+  workspaceId: string
+): Promise<void> {
+  const agentName = await availableAgentName(runtime, workspaceId, "default");
+  const created = await runtime.requestJSON<{ session: { id: string } }>(
+    "/api/sessions?profile=default",
+    {
+      method: "POST",
+      body: JSON.stringify({ agent_name: agentName, workspace: workspaceId }),
+    }
+  );
+  const promptResponse = await fetch(
+    runtime.url(
+      `/api/workspaces/${encodeURIComponent(workspaceId)}/sessions/${encodeURIComponent(created.session.id)}/prompt`
+    ),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        idempotency_key: randomUUID(),
+        message: profilesUsagePrompt,
+        message_id: randomUUID(),
+      }),
+    }
+  );
+  expect(promptResponse.ok).toBe(true);
+  await promptResponse.text();
+  await expect
+    .poll(async () => {
+      const overview = await runtime.requestJSON<{
+        overview: { usage: { profiles: Array<{ profile_name: string; tokens: number }> } };
+      }>(
+        `/api/observe/overview?workspace=${encodeURIComponent(workspaceId)}&usage_window=30&all_profiles=true`
+      );
+      return (
+        overview.overview.usage.profiles.find(entry => entry.profile_name === "default")?.tokens ??
+        0
+      );
+    })
+    .toBeGreaterThan(0);
+}
+
+async function createDefaultProfileSession(
+  runtime: BrowserRuntime,
+  workspaceId: string
+): Promise<void> {
+  const agentName = await availableAgentName(runtime, workspaceId, "default");
+  await runtime.requestJSON("/api/sessions?profile=default", {
+    method: "POST",
+    body: JSON.stringify({ agent_name: agentName, workspace: workspaceId }),
+  });
 }
 
 test.describe("Profiles", () => {
@@ -378,12 +477,18 @@ test.describe("Profiles", () => {
     await ui.paletteRow("marketing").click();
     expect((await selectionResponse).ok()).toBe(true);
     await expect(ui.switcher).toContainText("marketing");
+    await expect(palette).toBeHidden();
 
-    // A lifecycle action opens the canonical dialog; the palette owns no plan.
+    // A lifecycle action collects only its target, then opens the canonical
+    // dialog; the palette owns no plan or mutation behavior.
     const reopened = await openCommandPalette(appPage);
     await reopened.getByRole("combobox").fill("Archive profile");
     await reopened.getByTestId("os-palette-command-profile.archive").click();
-    await expect(appWindow(appPage, "settings")).toBeVisible();
+    const profileArgument = appPage.getByTestId("os-palette-arg-profile");
+    await profileArgument.fill("marketing");
+    await profileArgument.press("Enter");
+    await expect(ui.archiveDialog).toBeVisible();
+    await expect(ui.archiveDialog).toContainText("marketing");
   });
 
   test("E2E-015: All profiles labels every row, states the destination, and names the owner", async ({
@@ -395,6 +500,7 @@ test.describe("Profiles", () => {
     await createProfile(runtime, "marketing", "#c26ad6", "megaphone");
     await createProfile(runtime, "old-agency", "#b58e5f", "folder");
     await archiveProfile(runtime, "old-agency");
+    await createDefaultProfileSession(runtime, await activeWorkspaceId(runtime));
     await appPage.reload({ waitUntil: "domcontentloaded" });
 
     const ui = profilesOperatorSelectors(appPage);
@@ -403,7 +509,7 @@ test.describe("Profiles", () => {
     await expect(ui.switcher).toContainText("All profiles");
 
     // S3: every aggregate row names its owner, and an archived owner says so.
-    const sessions = await openAppWindow(appPage, "Sessions", "sessions");
+    const sessions = await openSessionsCatalog(appPage);
     const rows = profilesOperatorSelectors(appPage, sessions);
     await expect(rows.ownerTags.first()).toBeVisible();
 
@@ -413,6 +519,8 @@ test.describe("Profiles", () => {
     await expect(chip).toBeVisible();
     await expect(chip).toContainText("default");
     await expect(chip.locator("button, select, input")).toHaveCount(0);
+    await appPage.getByRole("button", { name: "Cancel", exact: true }).click();
+    await sessions.getByRole("button", { name: "Close sessions" }).click();
 
     // S11: the two axes compose — the globe stays independent of the profile.
     await appPage.getByTestId("os-global-scope-toggle").click();
@@ -432,14 +540,21 @@ test.describe("Profiles", () => {
     await ensureProjectWorkspace(appPage, runtime);
     await completeOnboardingIfPrompted(appPage);
     await createProfile(runtime, "consulting", "#4ea7fc", "briefcase");
+    const workspaceId = await activeWorkspaceId(runtime);
+    const agentName = await availableAgentName(runtime, workspaceId, "consulting");
     const foreign = await runtime.requestJSON<{ session: { id: string; agent_name: string } }>(
       "/api/sessions?profile=consulting",
-      { method: "POST", body: JSON.stringify({ agent_name: "claude-agent" }) }
+      {
+        method: "POST",
+        body: JSON.stringify({ agent_name: agentName, workspace: workspaceId }),
+      }
     );
     await appPage.reload({ waitUntil: "domcontentloaded" });
 
     const ui = profilesOperatorSelectors(appPage);
-    await appPage.goto(`/session/${foreign.session.id}`, { waitUntil: "domcontentloaded" });
+    await appPage.goto(runtime.url(`/session/${foreign.session.id}`), {
+      waitUntil: "domcontentloaded",
+    });
 
     // Informed, not blocked: the item resolves through the labeled aggregate read.
     await expect(ui.ownerBanner).toContainText("belongs to consulting");
@@ -471,6 +586,7 @@ test.describe("Profiles", () => {
     await ensureProjectWorkspace(appPage, runtime);
     await completeOnboardingIfPrompted(appPage);
     await createProfile(runtime, "marketing", "#c26ad6", "megaphone");
+    await recordDefaultProfileUsage(runtime, await activeWorkspaceId(runtime));
     await appPage.reload({ waitUntil: "domcontentloaded" });
 
     const home = await openAppWindow(appPage, "Home", "dashboard");
@@ -505,7 +621,7 @@ test.describe("Profiles", () => {
     await mkdir(agentDir, { recursive: true });
     await writeFile(
       path.join(agentDir, "AGENT.md"),
-      "---\nname: browser-dev\nprovider: anthropic\nmodel: claude-sonnet-4-20250514\n---\n",
+      "---\nname: browser-dev\ncategory_path: [Browser]\n---\n\nOwn browser development work.\n",
       "utf8"
     );
     const workspace = await runtime.resolveWorkspace(workspaceRoot);
@@ -527,10 +643,14 @@ test.describe("Profiles", () => {
     expect((await created).ok()).toBe(true);
     await expect(hint).toHaveCount(0);
 
-    const detail = await runtime.requestJSON<{ agents: Array<{ name: string }> }>(
-      `/api/workspaces/${workspace.id}?profile=dev`
-    );
-    expect(detail.agents.map(agent => agent.name)).toContain("browser-dev");
+    await expect
+      .poll(async () => {
+        const detail = await runtime.requestJSON<{ agents: Array<{ name: string }> }>(
+          `/api/agents?workspace=${encodeURIComponent(workspace.id)}&profile=dev`
+        );
+        return detail.agents.map(agent => agent.name);
+      })
+      .toContain("browser-dev");
   });
 
   test("E2E-028: palette results, ranking, and view sessions re-scope across a switch", async ({
@@ -540,6 +660,7 @@ test.describe("Profiles", () => {
     await ensureProjectWorkspace(appPage, runtime);
     await completeOnboardingIfPrompted(appPage);
     await createProfile(runtime, "marketing", "#c26ad6", "megaphone");
+    await createDefaultProfileSession(runtime, await activeWorkspaceId(runtime));
     await appPage.reload({ waitUntil: "domcontentloaded" });
 
     const ui = profilesOperatorSelectors(appPage);
@@ -551,17 +672,20 @@ test.describe("Profiles", () => {
     await openCommandPalette(appPage);
     expect((await scopedCatalog).ok()).toBe(true);
     await appPage.keyboard.press("Escape");
+    await expect(appPage.getByTestId("os-command-palette")).toBeHidden();
 
-    await ui.switcher.click();
-    await ui.switcherAll.click();
     const aggregateCatalog = appPage.waitForResponse(
       response =>
         response.url().includes("/api/cmd-palette/commands") &&
         response.url().includes("all_profiles=true")
     );
+    await ui.switcher.click();
+    await ui.switcherAll.click();
     const palette = await openCommandPalette(appPage);
     expect((await aggregateCatalog).ok()).toBe(true);
-    await palette.getByRole("combobox").fill("session");
+    await palette.getByRole("combobox").fill("Sessions");
+    await palette.getByTestId("os-palette-command-palette.view.sessions").click();
+    await expect(palette).toHaveAttribute("data-palette-view", "sessions");
     // The aggregate speaks the same owner vocabulary as the listings.
     await expect(profilesOperatorSelectors(appPage, palette).ownerTags.first()).toBeVisible();
   });
@@ -578,20 +702,27 @@ test.describe("Profiles", () => {
     // S1: notifications → palette → profile switcher → Settings, in that order.
     const order = await appPage.evaluate(() => {
       const slots = ["os-menubar-notifications", "os-menubar-command", "os-menubar-profile"];
-      const positions = slots.map(
-        slot =>
-          document.querySelector(`[data-testid="${slot}"]`)?.getBoundingClientRect().left ?? -1
-      );
+      const positions = slots.map(slot => {
+        const selector =
+          slot === "os-menubar-profile"
+            ? `[data-testid="${slot}"]`
+            : `[data-slot="${slot === "os-menubar-notifications" ? "os-menubar-bell" : slot}"]`;
+        return document.querySelector(selector)?.getBoundingClientRect().left ?? -1;
+      });
       const settings =
-        document.querySelector('[data-testid="os-menubar-settings"]')?.getBoundingClientRect()
-          .left ?? -1;
+        document.querySelector('[data-slot="os-menubar-settings"]')?.getBoundingClientRect().left ??
+        -1;
       return [...positions, settings];
     });
     expect(order).toEqual([...order].sort((left, right) => left - right));
 
     const ui = profilesOperatorSelectors(appPage);
     const palette = await openCommandPalette(appPage);
+    await palette.getByRole("combobox").fill("Profiles");
+    await palette.getByTestId("os-palette-command-palette.view.profiles").click();
+    await expect(paletteView(appPage, "profiles")).toBeVisible();
     await palette.getByRole("combobox").fill("marketing");
+    await expect(ui.paletteRow("marketing")).toBeVisible();
     await appPage.keyboard.press("Enter");
     await expect(ui.switcher).toContainText("marketing");
   });
@@ -609,6 +740,7 @@ test.describe("Profiles", () => {
     const peerPage = await second.newPage();
     try {
       await peerPage.goto(runtime.url("/"), { waitUntil: "domcontentloaded" });
+      await ensureProjectWorkspace(peerPage, runtime);
       await completeOnboardingIfPrompted(peerPage);
       const ui = profilesOperatorSelectors(appPage);
       const peer = profilesOperatorSelectors(peerPage);
@@ -721,7 +853,8 @@ test.describe("Profiles", () => {
     await tabUntilFocused(appPage, emojisTab, 4);
     await appPage.keyboard.press("Enter");
     await expect(emojis).toBeVisible();
-    await tabUntilFocused(appPage, iconsTab, 4);
+    await appPage.keyboard.press("Shift+Tab");
+    await expect(iconsTab).toBeFocused();
     await appPage.keyboard.press("Enter");
     await expect(icons).toBeVisible();
 

--- a/web/e2e/__tests__/session-clarify.spec.ts
+++ b/web/e2e/__tests__/session-clarify.spec.ts
@@ -10,7 +10,7 @@ import {
   type HostedMcpConnection,
 } from "../fixtures/hosted-mcp";
 import type { BrowserRuntime, RuntimePaths } from "../fixtures/runtime";
-import { sessionWindow } from "../fixtures/os-navigation";
+import { sessionWindow, switchWorkspace } from "../fixtures/os-navigation";
 import { sessionClarifySelectors, sessionWindowSelectors } from "../fixtures/selectors";
 import { expect, test } from "../fixtures/test";
 import { completeOnboardingIfPrompted } from "../fixtures/workspace";
@@ -104,6 +104,7 @@ test("operator answers a running clarification and unblocks the hosted-MCP call"
 
   await completeOnboardingIfPrompted(appPage);
   const workspace = await runtime.resolveWorkspace(runtime.paths.workspaceDir);
+  await switchWorkspace(appPage, workspace.id, workspace.name);
 
   const created = await runtime.requestJSON<SessionEnvelope>("/api/sessions", {
     method: "POST",
@@ -131,7 +132,7 @@ test("operator answers a running clarification and unblocks the hosted-MCP call"
     await sessionUI.composerTextarea.fill("hold native approval");
     await sessionUI.composerTextarea.press("Enter");
     await expect(appPage.getByText("native approval ready")).toBeVisible({ timeout: 20_000 });
-    await expect(sessionUI.stopButton).toBeVisible({ timeout: 20_000 });
+    await expect(sessionUI.composerStopButton).toBeVisible({ timeout: 20_000 });
 
     // The first prompt binds the accepted logical session and starts ACP. Connect promptly after
     // that bind so the hosted MCP server exists and its single-use nonce is still valid.

--- a/web/e2e/__tests__/session-hardening.spec.ts
+++ b/web/e2e/__tests__/session-hardening.spec.ts
@@ -141,9 +141,13 @@ test("first document navigation to a canonical session route loads the app shell
   await page.addInitScript(
     ({ workspaceId }) => {
       localStorage.setItem(
-        "compozy:active-workspace",
+        "compozy:active-workspace:v4",
         JSON.stringify({
-          state: { selectedWorkspaceId: workspaceId },
+          context: {
+            scope: "workspace",
+            selectedWorkspaceId: workspaceId,
+            worktreeByScope: {},
+          },
           version: 0,
         })
       );
@@ -325,6 +329,14 @@ test("operator cancels a running prompt, clears the transcript, and deletes the 
   await ui.composerTextarea.fill("block until canceled");
   await ui.composerTextarea.press("Enter");
   await expect(ui.chatView).toContainText("block until canceled");
+  await expect
+    .poll(async () => {
+      const transcript = await runtime.requestJSON<unknown>(
+        sessionAPIPath(workspace.id, session.id, "/transcript")
+      );
+      return JSON.stringify(transcript);
+    })
+    .toContain("block until canceled");
 
   const stopActionPaths = [
     sessionAPIPath(workspace.id, session.id, "/prompt/cancel"),
@@ -341,7 +353,7 @@ test("operator cancels a running prompt, clears the transcript, and deletes the 
 
   await expect(ui.topbarOverflow).toBeVisible({ timeout: 60_000 });
   const beforeClear = await captureSessionSnapshot(runtime, workspace.id, session.id);
-  expect(JSON.stringify(beforeClear.history)).toContain("block until canceled");
+  expect(JSON.stringify(beforeClear.transcript)).toContain("block until canceled");
 
   await ui.topbarOverflow.click();
   await ui.composerClearButton.click();
@@ -352,14 +364,20 @@ test("operator cancels a running prompt, clears the transcript, and deletes the 
       response.url().endsWith(sessionAPIPath(workspace.id, session.id, "/clear"))
   );
   await appPage.getByTestId("composer-clear-confirm").click();
-  expect((await clearResponsePromise).ok()).toBe(true);
+  const clearResponse = await clearResponsePromise;
+  if (!clearResponse.ok()) {
+    const daemonLog = runtime.paths?.daemonLog
+      ? await readFile(runtime.paths.daemonLog, "utf8")
+      : "daemon log unavailable";
+    throw new Error(`clear session returned ${clearResponse.status()}\n${daemonLog}`);
+  }
   await expect(ui.chatView).not.toContainText("block until canceled");
   await appPage.reload({ waitUntil: "domcontentloaded" });
   await expect(sessionWin).toBeVisible();
   await expect(ui.chatView).not.toContainText("block until canceled");
 
   const afterClear = await captureSessionSnapshot(runtime, workspace.id, session.id);
-  expect(JSON.stringify(afterClear.history)).not.toContain("block until canceled");
+  expect(JSON.stringify(afterClear.transcript)).not.toContain("block until canceled");
 
   const deletableSession = await createSession(runtime, faultAgent, workspace.id);
   await appPage.goto(runtime.url(sessionPath(faultAgent, deletableSession.id)), {
@@ -750,6 +768,7 @@ async function prepareSessionRuntime(
   const ui = sessionLifecycleSelectors(page);
   await page.goto(runtime.url("/"), { waitUntil: "domcontentloaded" });
   await completeOnboardingIfPrompted(ui);
+  await switchWorkspace(page, workspace.id, workspace.name);
   return workspace;
 }
 

--- a/web/e2e/__tests__/session-onboarding.spec.ts
+++ b/web/e2e/__tests__/session-onboarding.spec.ts
@@ -5,7 +5,7 @@ import { openAppWindow, sessionWindow } from "../fixtures/os-navigation";
 import { waitForSeedSessionActive } from "../fixtures/runtime";
 import { sessionLifecycleSelectors, sessionWindowSelectors } from "../fixtures/selectors";
 import { expect, test } from "../fixtures/test";
-import { completeOnboardingIfPrompted } from "../fixtures/workspace";
+import { ensureProjectWorkspace } from "../fixtures/workspace";
 
 const browserLifecycleFixture = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -52,7 +52,7 @@ test("operator can onboard, create a session, submit work, approve a permission 
 }) => {
   const ui = sessionLifecycleSelectors(appPage);
 
-  await completeOnboardingIfPrompted(ui);
+  await ensureProjectWorkspace(appPage, runtime);
   await expect(ui.osDesktop).toBeVisible();
   const agentsWin = await openAppWindow(appPage, "Agents", "agents");
   const fleet = sessionLifecycleSelectors(agentsWin);

--- a/web/e2e/__tests__/session-provider-override.spec.ts
+++ b/web/e2e/__tests__/session-provider-override.spec.ts
@@ -18,7 +18,7 @@ import {
   sessionWindowSelectors,
 } from "../fixtures/selectors";
 import { expect, test as base } from "../fixtures/test";
-import { completeOnboardingIfPrompted } from "../fixtures/workspace";
+import { ensureProjectWorkspace, completeOnboardingIfPrompted } from "../fixtures/workspace";
 
 const execFileAsync = promisify(execFile);
 
@@ -184,7 +184,7 @@ test("operator can create a provider/model override session and attach without l
 
   await expect(appPage.getByTestId("session-create-dialog")).toBeVisible();
   const createRequestPromise = appPage.waitForRequest(
-    request => request.method() === "POST" && request.url().endsWith("/api/sessions")
+    request => request.method() === "POST" && new URL(request.url()).pathname === "/api/sessions"
   );
   const createResponsePromise = appPage.waitForResponse(
     response =>
@@ -323,7 +323,7 @@ test("operator persists an advertised model and non-empty reasoning effort on th
 }) => {
   const ui = sessionLifecycleSelectors(appPage);
 
-  await completeOnboardingIfPrompted(ui);
+  await ensureProjectWorkspace(appPage, runtime);
   await expect(ui.osDesktop).toBeVisible();
   const agentsWin = await openAppWindow(appPage, "Agents", "agents");
   const fleet = sessionLifecycleSelectors(agentsWin);
@@ -336,7 +336,7 @@ test("operator persists an advertised model and non-empty reasoning effort on th
   await expect(appPage.getByTestId("session-create-dialog")).toBeVisible();
 
   const createRequestPromise = appPage.waitForRequest(
-    request => request.method() === "POST" && request.url().endsWith("/api/sessions")
+    request => request.method() === "POST" && new URL(request.url()).pathname === "/api/sessions"
   );
   const createResponsePromise = appPage.waitForResponse(
     response =>

--- a/web/e2e/__tests__/settings-transport.spec.ts
+++ b/web/e2e/__tests__/settings-transport.spec.ts
@@ -14,6 +14,7 @@ const remoteHTTPAPIBlockedMessage =
 test.use({
   runtimeOptions: {
     host: "0.0.0.0",
+    seedDefaultWorkspace: false,
     env: {
       ...process.env,
       COMPOZY_TEST_TELEGRAM_TOKEN: "telegram-bot-token",

--- a/web/e2e/__tests__/settings.spec.ts
+++ b/web/e2e/__tests__/settings.spec.ts
@@ -69,8 +69,10 @@ test("operator can navigate the settings shell and complete a restart-aware gene
     .poll(async () => normalizeTexts(await settingsUI.shell.sectionItems.allTextContents()))
     .toEqual([
       "General",
+      "Defaults",
       "Appearance",
       "Layouts",
+      "Profiles",
       "Palette",
       "Providers",
       "Memory",
@@ -146,10 +148,14 @@ test("operator can navigate the settings shell and complete a restart-aware gene
   await expect
     .poll(
       async () => {
-        const payload = await runtime.requestJSON<{ status: string }>(
-          `/api/settings/actions/restart/${encodeURIComponent(operationID)}`
-        );
-        return payload.status;
+        try {
+          const payload = await runtime.requestJSON<{ status: string }>(
+            `/api/settings/actions/restart/${encodeURIComponent(operationID)}`
+          );
+          return payload.status;
+        } catch {
+          return "unavailable";
+        }
       },
       {
         timeout: 45_000,
@@ -321,13 +327,31 @@ test("E2E-026: notification preset enablement follows the active profile", async
   const profiles = profilesOperatorSelectors(appPage);
   await profiles.switcher.click();
   await profiles.switcherOption("marketing").click();
-  await expect(profileLabel).toContainText("marketing");
-  await expect(taskTerminalToggle).toBeChecked();
+  await appPage.goto(runtime.url("/settings/hooks"), { waitUntil: "domcontentloaded" });
+  const marketingSettingsWin = appWindow(appPage, "settings");
+  await expect(marketingSettingsWin).toBeVisible();
+  const marketingProfileLabel = marketingSettingsWin.getByTestId(
+    "settings-page-hooks-notification-preset-profile"
+  );
+  const marketingTaskTerminalToggle = marketingSettingsWin.getByTestId(
+    "settings-page-hooks-notification-preset-row-task_terminal-toggle"
+  );
+  await expect(marketingProfileLabel).toContainText("marketing");
+  await expect(marketingTaskTerminalToggle).toBeChecked();
 
   await profiles.switcher.click();
   await profiles.switcherOption("default").click();
-  await expect(profileLabel).toContainText("default");
-  await expect(taskTerminalToggle).not.toBeChecked();
+  await appPage.goto(runtime.url("/settings/hooks"), { waitUntil: "domcontentloaded" });
+  const defaultSettingsWin = appWindow(appPage, "settings");
+  await expect(defaultSettingsWin).toBeVisible();
+  await expect(
+    defaultSettingsWin.getByTestId("settings-page-hooks-notification-preset-profile")
+  ).toContainText("default");
+  await expect(
+    defaultSettingsWin.getByTestId(
+      "settings-page-hooks-notification-preset-row-task_terminal-toggle"
+    )
+  ).not.toBeChecked();
 });
 
 test("operator can distinguish skills actions that apply now from policy changes that require restart", async ({
@@ -614,11 +638,18 @@ test("operator routes a background role, persists it across reload, and keeps bu
 }) => {
   const sessionUI = sessionLifecycleSelectors(appPage);
   const settingsUI = settingsOperatorSelectors(appPage);
-  const nextModel = "claude-haiku-4-5";
-  const nextModelLabel = "Claude Haiku 4.5";
 
   await ensureProjectWorkspace(appPage, runtime);
   await completeOnboardingIfPrompted(sessionUI);
+  const catalog = await runtime.requestJSON<{
+    models: Array<{ display_name?: string; model_id: string; provider_id: string }>;
+  }>("/api/model-catalog/models?include_stale=true&view=all");
+  const next =
+    catalog.models.find(model => model.model_id === "claude-haiku-4-5") ?? catalog.models[0];
+  if (!next) throw new Error("model catalog must advertise a background-role candidate");
+  const nextModel = next.model_id;
+  const nextModelLabel = next.display_name?.trim() || nextModel;
+  const nextProvider = next.provider_id;
   await appPage.goto(runtime.url("/settings/roles"), { waitUntil: "domcontentloaded" });
 
   await expect(settingsUI.roles.page).toBeVisible({ timeout: 20_000 });
@@ -638,7 +669,7 @@ test("operator routes a background role, persists it across reload, and keeps bu
   // provider/model decision instead of treating a known model as a custom ID.
   await appPage.getByTestId("runtime-selector-search").fill(nextModel);
   await appPage
-    .locator(`[role="option"][data-provider="opencode"][data-model="${nextModel}"]`)
+    .locator(`[role="option"][data-provider="${nextProvider}"][data-model="${nextModel}"]`)
     .click();
   await appPage.keyboard.press("Escape");
   await expect(appPage.getByTestId("runtime-selector-popup")).toHaveCount(0);
@@ -660,7 +691,7 @@ test("operator routes a background role, persists it across reload, and keeps bu
     readyTestId: "settings-page-roles",
   });
   await expect(settingsUI.roles.routeSummary("auto_title")).toContainText(
-    `opencode · ${nextModel}`
+    `${nextProvider} · ${nextModel}`
   );
 
   const section = await runtime.requestJSON<{ config: { auto_title: { model: string } } }>(

--- a/web/e2e/__tests__/tasks-coordinator-handoff.spec.ts
+++ b/web/e2e/__tests__/tasks-coordinator-handoff.spec.ts
@@ -297,6 +297,10 @@ test("starting a manual session is unaffected by task autonomy labels", async ({
   const sessionUI = sessionLifecycleSelectors(appPage);
 
   await ensureProjectWorkspace(appPage, runtime);
+  if (!runtime.paths?.workspaceDir) {
+    throw new Error("manual session browser test requires launch-mode workspace paths");
+  }
+  const workspace = await runtime.resolveWorkspace(runtime.paths.workspaceDir);
   await appPage.goto(runtime.url("/"), { waitUntil: "domcontentloaded" });
   await completeOnboardingIfPrompted(appPage);
 
@@ -344,7 +348,7 @@ test("starting a manual session is unaffected by task autonomy labels", async ({
 
   const sessions = await runtime.requestJSON<{
     sessions: Array<{ id: string; agent_name: string; state?: string }>;
-  }>("/api/sessions");
+  }>(`/api/sessions?workspace_id=${encodeURIComponent(workspace.id)}`);
   expect(
     sessions.sessions.some(
       session => session.id === sessionId && session.agent_name === handoffAgentName

--- a/web/e2e/__tests__/tasks-hardening.spec.ts
+++ b/web/e2e/__tests__/tasks-hardening.spec.ts
@@ -803,6 +803,7 @@ test("tasks list and kanban surface needs_attention as a distinct status", async
 
   await appPage.goto(runtime.url("/tasks"), { waitUntil: "domcontentloaded" });
   await completeOnboardingIfPrompted(ui);
+  await setGlobalScope(appPage, true);
   if ((await ui.modeList.getAttribute("aria-current")) !== "page") {
     await ui.modeList.click();
   }

--- a/web/e2e/__tests__/tasks.spec.ts
+++ b/web/e2e/__tests__/tasks.spec.ts
@@ -53,8 +53,8 @@ test.afterAll(async () => {
   await rm(tasksLoopWorkspaceRoot, { force: true, recursive: true });
 });
 
-function tasksSessionPath(sessionId: string): string {
-  return `/agents/${tasksSessionAgentName}/sessions/${sessionId}`;
+function tasksSessionPath(agentName: string, sessionId: string): string {
+  return `/agents/${encodeURIComponent(agentName)}/sessions/${encodeURIComponent(sessionId)}`;
 }
 
 function uniqueDraftTitle(prefix: string): string {
@@ -203,7 +203,7 @@ test("operator can execute the shipped Tasks flow through the shared daemon-serv
   await tasksUI.runSessionDrilldown.click();
   await expect
     .poll(() => new URL(appPage.url()).pathname)
-    .toBe(tasksSessionPath(seeded.session.id));
+    .toBe(tasksSessionPath(seeded.session.agent_name, seeded.session.id));
   const sessionWin = sessionWindowSelectors(sessionWindow(appPage, seeded.session.id));
   await expect(sessionWin.chatView).toBeVisible();
   await browserArtifacts.captureScreenshot("tasks-linked-session", appPage);
@@ -353,6 +353,13 @@ test("operator sets the task worktree policy from the setup sheet", async ({
 
   await modes.filter({ hasText: "Per-run" }).click();
   await expect(policy).toHaveAttribute("data-mode", "per_run");
+  const saveProfile = appPage.waitForResponse(
+    response =>
+      response.request().method() === "PUT" &&
+      new URL(response.url()).pathname === `/api/tasks/${taskId}/execution-profile`
+  );
+  await appPage.getByTestId("tasks-setup-editor-save").click();
+  expect((await saveProfile).ok()).toBe(true);
   await expect
     .poll(async () => {
       const profile = await runtime.requestJSON<{ profile: { worktree: { mode: string } } }>(
@@ -364,6 +371,7 @@ test("operator sets the task worktree policy from the setup sheet", async ({
 
   // The reference picker only exists in `ref` mode, and only offers ready
   // worktrees from this task's own workspace.
+  await appPage.getByTestId("tasks-setup-edit").click();
   await modes.filter({ hasText: "Named worktree" }).click();
   await expect(appPage.getByTestId("tasks-setup-worktree-ref")).toBeVisible();
 });
@@ -532,6 +540,7 @@ interface SeededLoopRecords {
   loopName: string;
   coordinatorTaskId: string;
   cellTaskId: string;
+  profileId: string;
   workspaceId: string;
 }
 
@@ -595,11 +604,11 @@ async function seedLoopRecords(
     .toBe(true);
 
   const revealed = await runtime.requestJSON<{
-    tasks: Array<{ id: string; loop?: { role?: string } }>;
+    tasks: Array<{ id: string; profile_id: string; loop?: { role?: string } }>;
   }>(revealedPath);
   const coordinator = revealed.tasks.find(task => task.loop?.role === "coordinator");
   const cell = revealed.tasks.find(task => task.loop?.role === "cell");
-  if (!coordinator || !cell) {
+  if (!coordinator || !cell || coordinator.profile_id.trim() === "") {
     throw new Error(`Loop legibility seed produced no records: ${JSON.stringify(revealed)}`);
   }
   return {
@@ -607,6 +616,7 @@ async function seedLoopRecords(
     loopName,
     coordinatorTaskId: coordinator.id,
     cellTaskId: cell.id,
+    profileId: coordinator.profile_id,
     workspaceId: workspace.id,
   };
 }
@@ -674,7 +684,7 @@ test.describe("Loop record legibility", () => {
 
     const trueEmpty = tasksWin.getByTestId("tasks-empty-state");
     await expect(trueEmpty).toBeVisible();
-    await expect(trueEmpty).toContainText("No tasks yet");
+    await expect(trueEmpty).toContainText("No tasks in default yet");
     await expect(tasksWin.locator('[data-slot="task-loop-row"]')).toHaveCount(0);
     await expect(tasksUI.taskCard(seeded.coordinatorTaskId)).toHaveCount(0);
     await expect(tasksUI.taskCard(seeded.cellTaskId)).toHaveCount(0);
@@ -850,6 +860,7 @@ test.describe("Loop record legibility", () => {
     // the record reads as a Loop step purely from projected provenance.
     const retained = await seedRetainedLoopTask(runtime, {
       loopRunId: RETAINED_LOOP_RUN_ID,
+      profileId: seeded.profileId,
       runId: "run-retained-loop-record",
       taskId: RETAINED_TASK_ID,
       workspaceId: seeded.workspaceId,

--- a/web/e2e/__tests__/tool-approval-grants.spec.ts
+++ b/web/e2e/__tests__/tool-approval-grants.spec.ts
@@ -10,7 +10,7 @@ import {
   type HostedMcpConnection,
 } from "../fixtures/hosted-mcp";
 import type { BrowserRuntime, RuntimePaths } from "../fixtures/runtime";
-import { sessionWindow } from "../fixtures/os-navigation";
+import { sessionWindow, switchWorkspace } from "../fixtures/os-navigation";
 import { sessionWindowSelectors, toolApprovalGrantsSelectors } from "../fixtures/selectors";
 import { expect, test } from "../fixtures/test";
 import { completeOnboardingIfPrompted } from "../fixtures/workspace";
@@ -83,6 +83,7 @@ test("operator remembers a native-tool decision and revokes it end to end", asyn
   // The session and its remembered decision belong to the isolated project runtime binding.
   await completeOnboardingIfPrompted(appPage);
   const workspace = await runtime.resolveWorkspace(runtime.paths.workspaceDir);
+  await switchWorkspace(appPage, workspace.id, workspace.name);
 
   const created = await runtime.requestJSON<SessionEnvelope>("/api/sessions", {
     method: "POST",
@@ -112,7 +113,7 @@ test("operator remembers a native-tool decision and revokes it end to end", asyn
     await sessionUI.composerTextarea.fill("hold native approval");
     await sessionUI.composerTextarea.press("Enter");
     await expect(appPage.getByText("native approval ready")).toBeVisible({ timeout: 20_000 });
-    await expect(sessionUI.stopButton).toBeVisible({ timeout: 20_000 });
+    await expect(sessionUI.composerStopButton).toBeVisible({ timeout: 20_000 });
 
     // The first prompt binds the accepted logical session and starts ACP. Connect promptly after
     // that bind so the hosted MCP server exists and its single-use nonce is still valid.

--- a/web/e2e/__tests__/triggers-hardening.spec.ts
+++ b/web/e2e/__tests__/triggers-hardening.spec.ts
@@ -195,7 +195,8 @@ test("operator creates updates fires disables re-enables and deletes a webhook t
 
   const createResponse = appPage.waitForResponse(
     response =>
-      response.request().method() === "POST" && response.url().endsWith("/api/automation/triggers")
+      response.request().method() === "POST" &&
+      new URL(response.url()).pathname === "/api/automation/triggers"
   );
   await ui.submitTriggerForm.click();
   const createBody = await (await createResponse).text();
@@ -218,7 +219,8 @@ test("operator creates updates fires disables re-enables and deletes a webhook t
   const updateResponse = appPage.waitForResponse(
     response =>
       response.request().method() === "PATCH" &&
-      response.url().endsWith(`/api/automation/triggers/${encodeURIComponent(created.id)}`)
+      new URL(response.url()).pathname ===
+        `/api/automation/triggers/${encodeURIComponent(created.id)}`
   );
   await ui.submitTriggerForm.click();
   const updateBody = await (await updateResponse).text();
@@ -329,12 +331,7 @@ test("operator creates updates fires disables re-enables and deletes a webhook t
     runtime,
     reenabledRun.workspace_id
   );
-  const parity = await captureTriggerParity(
-    runtime,
-    updated.id,
-    reenabledRun.id,
-    reenabledWorkspaceID
-  );
+  const parity = await captureTriggerParity(runtime, updated.id, reenabledRun.id);
   expect(parity.http.trigger.name).toBe(editedName);
   expect(parity.uds.trigger.webhook_id).toBe(webhookID);
   expect(parity.cliGet.id).toBe(updated.id);
@@ -374,6 +371,9 @@ test("operator creates updates fires disables re-enables and deletes a webhook t
   if (!reenabledSessionId) {
     throw new Error("Expected the re-enabled trigger run to expose a linked session.");
   }
+  const workspaceSwitchDialog = appPage.getByRole("dialog", { name: "Switch workspace?" });
+  await expect(workspaceSwitchDialog).toBeVisible();
+  await workspaceSwitchDialog.getByRole("button", { name: "Switch workspace" }).click();
   const sessionUI = sessionWindowSelectors(sessionWindow(appPage, reenabledSessionId));
   await expect(sessionUI.chatView).toBeVisible();
   await expect(sessionUI.chatView).toContainText("Review payload deploy for main");
@@ -481,7 +481,7 @@ test("failed webhook trigger run is diagnosable with retry evidence and no secre
   await expect(ui.run(failedRun.id)).toContainText(failureSummary);
 
   const failedWorkspaceID = await resolveAutomationWorkspaceID(runtime, failedRun.workspace_id);
-  const parity = await captureTriggerParity(runtime, trigger.id, failedRun.id, failedWorkspaceID);
+  const parity = await captureTriggerParity(runtime, trigger.id, failedRun.id);
   expect(parity.httpRun.run.status).toBe("failed");
   expect(parity.cliRun.status).toBe("failed");
   expect(parity.cliHistory.runs.some(run => run.id === failedRun.id && run.attempt > 1)).toBe(true);
@@ -577,12 +577,7 @@ test("operator sees fire-limit rejection across browser and runtime surfaces", a
   await expect(ui.run(limitedRun?.id ?? "")).toContainText("Failed");
   await expect(ui.runHistory).toContainText("Completed");
   const acceptedWorkspaceID = await resolveAutomationWorkspaceID(runtime, acceptedRun.workspace_id);
-  const parity = await captureTriggerParity(
-    runtime,
-    trigger.id,
-    acceptedRun.id,
-    acceptedWorkspaceID
-  );
+  const parity = await captureTriggerParity(runtime, trigger.id, acceptedRun.id);
   expect(parity.httpRuns.runs).toHaveLength(2);
   expect(parity.cliHistory.runs).toHaveLength(2);
   await runtime.artifactCollector.captureJSON("browser_api_snapshots", {
@@ -758,12 +753,7 @@ async function waitForLatestTriggerRun(
   return matched;
 }
 
-async function captureTriggerParity(
-  runtime: BrowserRuntime,
-  triggerID: string,
-  runID: string,
-  workspaceID: string
-) {
+async function captureTriggerParity(runtime: BrowserRuntime, triggerID: string, runID: string) {
   const http = await getTrigger(runtime, triggerID);
   const uds = await requestOperatorJSONOrThrow<TriggerResponse>(
     runtime,
@@ -790,11 +780,22 @@ async function captureTriggerParity(
     "50",
   ]);
   const cliRun = await automationCLI<AutomationRun>(runtime, ["automation", "runs", "get", runID]);
-  const observe = httpRun.run.session_id
-    ? await runtime.requestJSON<LogsListResponse>(
-        workspaceListLogsPath(workspaceID, httpRun.run.session_id)
+  let observe: LogsListResponse = { events: [] };
+  if (httpRun.run.session_id) {
+    const owner = await runtime.requestJSON<{ workspace_id: string }>(
+      `/api/sessions/${encodeURIComponent(httpRun.run.session_id)}/owner`
+    );
+    const logsPath = workspaceListLogsPath(owner.workspace_id, httpRun.run.session_id);
+    await expect
+      .poll(
+        async () => {
+          observe = await runtime.requestJSON<LogsListResponse>(logsPath);
+          return observe.events.length;
+        },
+        { timeout: 20_000 }
       )
-    : { events: [] };
+      .toBeGreaterThan(0);
+  }
   return {
     cliGet,
     cliHistory,

--- a/web/e2e/__tests__/workspace-setup.spec.ts
+++ b/web/e2e/__tests__/workspace-setup.spec.ts
@@ -119,12 +119,14 @@ test.describe("first-run default model", () => {
         response.request().method() === "PUT" &&
         response.url().endsWith(`/api/settings/providers/${mockAgentProvider}`)
     );
-    const generalRequestPromise = appPage.waitForRequest(
-      request => request.method() === "PATCH" && request.url().endsWith("/api/settings/general")
+    const personaRequestPromise = appPage.waitForRequest(
+      request =>
+        request.method() === "PATCH" && new URL(request.url()).pathname === "/api/settings/persona"
     );
-    const generalResponsePromise = appPage.waitForResponse(
+    const personaResponsePromise = appPage.waitForResponse(
       response =>
-        response.request().method() === "PATCH" && response.url().endsWith("/api/settings/general")
+        response.request().method() === "PATCH" &&
+        new URL(response.url()).pathname === "/api/settings/persona"
     );
 
     await expect(appPage.getByTestId("onboarding-continue")).toBeEnabled();
@@ -141,12 +143,12 @@ test.describe("first-run default model", () => {
     });
     expect(providerResponse.ok()).toBe(true);
 
-    const generalRequest = await generalRequestPromise;
-    const generalResponse = await generalResponsePromise;
-    expect(generalRequest.postDataJSON()).toMatchObject({
-      config: { defaults: { provider: mockAgentProvider } },
+    const personaRequest = await personaRequestPromise;
+    const personaResponse = await personaResponsePromise;
+    expect(personaRequest.postDataJSON()).toMatchObject({
+      config: { provider: mockAgentProvider },
     });
-    expect(generalResponse.ok()).toBe(true);
+    expect(personaResponse.ok()).toBe(true);
     await expect(appPage.getByTestId("onboarding-step-workspaces")).toBeVisible();
 
     const provider = await runtime.requestJSON<{

--- a/web/e2e/__tests__/worktrees.spec.ts
+++ b/web/e2e/__tests__/worktrees.spec.ts
@@ -128,7 +128,9 @@ async function openOverviewMenu(page: Page, workspaceId: string) {
   await page.getByRole("menuitem", { name: /^Workspace picker/ }).click();
   await expect(page.getByTestId("os-workspaces-overview")).toBeVisible();
   // The focused tile anchors the always-visible vertical worktree menu.
-  await expect(page.getByTestId(`os-workspace-tile-${workspaceId}`)).toBeVisible();
+  const workspaceTile = page.getByTestId(`os-workspace-tile-${workspaceId}`);
+  await expect(workspaceTile).toBeVisible();
+  await workspaceTile.hover();
   await expect(page.getByTestId("os-workspaces-worktree-menu")).toBeVisible();
 }
 

--- a/web/e2e/fixtures/__tests__/selectors.test.ts
+++ b/web/e2e/fixtures/__tests__/selectors.test.ts
@@ -81,6 +81,9 @@ describe("session window selectors", () => {
       `portal-locator:${sessionWindowTestIds.composerClearButton}`
     );
     expect(selectors.composerSendButton).toBe("win-role:button:Send message");
+    expect(selectors.composerStopButton).toBe(
+      `win-locator:${sessionWindowTestIds.composerStopButton}`
+    );
     expect(selectors.composerTextarea).toBe("win-role:textbox:Session prompt");
     expect(selectors.deleteButton).toBe(`portal-locator:${sessionWindowTestIds.deleteButton}`);
     expect(selectors.permissionAllowAlways).toBe(

--- a/web/e2e/fixtures/os-navigation.ts
+++ b/web/e2e/fixtures/os-navigation.ts
@@ -120,10 +120,23 @@ export function commandPalette(page: Page): Locator {
 
 /** Opens ⌘K and waits for the overlay; the palette must not block on the daemon. */
 export async function openCommandPalette(page: Page): Promise<Locator> {
-  await page.keyboard.press("ControlOrMeta+KeyK");
   const palette = commandPalette(page);
-  await expect(palette).toBeVisible();
+  await expect(async () => {
+    if (await palette.isVisible().catch(() => false)) return;
+    await page.keyboard.press("ControlOrMeta+KeyK");
+    await expect(palette).toBeVisible({ timeout: 500 });
+  }).toPass({ timeout: 20_000 });
   return palette;
+}
+
+/** Opens the dedicated Sessions catalog through its current public menu command. */
+export async function openSessionsCatalog(page: Page): Promise<Locator> {
+  await page.getByRole("menuitem", { name: "Session", exact: true }).click();
+  await expect(page.getByTestId("os-menu-session")).toBeVisible();
+  await page.getByTestId("os-menubar-command-shell.sessions.toggle").click();
+  const catalog = page.getByTestId("os-sessions-modal");
+  await expect(catalog).toBeVisible();
+  return catalog;
 }
 
 /** One command row, addressed by its registry id. */

--- a/web/e2e/fixtures/retained-loop-task-seeder/main.go
+++ b/web/e2e/fixtures/retained-loop-task-seeder/main.go
@@ -112,7 +112,9 @@ func parseOptions(args []string) (options, error) {
 		strings.TrimSpace(parsed.workspaceID) == "" ||
 		strings.TrimSpace(parsed.taskID) == "" || strings.TrimSpace(parsed.runID) == "" ||
 		strings.TrimSpace(parsed.loopRunID) == "" {
-		return options{}, errors.New("retained Loop task seeder requires home, profile, workspace, task, run, and loop-run")
+		return options{}, errors.New(
+			"retained Loop task seeder requires home, profile, workspace, task, run, and loop-run",
+		)
 	}
 	return parsed, nil
 }

--- a/web/e2e/fixtures/retained-loop-task-seeder/main.go
+++ b/web/e2e/fixtures/retained-loop-task-seeder/main.go
@@ -17,6 +17,7 @@ import (
 
 type options struct {
 	homeDir     string
+	profileID   string
 	workspaceID string
 	taskID      string
 	runID       string
@@ -54,6 +55,7 @@ func run(ctx context.Context, args []string) (err error) {
 	}
 	record := taskpkg.Task{
 		ID:             options.taskID,
+		ProfileID:      options.profileID,
 		Scope:          taskpkg.ScopeWorkspace,
 		WorkspaceID:    options.workspaceID,
 		Title:          "Retained Loop execution record",
@@ -98,6 +100,7 @@ func parseOptions(args []string) (options, error) {
 	flags.SetOutput(os.Stderr)
 	var parsed options
 	flags.StringVar(&parsed.homeDir, "home", "", "isolated CompozyOS home")
+	flags.StringVar(&parsed.profileID, "profile", "", "owning profile id")
 	flags.StringVar(&parsed.workspaceID, "workspace", "", "workspace id")
 	flags.StringVar(&parsed.taskID, "task", "", "task id")
 	flags.StringVar(&parsed.runID, "run", "", "task run id")
@@ -105,10 +108,11 @@ func parseOptions(args []string) (options, error) {
 	if err := flags.Parse(args); err != nil {
 		return options{}, err
 	}
-	if strings.TrimSpace(parsed.homeDir) == "" || strings.TrimSpace(parsed.workspaceID) == "" ||
+	if strings.TrimSpace(parsed.homeDir) == "" || strings.TrimSpace(parsed.profileID) == "" ||
+		strings.TrimSpace(parsed.workspaceID) == "" ||
 		strings.TrimSpace(parsed.taskID) == "" || strings.TrimSpace(parsed.runID) == "" ||
 		strings.TrimSpace(parsed.loopRunID) == "" {
-		return options{}, errors.New("retained Loop task seeder requires home, workspace, task, run, and loop-run")
+		return options{}, errors.New("retained Loop task seeder requires home, profile, workspace, task, run, and loop-run")
 	}
 	return parsed, nil
 }

--- a/web/e2e/fixtures/retained-loop-task.ts
+++ b/web/e2e/fixtures/retained-loop-task.ts
@@ -10,6 +10,7 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../
 
 export interface RetainedLoopTaskSeed {
   loopRunId: string;
+  profileId: string;
   runId: string;
   taskId: string;
   workspaceId: string;
@@ -40,6 +41,8 @@ export async function seedRetainedLoopTask(
       runtime.paths.homeDir,
       "--workspace",
       seed.workspaceId,
+      "--profile",
+      seed.profileId,
       "--task",
       seed.taskId,
       "--run",

--- a/web/e2e/fixtures/runtime.ts
+++ b/web/e2e/fixtures/runtime.ts
@@ -83,6 +83,7 @@ export interface BrowserRuntimeOptions {
   networkEnabled?: boolean;
   readyTimeoutMs?: number;
   seed?: BrowserRuntimeSeed;
+  seedDefaultWorkspace?: boolean;
   toolsExternalDefault?: "disabled" | "ask" | "enabled";
 }
 
@@ -230,7 +231,9 @@ export async function createBrowserRuntime(
       paths,
       launchState: runtime,
     });
-    const seeded = await applyBrowserRuntimeSeed(activeRuntime, options.seed, paths.workspaceDir);
+    const fallbackWorkspace =
+      options.seedDefaultWorkspace === false ? undefined : paths.workspaceDir;
+    const seeded = await applyBrowserRuntimeSeed(activeRuntime, options.seed, fallbackWorkspace);
     return activeRuntime.withSeeded(seeded);
   } catch (error) {
     return await cleanupFailedRuntimeLaunch(

--- a/web/e2e/fixtures/selectors.ts
+++ b/web/e2e/fixtures/selectors.ts
@@ -40,6 +40,7 @@ export const sessionWindowTestIds = {
   composerDropOverlay: "composer-drop-overlay",
   composerQueuedAttachmentWell: "composer-queued-attachment-well",
   composerSendButton: "composer-send-button",
+  composerStopButton: "composer-stop-button",
   deleteButton: "delete-button",
   permissionAllowAlways: "permission-allow-always",
   permissionAllowOnce: "permission-allow-once",
@@ -72,6 +73,7 @@ export interface SessionWindowSelectors {
   composerDropOverlay: Locator;
   composerQueuedAttachmentWell: Locator;
   composerSendButton: Locator;
+  composerStopButton: Locator;
   composerTextarea: Locator;
   deleteButton: Locator;
   permissionAllowAlways: Locator;
@@ -1011,6 +1013,7 @@ export function sessionWindowSelectors(
       sessionWindowTestIds.composerQueuedAttachmentWell
     ),
     composerSendButton: win.getByRole("button", { name: "Send message" }),
+    composerStopButton: win.getByTestId(sessionWindowTestIds.composerStopButton),
     composerTextarea: win.getByRole("textbox", { name: "Session prompt" }),
     deleteButton: portalRoot.getByTestId(sessionWindowTestIds.deleteButton),
     permissionAllowAlways: win.getByTestId(sessionWindowTestIds.permissionAllowAlways),

--- a/web/e2e/fixtures/workspace.ts
+++ b/web/e2e/fixtures/workspace.ts
@@ -101,20 +101,17 @@ async function completeFirstRunOnboarding(page: Page): Promise<void> {
         body: JSON.stringify({ settings: provider.settings }),
         method: "PUT",
       });
-      const general = await requestJSON<{ config?: { defaults?: Record<string, unknown> } }>(
-        "/api/settings/general"
-      );
-      if (!general.config) {
-        throw new Error("First-run E2E bootstrap could not load general settings.");
+      const persona = await requestJSON<{
+        config?: { agent?: string; provider?: string; sandbox?: string };
+      }>("/api/settings/persona?scope=user");
+      if (!persona.config) {
+        throw new Error("First-run E2E bootstrap could not load default profile settings.");
       }
-      await requestJSON("/api/settings/general", {
+      await requestJSON("/api/settings/persona?scope=user", {
         body: JSON.stringify({
           config: {
-            ...general.config,
-            defaults: {
-              ...general.config.defaults,
-              provider: provider.name,
-            },
+            ...persona.config,
+            provider: provider.name,
           },
         }),
         method: "PATCH",

--- a/web/src/routes/_app/-agent-session-route-loader.ts
+++ b/web/src/routes/_app/-agent-session-route-loader.ts
@@ -1,9 +1,10 @@
 import type { QueryClient } from "@tanstack/react-query";
 
-import { resolveActiveWorkspaceId } from "./-route-preload";
+import { resolveDesktopWorkspaceId } from "./-route-preload";
 import {
   cachedForeignSessionOwner,
-  resolveForeignSessionOwner,
+  resolveSessionOwner,
+  sessionAcrossProfilesOptions,
   sessionDetailOptions,
   sessionScopedDetailOptions,
   SessionNotFoundError,
@@ -34,7 +35,7 @@ export async function prefetchAgentSessionRoute({
   queryClient: QueryClient;
   sessionId: string;
 }): Promise<AgentSessionRouteLoaderData> {
-  const workspaceId = await resolveActiveWorkspaceId(queryClient);
+  const workspaceId = await resolveDesktopWorkspaceId(queryClient);
   if (!workspaceId) {
     return { status: "not-found" };
   }
@@ -75,9 +76,16 @@ async function resolveForeignSession(
   sessionId: string,
   activeWorkspaceId: string
 ): Promise<AgentSessionRouteLoaderData> {
-  const owner = await resolveForeignSessionOwner(queryClient, sessionId, activeWorkspaceId);
+  const owner = await resolveSessionOwner(queryClient, sessionId);
   if (!owner) {
     return { status: "not-found" };
+  }
+  if (owner.workspaceId === activeWorkspaceId) {
+    await queryClient.ensureQueryData(sessionAcrossProfilesOptions(sessionId));
+    await Promise.allSettled([
+      queryClient.ensureInfiniteQueryData(sessionTranscriptOptions(activeWorkspaceId, sessionId)),
+    ]);
+    return { status: "loaded", workspaceId: activeWorkspaceId };
   }
   return { status: "foreign", owner };
 }

--- a/web/src/routes/_app/-route-preload.ts
+++ b/web/src/routes/_app/-route-preload.ts
@@ -53,6 +53,12 @@ export async function resolveActiveWorkspaceId(queryClient: QueryClient): Promis
   return resolution.runtimeWorkspaceId;
 }
 
+/** Workspace that owns the mounted desktop, including while data scope is Global. */
+export async function resolveDesktopWorkspaceId(queryClient: QueryClient): Promise<string | null> {
+  const resolution = await resolveActiveWorkspaceSelection(queryClient);
+  return resolution.desktopWorkspaceId;
+}
+
 function loadWorkspaceSelection(queryClient: QueryClient) {
   const hydration = isActiveWorkspaceStoreHydrated()
     ? Promise.resolve()

--- a/web/src/routes/_app/-session-permalink-route.ts
+++ b/web/src/routes/_app/-session-permalink-route.ts
@@ -4,10 +4,11 @@ import { redirect } from "@tanstack/react-router";
 import type { RouterContext } from "@/integrations/tanstack-query/root-context";
 
 import type { TopbarRouteContext } from "@/types/topbar";
-import { resolveActiveWorkspaceId } from "./-route-preload";
+import { resolveDesktopWorkspaceId } from "./-route-preload";
 import {
   cachedForeignSessionOwner,
-  resolveForeignSessionOwner,
+  resolveSessionOwner,
+  sessionAcrossProfilesOptions,
   sessionDetailOptions,
   type SessionDeepLinkSearch,
   sessionScopedDetailOptions,
@@ -87,7 +88,10 @@ export async function resolveSessionPermalink({
   queryClient: QueryClient;
   sessionId: string;
 }): Promise<SessionPermalinkResolution> {
-  const workspaceId = await resolveActiveWorkspaceId(queryClient);
+  // Global data scope still renders inside the remembered project's desktop.
+  // Session windows belong to that durable layout partition, not to the
+  // workspace-free catalog lens used by global listings.
+  const workspaceId = await resolveDesktopWorkspaceId(queryClient);
   if (!workspaceId) {
     throw new SessionNotFoundError(sessionId);
   }
@@ -128,9 +132,16 @@ async function resolveForeignPermalink(
   sessionId: string,
   activeWorkspaceId: string
 ): Promise<SessionPermalinkResolution> {
-  const owner = await resolveForeignSessionOwner(queryClient, sessionId, activeWorkspaceId);
+  const owner = await resolveSessionOwner(queryClient, sessionId);
   if (!owner) {
     throw new SessionNotFoundError(sessionId);
+  }
+  if (owner.workspaceId === activeWorkspaceId) {
+    const session = await queryClient.ensureQueryData(sessionAcrossProfilesOptions(sessionId));
+    await Promise.allSettled([
+      queryClient.ensureInfiniteQueryData(sessionTranscriptOptions(activeWorkspaceId, sessionId)),
+    ]);
+    return { status: "resolved", session };
   }
   return { status: "foreign", owner };
 }

--- a/web/src/routes/_app/__tests__/-agent-session-deeplink.router.integration.test.tsx
+++ b/web/src/routes/_app/__tests__/-agent-session-deeplink.router.integration.test.tsx
@@ -38,6 +38,7 @@ import { statusKeys, type StatusPayload } from "@/systems/status";
 import {
   ACTIVE_WORKSPACE_PERSIST_KEY,
   activeWorkspaceStore,
+  enableGlobalScope,
   setActiveWorkspaceId,
   workspaceKeys,
   type WorkspacePayload,
@@ -57,6 +58,7 @@ const BENCH_WORKSPACE_ID = "ws_74a58ac2bf973937";
 const PRIMARY_SESSION_ID = "sess-5ec18f5f2a13fe16";
 const PRIMARY_WORKSPACE_ID = "ws_06366aad69887872";
 const PRIMARY_WORKSPACE_NAME = "primary";
+const SIBLING_PROFILE_SESSION_ID = "sess-83c389e7e46274aa";
 const UNKNOWN_SESSION_ID = "sess-000000000000dead";
 
 interface TestRouterContext {
@@ -107,6 +109,11 @@ const foreignSession = makeSession(
   PRIMARY_WORKSPACE_ID,
   PRIMARY_WORKSPACE_NAME
 );
+const siblingProfileSession = {
+  ...makeSession(SIBLING_PROFILE_SESSION_ID, BENCH_WORKSPACE_ID, "bench-ops"),
+  profile_id: "01JMARKETINGPROFILE0000000000",
+  profile_name: "marketing",
+};
 
 /**
  * Seeds only what the active workspace legitimately owns. The foreign session stays out of every
@@ -156,6 +163,28 @@ function stubForeignSessionBackend(): void {
       pathname === `/api/sessions/${PRIMARY_SESSION_ID}`
     ) {
       return Promise.resolve(Response.json({ session: foreignSession }));
+    }
+    return Promise.resolve(new Response(null, { status: 404 }));
+  });
+}
+
+function stubSiblingProfileSessionBackend(): void {
+  vi.mocked(globalThis.fetch).mockImplementation(request => {
+    const url = new URL(request instanceof Request ? request.url : String(request));
+    if (url.pathname === `/api/sessions/${SIBLING_PROFILE_SESSION_ID}/owner`) {
+      return Promise.resolve(
+        Response.json({
+          session_id: SIBLING_PROFILE_SESSION_ID,
+          workspace_id: BENCH_WORKSPACE_ID,
+          workspace_name: "bench-ops",
+        })
+      );
+    }
+    if (
+      url.pathname === `/api/sessions/${SIBLING_PROFILE_SESSION_ID}` &&
+      url.searchParams.get("all_profiles") === "true"
+    ) {
+      return Promise.resolve(Response.json({ session: siblingProfileSession }));
     }
     return Promise.resolve(new Response(null, { status: 404 }));
   });
@@ -496,6 +525,38 @@ describe("cross-workspace session deep-link router integration", () => {
     expect(activeWorkspaceStore.getSnapshot().context.selectedWorkspaceId).toBe(
       PRIMARY_WORKSPACE_ID
     );
+  });
+
+  it("Should resolve a same-workspace permalink across profiles without a workspace prompt", async () => {
+    stubSiblingProfileSessionBackend();
+    const { queryClient, router } = buildSessionDeepLinkRouter({
+      initialEntry: `/session/${SIBLING_PROFILE_SESSION_ID}`,
+    });
+    renderRouter(router);
+
+    await screen.findByText(`Loaded session: ${SIBLING_PROFILE_SESSION_ID}`);
+    expect(router.state.location.pathname).toBe(
+      `/agents/general/sessions/${SIBLING_PROFILE_SESSION_ID}`
+    );
+    expect(screen.queryByTestId("session-workspace-switch-dialog")).not.toBeInTheDocument();
+    expect(queryClient.getQueryData(sessionKeys.byId(SIBLING_PROFILE_SESSION_ID, "@all"))).toEqual(
+      siblingProfileSession
+    );
+    expect(fetchedPathnames()).toContain(`/api/sessions/${SIBLING_PROFILE_SESSION_ID}/owner`);
+    expect(fetchedPathnames()).toContain(`/api/sessions/${SIBLING_PROFILE_SESSION_ID}`);
+  });
+
+  it("Should resolve a permalink against the remembered desktop workspace in Global scope", async () => {
+    enableGlobalScope();
+    const { router } = buildSessionDeepLinkRouter({
+      initialEntry: `/session/${BENCH_SESSION_ID}`,
+    });
+    renderRouter(router);
+
+    await screen.findByText(`Loaded session: ${BENCH_SESSION_ID}`);
+    expect(router.state.location.pathname).toBe(`/agents/general/sessions/${BENCH_SESSION_ID}`);
+    expect(screen.queryByTestId("session-workspace-switch-dialog")).not.toBeInTheDocument();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it("Should keep an external permalink on today's not-found rendering when declined", async () => {

--- a/web/src/systems/os/apps/session/__tests__/session-window.test.tsx
+++ b/web/src/systems/os/apps/session/__tests__/session-window.test.tsx
@@ -304,6 +304,7 @@ describe("SessionWindow", () => {
     // alone does not mean gone, only "not in this profile".
     expect(userClose).not.toHaveBeenCalled();
     expect(userOpen).not.toHaveBeenCalled();
+    expect(useSessionPresenceSpy).toHaveBeenLastCalledWith("ws-1", "sess-1", false);
     expect(sessionWindowViewSpy).toHaveBeenLastCalledWith(
       expect.objectContaining({ isLoading: true })
     );

--- a/web/src/systems/os/apps/session/__tests__/session-window.test.tsx
+++ b/web/src/systems/os/apps/session/__tests__/session-window.test.tsx
@@ -332,6 +332,26 @@ describe("SessionWindow", () => {
     expect(sessionWindowNoticeSpy).not.toHaveBeenCalled();
   });
 
+  it("Should reject a foreign session from another workspace before acquiring presence", async () => {
+    queryState.data = undefined;
+    queryState.error = new SessionNotFoundError("sess-1");
+    queryState.isError = true;
+    foreignState.current = {
+      status: "found",
+      session: { ...session, workspace_id: "ws-2" },
+      owner: { id: "01J9CONSULTING000000000000", name: "consulting", archived: false },
+    };
+
+    render(<SessionWindow windowId="session:sess-1" />);
+
+    expect(useSessionPresenceSpy).toHaveBeenLastCalledWith("ws-2", "sess-1", false);
+    expect(ownerViewSpy).not.toHaveBeenCalled();
+    expect(sessionWindowNoticeSpy).toHaveBeenLastCalledWith({
+      message: "Session not found: sess-1",
+    });
+    await waitFor(() => expect(userClose).toHaveBeenCalledExactlyOnceWith("session:sess-1"));
+  });
+
   it("Should surface a failed owner lookup instead of claiming the session is gone", async () => {
     queryState.data = undefined;
     queryState.error = new SessionNotFoundError("sess-1");

--- a/web/src/systems/os/apps/session/__tests__/session-window.test.tsx
+++ b/web/src/systems/os/apps/session/__tests__/session-window.test.tsx
@@ -3,7 +3,7 @@
 // presence additionally requires the shell window and browser document to hold focus; and the
 // window resolves a session through the profile-enforced read before deciding it is gone.
 // Owning layer: the OS session-window controller.
-import { render, waitFor } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const session = {
@@ -189,6 +189,28 @@ describe("SessionWindow", () => {
     );
   });
 
+  it("Should release live-tail ownership before closing a deleted session window", async () => {
+    render(<SessionWindow windowId="session:sess-1" />);
+    const props = sessionWindowViewSpy.mock.lastCall?.[0] as
+      | { onDeleteSuccess?: () => void }
+      | undefined;
+
+    act(() => props?.onDeleteSuccess?.());
+
+    expect(scopedDetailSpy).toHaveBeenLastCalledWith(
+      "sess-1",
+      { profile: "marketing" },
+      expect.objectContaining({ enabled: true, liveTail: false })
+    );
+    await waitFor(() => expect(userClose).toHaveBeenCalledExactlyOnceWith("session:sess-1"));
+    await waitFor(() =>
+      expect(userOpen).toHaveBeenCalledExactlyOnceWith({
+        app: "agents",
+        route: { pathname: "/agents/qa-agent", search: {} },
+      })
+    );
+  });
+
   it("Should release operator presence when the browser document loses focus", () => {
     const view = render(<SessionWindow windowId="session:sess-1" />);
     expect(useSessionPresenceSpy).toHaveBeenLastCalledWith("ws-1", "sess-1", true);
@@ -202,17 +224,16 @@ describe("SessionWindow", () => {
     );
   });
 
-  it("Should treat an empty runtime workspace as unavailable without rendering the session", () => {
+  it("Should render a Global-scope session from its authoritative workspace", () => {
     workspace.runtimeWorkspaceId = "";
 
     render(<SessionWindow windowId="session:sess-1" />);
 
-    // The by-id read carries no workspace, so an unresolved shell no longer
-    // gates the request — it gates what is shown.
-    expect(sessionWindowNoticeSpy).toHaveBeenLastCalledWith({
-      message: "Session workspace unavailable",
-    });
-    expect(sessionWindowViewSpy).not.toHaveBeenCalled();
+    expect(sessionWindowViewSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ session, workspaceId: "ws-1" })
+    );
+    expect(useSessionPresenceSpy).toHaveBeenLastCalledWith("ws-1", "sess-1", true);
+    expect(sessionWindowNoticeSpy).not.toHaveBeenCalled();
   });
 
   it("Should show the truthful gone notice and return a restored missing session to its agent list (UT-087)", async () => {

--- a/web/src/systems/os/apps/session/hooks/use-session-window-controller.ts
+++ b/web/src/systems/os/apps/session/hooks/use-session-window-controller.ts
@@ -44,7 +44,10 @@ export function useSessionWindowController(windowId: string) {
   useSessionPresence(
     resolution.workspaceId,
     sessionId,
-    presenceEnabled && !deletedLocally && !resolution.crossesWorkspace
+    presenceEnabled &&
+      !deletedLocally &&
+      !resolution.crossesWorkspace &&
+      resolution.foreign.status !== "loading"
   );
 
   useEffect(() => {

--- a/web/src/systems/os/apps/session/hooks/use-session-window-controller.ts
+++ b/web/src/systems/os/apps/session/hooks/use-session-window-controller.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+import { useSessionPresence } from "@/systems/session";
+import { useActiveWorkspace } from "@/systems/workspace";
+
+import type { OsShellHandle } from "../../../contexts/os-shell-context";
+import { useOsShell } from "../../../hooks/use-os-shell";
+import { useSessionWindowResolution } from "./use-session-window-resolution";
+import { useSessionWindowRuntime } from "./use-session-window-runtime";
+
+function returnToAgent(
+  coordinator: OsShellHandle["coordinator"],
+  windowId: string,
+  agentName: string
+): void {
+  void coordinator.userClose(windowId).then(closed => {
+    if (!closed) return;
+    void coordinator.userOpen({
+      app: "agents",
+      route: {
+        pathname: `/agents/${encodeURIComponent(agentName)}`,
+        search: {},
+      },
+    });
+  });
+}
+
+/** Resolves the session window identity and owns its redirect/delete lifecycle. */
+export function useSessionWindowController(windowId: string) {
+  const { coordinator } = useOsShell();
+  const activeWorkspace = useActiveWorkspace();
+  const runtimeWorkspaceId = activeWorkspace.runtimeWorkspaceId?.trim() || null;
+  const { liveTailEnabled, presenceEnabled, sessionId, agentName } =
+    useSessionWindowRuntime(windowId);
+  const [deletedSessionId, setDeletedSessionId] = useState<string | null>(null);
+  const deletedLocally = sessionId !== null && deletedSessionId === sessionId;
+  const effectiveLiveTailEnabled = liveTailEnabled && !deletedLocally;
+  const resolution = useSessionWindowResolution({
+    sessionId,
+    runtimeWorkspaceId,
+    liveTailEnabled: effectiveLiveTailEnabled,
+  });
+  useSessionPresence(resolution.workspaceId, sessionId, presenceEnabled && !deletedLocally);
+
+  useEffect(() => {
+    if (agentName === null || deletedLocally) return;
+    const gone = resolution.scopedMiss && resolution.foreign.status === "missing";
+    if (!gone && !resolution.crossesWorkspace) return;
+    toast.error("Session not found");
+    returnToAgent(coordinator, windowId, agentName);
+  }, [
+    agentName,
+    coordinator,
+    deletedLocally,
+    resolution.crossesWorkspace,
+    resolution.foreign.status,
+    resolution.scopedMiss,
+    windowId,
+  ]);
+
+  useEffect(() => {
+    if (!deletedLocally || agentName === null) return;
+    returnToAgent(coordinator, windowId, agentName);
+  }, [agentName, coordinator, deletedLocally, windowId]);
+
+  return {
+    ...resolution,
+    agentName,
+    deletedLocally,
+    effectiveLiveTailEnabled,
+    liveTailEnabled,
+    sessionId,
+    handleDeleteSuccess: () => {
+      if (sessionId !== null) setDeletedSessionId(sessionId);
+    },
+  };
+}

--- a/web/src/systems/os/apps/session/hooks/use-session-window-controller.ts
+++ b/web/src/systems/os/apps/session/hooks/use-session-window-controller.ts
@@ -41,7 +41,11 @@ export function useSessionWindowController(windowId: string) {
     runtimeWorkspaceId,
     liveTailEnabled: effectiveLiveTailEnabled,
   });
-  useSessionPresence(resolution.workspaceId, sessionId, presenceEnabled && !deletedLocally);
+  useSessionPresence(
+    resolution.workspaceId,
+    sessionId,
+    presenceEnabled && !deletedLocally && !resolution.crossesWorkspace
+  );
 
   useEffect(() => {
     if (agentName === null || deletedLocally) return;

--- a/web/src/systems/os/apps/session/hooks/use-session-window-resolution.ts
+++ b/web/src/systems/os/apps/session/hooks/use-session-window-resolution.ts
@@ -46,7 +46,9 @@ export function useSessionWindowResolution({
   );
   const scopedMiss = query.isError && isNotFound(query.error);
   const foreign = useForeignProfileSession(sessionId, scopedMiss);
-  const sessionWorkspaceId = query.data?.workspace_id?.trim() || null;
+  const foreignSession = foreign.status === "found" ? foreign.session : undefined;
+  const sessionWorkspaceId =
+    query.data?.workspace_id?.trim() || foreignSession?.workspace_id?.trim() || null;
   return {
     session: query.data,
     workspaceId: sessionWorkspaceId ?? runtimeWorkspaceId,

--- a/web/src/systems/os/apps/session/hooks/use-session-window-resolution.ts
+++ b/web/src/systems/os/apps/session/hooks/use-session-window-resolution.ts
@@ -10,6 +10,7 @@ import {
 
 export interface SessionWindowResolution {
   session: SessionPayload | undefined;
+  workspaceId: string | null;
   isLoading: boolean;
   error: Error | null;
   /** The scoped read answered "not in this profile" — not yet "nowhere". */
@@ -45,15 +46,16 @@ export function useSessionWindowResolution({
   );
   const scopedMiss = query.isError && isNotFound(query.error);
   const foreign = useForeignProfileSession(sessionId, scopedMiss);
-  const sessionWorkspaceId = query.data?.workspace_id?.trim();
+  const sessionWorkspaceId = query.data?.workspace_id?.trim() || null;
   return {
     session: query.data,
+    workspaceId: sessionWorkspaceId ?? runtimeWorkspaceId,
     isLoading: query.isLoading,
     error: query.error,
     scopedMiss,
     foreign,
     crossesWorkspace:
-      sessionWorkspaceId !== undefined &&
+      sessionWorkspaceId !== null &&
       runtimeWorkspaceId !== null &&
       sessionWorkspaceId !== runtimeWorkspaceId,
   };

--- a/web/src/systems/os/apps/session/hooks/use-session-window-runtime.ts
+++ b/web/src/systems/os/apps/session/hooks/use-session-window-runtime.ts
@@ -2,22 +2,21 @@ import { useDesktop } from "../../../hooks/use-desktop";
 import { matchSessionInstance } from "../../../lib/app-catalog";
 import { useSessionWindowDesktopState } from "./use-session-window-desktop-state";
 import { useDocumentActive } from "@/hooks/use-document-active";
-import { useSessionPresence } from "@/systems/session";
-import { useActiveWorkspace } from "@/systems/workspace";
 
 const SESSION_AGENT_PATTERN = /^\/agents\/([^/]+)\/sessions\//;
 
 export interface SessionWindowRuntime {
-  runtimeWorkspaceId: string | null;
   liveTailEnabled: boolean;
+  presenceEnabled: boolean;
   sessionId: string | null;
   agentName: string | null;
 }
 
 /**
  * Everything the session window needs from the shell: which session its route
- * points at, whether its data should stay live, and — while the operator is
- * actually looking at it — an operator presence lease.
+ * points at, whether its data should stay live, and whether the operator is
+ * actually looking at it. The controller combines that eligibility with the
+ * workspace resolved from the authoritative session read before leasing presence.
  *
  * Presence is reported only when this window holds focus *and* its content is
  * visible. That pairing is the whole definition of "being viewed": a focused
@@ -25,17 +24,14 @@ export interface SessionWindowRuntime {
  * claiming otherwise would silently stop `done` from ever appearing.
  */
 export function useSessionWindowRuntime(windowId: string): SessionWindowRuntime {
-  const activeWorkspace = useActiveWorkspace();
   const { liveTailEnabled, pathname } = useSessionWindowDesktopState(windowId);
   const focused = useDesktop(state => state.focusedId === windowId);
   const documentActive = useDocumentActive();
-  const runtimeWorkspaceId = activeWorkspace.runtimeWorkspaceId?.trim() || null;
   const sessionId = matchSessionInstance(pathname);
   const agentMatch = SESSION_AGENT_PATTERN.exec(pathname);
-  useSessionPresence(runtimeWorkspaceId, sessionId, focused && liveTailEnabled && documentActive);
   return {
-    runtimeWorkspaceId,
     liveTailEnabled,
+    presenceEnabled: focused && liveTailEnabled && documentActive,
     sessionId,
     agentName: agentMatch ? decodeURIComponent(agentMatch[1]) : null,
   };

--- a/web/src/systems/os/apps/session/session-window.tsx
+++ b/web/src/systems/os/apps/session/session-window.tsx
@@ -1,10 +1,4 @@
-import { useEffect } from "react";
-import { toast } from "sonner";
-
-import type { OsShellHandle } from "../../contexts/os-shell-context";
-import { useOsShell } from "../../hooks/use-os-shell";
-import { useSessionWindowResolution } from "./hooks/use-session-window-resolution";
-import { useSessionWindowRuntime } from "./hooks/use-session-window-runtime";
+import { useSessionWindowController } from "./hooks/use-session-window-controller";
 import { preloadSessionWindowModules } from "./session-window-module-loader";
 import { SessionProfileOwnerNotice } from "./session-profile-owner-notice";
 import { SessionWindowNotice, SessionWindowView } from "./session-window-view";
@@ -12,23 +6,6 @@ import { SessionWindowNotice, SessionWindowView } from "./session-window-view";
 // This controller is itself route-local and lazy. Once it is requested, warm
 // the chat surface chunks together so nested lazy boundaries do not waterfall.
 void Promise.allSettled([preloadSessionWindowModules()]);
-
-function returnToAgent(
-  coordinator: OsShellHandle["coordinator"],
-  windowId: string,
-  agentName: string
-): void {
-  void coordinator.userClose(windowId).then(closed => {
-    if (!closed) return;
-    void coordinator.userOpen({
-      app: "agents",
-      route: {
-        pathname: `/agents/${encodeURIComponent(agentName)}`,
-        search: {},
-      },
-    });
-  });
-}
 
 /**
  * Session window controller: parses `agent + session` identity from the window's
@@ -43,21 +20,22 @@ function returnToAgent(
  * visible session look deleted.
  */
 export function SessionWindow({ windowId }: { windowId: string }) {
-  const { coordinator } = useOsShell();
-  const { runtimeWorkspaceId, liveTailEnabled, sessionId, agentName } =
-    useSessionWindowRuntime(windowId);
-  const { session, isLoading, error, scopedMiss, foreign, crossesWorkspace } =
-    useSessionWindowResolution({ sessionId, runtimeWorkspaceId, liveTailEnabled });
+  const {
+    agentName,
+    crossesWorkspace,
+    deletedLocally,
+    effectiveLiveTailEnabled,
+    error,
+    foreign,
+    handleDeleteSuccess,
+    isLoading,
+    liveTailEnabled,
+    session,
+    sessionId,
+    workspaceId,
+  } = useSessionWindowController(windowId);
 
-  useEffect(() => {
-    if (agentName === null) return;
-    // Only a settled "nowhere" licenses the bounce. `loading` and `found` both
-    // mean the operator is still owed an answer on this screen.
-    const gone = scopedMiss && foreign.status === "missing";
-    if (!gone && !crossesWorkspace) return;
-    toast.error("Session not found");
-    returnToAgent(coordinator, windowId, agentName);
-  }, [agentName, coordinator, crossesWorkspace, foreign.status, scopedMiss, windowId]);
+  if (deletedLocally) return null;
 
   if (sessionId === null || agentName === null) {
     return <SessionWindowNotice message="This window does not point at a session." />;
@@ -66,7 +44,7 @@ export function SessionWindow({ windowId }: { windowId: string }) {
     return (
       <SessionProfileOwnerNotice
         agentName={agentName}
-        liveTailEnabled={liveTailEnabled}
+        liveTailEnabled={effectiveLiveTailEnabled}
         owner={foreign.owner}
         session={foreign.session}
         windowId={windowId}
@@ -79,19 +57,19 @@ export function SessionWindow({ windowId }: { windowId: string }) {
         windowId={windowId}
         name={agentName}
         id={sessionId}
-        workspaceId={runtimeWorkspaceId ?? ""}
+        workspaceId={workspaceId ?? ""}
         session={undefined}
         liveTailEnabled={liveTailEnabled}
         isLoading
         error={null}
-        onDeleteSuccess={() => returnToAgent(coordinator, windowId, agentName)}
+        onDeleteSuccess={handleDeleteSuccess}
       />
     );
   }
   if (foreign.status === "error") {
     return <SessionWindowNotice message={foreign.error.message} />;
   }
-  if (runtimeWorkspaceId === null || crossesWorkspace) {
+  if (workspaceId === null || crossesWorkspace) {
     return <SessionWindowNotice message={error?.message ?? "Session workspace unavailable"} />;
   }
 
@@ -101,12 +79,12 @@ export function SessionWindow({ windowId }: { windowId: string }) {
         windowId={windowId}
         name={agentName}
         id={sessionId}
-        workspaceId={runtimeWorkspaceId}
+        workspaceId={workspaceId}
         session={session}
-        liveTailEnabled={liveTailEnabled}
+        liveTailEnabled={effectiveLiveTailEnabled}
         isLoading={isLoading}
         error={error}
-        onDeleteSuccess={() => returnToAgent(coordinator, windowId, agentName)}
+        onDeleteSuccess={handleDeleteSuccess}
       />
     </div>
   );

--- a/web/src/systems/os/apps/session/session-window.tsx
+++ b/web/src/systems/os/apps/session/session-window.tsx
@@ -40,6 +40,9 @@ export function SessionWindow({ windowId }: { windowId: string }) {
   if (sessionId === null || agentName === null) {
     return <SessionWindowNotice message="This window does not point at a session." />;
   }
+  if (crossesWorkspace) {
+    return <SessionWindowNotice message={error?.message ?? "Session workspace unavailable"} />;
+  }
   if (foreign.status === "found") {
     return (
       <SessionProfileOwnerNotice
@@ -69,7 +72,7 @@ export function SessionWindow({ windowId }: { windowId: string }) {
   if (foreign.status === "error") {
     return <SessionWindowNotice message={foreign.error.message} />;
   }
-  if (workspaceId === null || crossesWorkspace) {
+  if (workspaceId === null) {
     return <SessionWindowNotice message={error?.message ?? "Session workspace unavailable"} />;
   }
 

--- a/web/src/systems/os/components/__tests__/os-dock.test.tsx
+++ b/web/src/systems/os/components/__tests__/os-dock.test.tsx
@@ -1,5 +1,6 @@
 // Suite: OS dock state
-// Invariant: dock activation resolves the correct instance and every available destination is reachable.
+// Invariant: dock activation resolves the correct instance, every available destination is reachable,
+// and launchers wait for the authoritative HTTP command fence rather than the live event stream.
 // Boundary IN: OsDock presentation, DesktopDock projection, and OsDockAppMenu interaction semantics.
 // Boundary OUT: coordinator command execution and browser lifecycle journeys.
 import { act, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
@@ -10,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TooltipProvider } from "@compozy/ui";
 
 import type { OsDesktopRuntimeStore, OsWindow } from "../../lib/os-types";
+import type { WindowManagerConfig, WindowManagerSnapshot } from "../../lib/window-manager-types";
 import { DesktopDock } from "../desktop-dock";
 import { OsDock } from "../os-dock";
 import { OsDockAppMenu } from "../os-dock-app-menu";
@@ -24,6 +26,45 @@ const dockShell = vi.hoisted(() => ({
     userOpen: vi.fn(),
   },
 }));
+
+const SNAPSHOT: WindowManagerSnapshot = {
+  version: 3,
+  workspaceId: "workspace:test",
+  revision: 1,
+  desktops: [],
+  windows: {},
+  closedEntryCount: 0,
+  overrides: {},
+  updatedAt: "2026-07-31T00:00:00Z",
+};
+
+const CONFIG: WindowManagerConfig = {
+  newWindowPolicy: "floating",
+  smallViewportPolicy: "stack",
+  focusPolicy: "click_directional",
+  focusWrap: true,
+  focusFollowsPointer: false,
+  raiseOnFocus: true,
+  dragAwayPolicy: "window",
+  groupMoveModifier: "alt",
+  swapModifier: "shift",
+  historyLimit: 50,
+  navStackLimit: 50,
+  closedEntryLimit: 20,
+  desktopTransition: "slide",
+  gaps: { inner: 8, top: 0, right: 0, bottom: 0, left: 0 },
+  snap: {
+    edgeBand: 32,
+    cornerReach: 150,
+    exitSlack: 16,
+    repeatRatios: [0.5, 0.666667, 0.333333],
+  },
+  bindings: { topCenter: "zoom", bottomCenter: "reserved" },
+  shortcuts: {},
+  globalShortcuts: {},
+  shortcutDefaults: {},
+  effectiveShortcuts: {},
+};
 
 vi.mock("../../hooks/use-desktop", () => ({
   useDesktop: (selector: (state: unknown) => unknown) => selector(dockShell.state),
@@ -65,8 +106,8 @@ function desktopState(
   focusOrder: readonly string[] = []
 ): OsDesktopRuntimeStore {
   return {
-    snapshot: null,
-    windowManagerConfig: null,
+    snapshot: SNAPSHOT,
+    windowManagerConfig: CONFIG,
     client: {
       workspaceId: "workspace:test",
       clientId: "client:web",
@@ -139,6 +180,31 @@ describe("OsDock", () => {
       "minimized"
     );
     expect(screen.getByRole("button", { name: "Agents" })).toHaveAttribute("data-state", "closed");
+  });
+
+  it("Should wait for authoritative hydration but stay enabled while the stream reconnects", async () => {
+    const user = userEvent.setup();
+    setDockState({ ...desktopState(), hydration: "pending", connectionStatus: "reconnecting" });
+    const view = renderDock(
+      <DesktopDock badges={{}} onNewSession={vi.fn()} pager={null} contextMenusEnabled />
+    );
+    const tasks = screen.getByRole("button", { name: "Tasks" });
+
+    expect(tasks).toBeDisabled();
+    fireEvent.click(tasks);
+    expect(dockShell.coordinator.userOpen).not.toHaveBeenCalled();
+
+    setDockState({ ...desktopState(), connectionStatus: "reconnecting" });
+    view.rerender(
+      <TooltipProvider delay={0}>
+        <DesktopDock badges={{}} onNewSession={vi.fn()} pager={null} contextMenusEnabled />
+      </TooltipProvider>
+    );
+
+    const reconnectedTasks = screen.getByRole("button", { name: "Tasks" });
+    expect(reconnectedTasks).toBeEnabled();
+    await user.click(reconnectedTasks);
+    expect(dockShell.coordinator.userOpen).toHaveBeenCalledWith({ app: "tasks" });
   });
 
   it("Should hide zero badges and cap large attention counts at 9+ (UT-066)", () => {

--- a/web/src/systems/os/components/desktop-dock.tsx
+++ b/web/src/systems/os/components/desktop-dock.tsx
@@ -37,9 +37,10 @@ export function DesktopDock({
   pager,
   dormant = false,
 }: DesktopDockProps) {
-  const { entries, presentation, magnify, handleSelect } = useDesktopDock(badges, {
-    onNewSession,
-  });
+  const { entries, presentation, magnify, commandsAvailable, handleSelect } = useDesktopDock(
+    badges,
+    { onNewSession }
+  );
   const dormancy = cn(WAKE, dormant && DORMANT);
 
   if (presentation === "compact") {
@@ -49,6 +50,7 @@ export function DesktopDock({
         items={entries}
         leading={pager}
         onSelect={handleSelect}
+        disabled={!commandsAvailable}
         onNewSession={onNewSession}
       />
     );
@@ -60,8 +62,9 @@ export function DesktopDock({
       items={entries}
       leading={pager}
       onSelect={handleSelect}
+      disabled={!commandsAvailable}
       renderItemMenu={
-        !contextMenusEnabled
+        !commandsAvailable || !contextMenusEnabled
           ? undefined
           : (item, children) =>
               item.id === "session" ? (

--- a/web/src/systems/os/components/desktop-shell.tsx
+++ b/web/src/systems/os/components/desktop-shell.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { Outlet } from "@tanstack/react-router";
 
 import { cn } from "@compozy/ui";
@@ -6,14 +7,18 @@ import { CmdPaletteRegistryProvider } from "../contexts/cmd-palette-registry-con
 import { OsShellContext } from "../contexts/os-shell-context";
 import { useCmdPaletteRegistry } from "../hooks/use-cmd-palette-registry";
 import { WorktreeDialogActionsContext } from "../contexts/worktree-dialog-actions-context";
-import { useDesktopChrome } from "../hooks/use-desktop-chrome";
+import { useDesktopChromeController } from "../hooks/use-desktop-chrome-controller";
+import { useDesktop } from "../hooks/use-desktop";
 import { useDesktopShellBody } from "../hooks/use-desktop-shell-body";
-import { useDesktopShellModel, type DesktopShellModel } from "../hooks/use-desktop-shell-model";
+import type { DesktopShellModel } from "../hooks/use-desktop-shell-model";
 import { useProfileAutomationEnablement } from "../hooks/use-profile-automation-enablement";
 import { useDesktopWorktreeScope, WindowScopeContext } from "../hooks/use-worktree-scope";
-import { useWorktreeDialogTargets } from "../hooks/use-worktree-dialog-targets";
-import { useWorkspaceSetupDefaults } from "../hooks/use-workspace-setup-defaults";
+import type { WorktreeDialogTargets } from "../hooks/use-worktree-dialog-targets";
 import type { ClientCommandChannel } from "../lib/client-command-channel";
+import {
+  backgroundStreamsWithinConnectionBudget,
+  continuityStreamsWithinConnectionBudget,
+} from "../lib/background-stream-budget";
 import type { WindowManagerRegisteredClientView } from "../lib/window-manager-types";
 import { DesktopGate } from "./desktop-gate";
 import { DesktopWorktreeDialogs } from "./desktop-worktree-dialogs";
@@ -83,38 +88,55 @@ function DesktopChrome({
   firstRun: boolean;
   updateAvailable: boolean;
 }) {
-  const model = useDesktopShellModel();
-  const chrome = useDesktopChrome(model.desktopWorkspaceId);
-  const worktreeDialogs = useWorktreeDialogTargets();
-  const workspaceSetupDefaults = useWorkspaceSetupDefaults();
+  const controller = useDesktopChromeController();
 
   // Zero project workspaces boots Global-on; the home registration is not a
   // project workspace and must not replace the shell with setup.
 
   return (
-    <WorktreeDialogActionsContext.Provider value={worktreeDialogs}>
-      <OsShellContext.Provider value={chrome.shell}>
+    <WorktreeDialogActionsContext.Provider value={controller.worktreeDialogs}>
+      <OsShellContext.Provider value={controller.chrome.shell}>
+        <BackgroundStreamBudgetBridge
+          onBackgroundChange={controller.setBackgroundStreamsEnabled}
+          onContinuityChange={controller.setContinuityStreamsEnabled}
+        />
         <DesktopChromeContent
-          client={chrome.client}
+          client={controller.chrome.client}
           firstRun={firstRun}
-          model={model}
-          clientCommandChannel={chrome.clientCommandChannel}
+          continuityStreamsEnabled={controller.continuityStreamsEnabled}
+          model={controller.model}
+          clientCommandChannel={controller.chrome.clientCommandChannel}
           updateAvailable={updateAvailable}
-          worktreeDialogs={worktreeDialogs}
-          workspaceSetupDefaults={workspaceSetupDefaults}
+          worktreeDialogs={controller.worktreeDialogs}
+          workspaceSetupDefaults={controller.workspaceSetupDefaults}
         />
       </OsShellContext.Provider>
     </WorktreeDialogActionsContext.Provider>
   );
 }
 
+function BackgroundStreamBudgetBridge({
+  onBackgroundChange,
+  onContinuityChange,
+}: {
+  onBackgroundChange: (enabled: boolean) => void;
+  onContinuityChange: (enabled: boolean) => void;
+}) {
+  const backgroundEnabled = useDesktop(backgroundStreamsWithinConnectionBudget);
+  const continuityEnabled = useDesktop(continuityStreamsWithinConnectionBudget);
+  useEffect(() => onBackgroundChange(backgroundEnabled), [backgroundEnabled, onBackgroundChange]);
+  useEffect(() => onContinuityChange(continuityEnabled), [continuityEnabled, onContinuityChange]);
+  return null;
+}
+
 interface DesktopShellBodyProps {
+  continuityStreamsEnabled: boolean;
   client: WindowManagerRegisteredClientView | null;
   model: DesktopShellModel;
   firstRun: boolean;
   updateAvailable: boolean;
   workspaceSetupDefaults: WorkspaceSetupDefaultsModel;
-  worktreeDialogs: ReturnType<typeof useWorktreeDialogTargets>;
+  worktreeDialogs: WorktreeDialogTargets;
   /** The daemon's client-command channel reads the current shell seam through this port. */
   clientCommandChannel: ClientCommandChannel;
 }
@@ -165,6 +187,7 @@ function DesktopShellBody(props: DesktopShellBodyProps) {
 }
 
 function DesktopShellScopedBody({
+  continuityStreamsEnabled,
   client,
   model,
   firstRun,
@@ -436,7 +459,10 @@ function DesktopShellScopedBody({
       />
       {/* Profile lifecycle dialogs live at the shell so a flow started from the
           command palette does not depend on Settings being open. */}
-      <ProfileLifecycleHost onSetAutomationEnabled={setAutomationEnabled} />
+      <ProfileLifecycleHost
+        enabled={continuityStreamsEnabled}
+        onSetAutomationEnabled={setAutomationEnabled}
+      />
     </div>
   );
 }

--- a/web/src/systems/os/components/desktop-shell.tsx
+++ b/web/src/systems/os/components/desktop-shell.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Outlet } from "@tanstack/react-router";
 
 import { cn } from "@compozy/ui";
@@ -8,17 +7,12 @@ import { OsShellContext } from "../contexts/os-shell-context";
 import { useCmdPaletteRegistry } from "../hooks/use-cmd-palette-registry";
 import { WorktreeDialogActionsContext } from "../contexts/worktree-dialog-actions-context";
 import { useDesktopChromeController } from "../hooks/use-desktop-chrome-controller";
-import { useDesktop } from "../hooks/use-desktop";
 import { useDesktopShellBody } from "../hooks/use-desktop-shell-body";
 import type { DesktopShellModel } from "../hooks/use-desktop-shell-model";
 import { useProfileAutomationEnablement } from "../hooks/use-profile-automation-enablement";
 import { useDesktopWorktreeScope, WindowScopeContext } from "../hooks/use-worktree-scope";
 import type { WorktreeDialogTargets } from "../hooks/use-worktree-dialog-targets";
 import type { ClientCommandChannel } from "../lib/client-command-channel";
-import {
-  backgroundStreamsWithinConnectionBudget,
-  continuityStreamsWithinConnectionBudget,
-} from "../lib/background-stream-budget";
 import type { WindowManagerRegisteredClientView } from "../lib/window-manager-types";
 import { DesktopGate } from "./desktop-gate";
 import { DesktopWorktreeDialogs } from "./desktop-worktree-dialogs";
@@ -96,10 +90,6 @@ function DesktopChrome({
   return (
     <WorktreeDialogActionsContext.Provider value={controller.worktreeDialogs}>
       <OsShellContext.Provider value={controller.chrome.shell}>
-        <BackgroundStreamBudgetBridge
-          onBackgroundChange={controller.setBackgroundStreamsEnabled}
-          onContinuityChange={controller.setContinuityStreamsEnabled}
-        />
         <DesktopChromeContent
           client={controller.chrome.client}
           firstRun={firstRun}
@@ -113,20 +103,6 @@ function DesktopChrome({
       </OsShellContext.Provider>
     </WorktreeDialogActionsContext.Provider>
   );
-}
-
-function BackgroundStreamBudgetBridge({
-  onBackgroundChange,
-  onContinuityChange,
-}: {
-  onBackgroundChange: (enabled: boolean) => void;
-  onContinuityChange: (enabled: boolean) => void;
-}) {
-  const backgroundEnabled = useDesktop(backgroundStreamsWithinConnectionBudget);
-  const continuityEnabled = useDesktop(continuityStreamsWithinConnectionBudget);
-  useEffect(() => onBackgroundChange(backgroundEnabled), [backgroundEnabled, onBackgroundChange]);
-  useEffect(() => onContinuityChange(continuityEnabled), [continuityEnabled, onContinuityChange]);
-  return null;
 }
 
 interface DesktopShellBodyProps {

--- a/web/src/systems/os/components/os-dock-tab-bar.tsx
+++ b/web/src/systems/os/components/os-dock-tab-bar.tsx
@@ -11,7 +11,15 @@ function formatBadge(count: number): string {
   return count > 9 ? "9+" : String(count);
 }
 
-function TabBarItem({ item, onSelect }: { item: OsDockItemData; onSelect: (id: string) => void }) {
+function TabBarItem({
+  item,
+  onSelect,
+  disabled,
+}: {
+  item: OsDockItemData;
+  onSelect: (id: string) => void;
+  disabled?: boolean;
+}) {
   const state = item.minimized ? "minimized" : item.running ? "running" : "closed";
   return (
     <button
@@ -20,6 +28,7 @@ function TabBarItem({ item, onSelect }: { item: OsDockItemData; onSelect: (id: s
       data-app={item.id}
       data-state={state}
       aria-label={item.name}
+      disabled={disabled}
       className={cn(
         "relative grid size-dock-tab-item shrink-0 place-items-center rounded-lg",
         "transition-colors duration-shell-fast",
@@ -62,6 +71,7 @@ export interface OsDockTabBarProps extends Omit<React.ComponentProps<"nav">, "on
   items: OsDockEntry[];
   leading?: React.ReactNode;
   onSelect: (id: string) => void;
+  disabled?: boolean;
   onNewSession: () => void;
 }
 
@@ -75,6 +85,7 @@ export function OsDockTabBar({
   items,
   leading,
   onSelect,
+  disabled,
   onNewSession,
   className,
   ...props
@@ -108,7 +119,7 @@ export function OsDockTabBar({
       >
         {items.map(entry =>
           isOsDockSeparator(entry) ? null : (
-            <TabBarItem key={entry.id} item={entry} onSelect={onSelect} />
+            <TabBarItem key={entry.id} item={entry} onSelect={onSelect} disabled={disabled} />
           )
         )}
       </div>

--- a/web/src/systems/os/components/os-dock.tsx
+++ b/web/src/systems/os/components/os-dock.tsx
@@ -23,6 +23,8 @@ export interface OsDockProps extends Omit<React.ComponentProps<"nav">, "onSelect
   items: OsDockEntry[];
   /** Item activation. Omit to render items as presentation. */
   onSelect?: (id: string) => void;
+  /** Keeps launchers visible while the authoritative command fence hydrates. */
+  disabled?: boolean;
   /** Wraps each interactive item with its destination context menu (US-006). */
   renderItemMenu?: (item: OsDockItemData, children: React.ReactNode) => React.ReactNode;
   /**
@@ -64,10 +66,12 @@ function DockTip({ label }: { label: string }) {
 function DockItem({
   item,
   onSelect,
+  disabled,
   renderItemMenu,
 }: {
   item: OsDockItemData;
   onSelect?: (id: string) => void;
+  disabled?: boolean;
   renderItemMenu?: OsDockProps["renderItemMenu"];
 }) {
   const state = item.minimized ? "minimized" : item.running ? "running" : "closed";
@@ -138,6 +142,7 @@ function DockItem({
             data-app={item.id}
             data-state={state}
             aria-label={item.name}
+            disabled={disabled}
             className={classes}
             onClick={() => onSelect(item.id)}
           />
@@ -157,6 +162,7 @@ const DOCK_SEG =
 export function OsDock({
   items,
   onSelect,
+  disabled,
   renderItemMenu,
   magnify = true,
   className,
@@ -186,6 +192,7 @@ export function OsDock({
             key={entry.id}
             item={entry}
             onSelect={onSelect}
+            disabled={disabled}
             renderItemMenu={renderItemMenu}
           />
         )
@@ -261,6 +268,7 @@ export function OsDockZone({
   items,
   leading,
   onSelect,
+  disabled,
   renderItemMenu,
   onNewSession,
   magnify = true,
@@ -271,6 +279,7 @@ export function OsDockZone({
   items: OsDockEntry[];
   leading?: React.ReactNode;
   onSelect?: (id: string) => void;
+  disabled?: boolean;
   renderItemMenu?: OsDockProps["renderItemMenu"];
   onNewSession?: () => void;
   magnify?: boolean;
@@ -298,6 +307,7 @@ export function OsDockZone({
         <OsDock
           items={items}
           onSelect={onSelect}
+          disabled={disabled}
           renderItemMenu={renderItemMenu}
           magnify={magnify}
           className="pointer-events-auto"

--- a/web/src/systems/os/components/os-window.tsx
+++ b/web/src/systems/os/components/os-window.tsx
@@ -55,20 +55,16 @@ export function OsWindow({ frame }: OsWindowProps) {
     registerRnd,
     resizeMax,
   } = useOsWindow(frame);
-  const { presentation, activeApp, reduceMotion, closeShortcut, newTabShortcut } = useDesktop(
-    state => {
-      const effective = state.windowManagerConfig?.effectiveShortcuts;
-      const platform = typeof navigator === "undefined" ? "" : navigator.platform;
-      return {
-        presentation: state.presentation,
-        activeApp: state.windows[frame.activeWindowId]?.app ?? null,
-        reduceMotion: state.reduceMotion,
-        closeShortcut: shortcutActionLabel(effective, "window.close", platform) ?? undefined,
-        newTabShortcut: shortcutActionLabel(effective, "window.tab.new", platform) ?? undefined,
-      };
-    },
-    shallowEqual
-  );
+  const { presentation, activeApp, closeShortcut, newTabShortcut } = useDesktop(state => {
+    const effective = state.windowManagerConfig?.effectiveShortcuts;
+    const platform = typeof navigator === "undefined" ? "" : navigator.platform;
+    return {
+      presentation: state.presentation,
+      activeApp: state.windows[frame.activeWindowId]?.app ?? null,
+      closeShortcut: shortcutActionLabel(effective, "window.close", platform) ?? undefined,
+      newTabShortcut: shortcutActionLabel(effective, "window.tab.new", platform) ?? undefined,
+    };
+  }, shallowEqual);
   const dragging = useWindowManagerGestureDragging(frame.activeWindowId);
   const compact = presentation === "compact";
   const deckVisible = frame.members.length >= 2 && !compact;
@@ -99,7 +95,7 @@ export function OsWindow({ frame }: OsWindowProps) {
   return (
     <Rnd
       ref={registerRnd}
-      className={compact ? "absolute inset-0" : undefined}
+      className={cn(compact && "absolute inset-0", focused && "will-change-transform")}
       position={compact ? { x: 0, y: 0 } : { x: rect.x, y: rect.y }}
       size={compact ? { width: "100%", height: "100%" } : { width: rect.w, height: rect.h }}
       minWidth={compact ? undefined : minimum.width}
@@ -125,12 +121,11 @@ export function OsWindow({ frame }: OsWindowProps) {
         focused={focused}
         presentation={presentation}
         kind={frame.kind}
-        // Reduced opacity plus a slight shrink while dragging keeps the merge
-        // and snap affordances underneath readable through the moving frame.
+        // Reduced opacity keeps merge and snap affordances readable through
+        // the moving frame without rerasterizing the full window during drag.
         className={cn(
-          "relative h-full w-full transition-[opacity,transform] duration-base ease-out",
-          dragging && "opacity-70",
-          dragging && !reduceMotion && "scale-[0.98]"
+          "relative h-full w-full transition-opacity duration-base ease-out",
+          dragging && "opacity-70"
         )}
         data-dragging={dragging ? "" : undefined}
         data-testid={`os-window-frame-${frame.id}`}

--- a/web/src/systems/os/hooks/__tests__/os-interaction-hooks.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/os-interaction-hooks.test.tsx
@@ -184,25 +184,27 @@ function acceptedOutcome(): WindowManagerCommandOutcome {
   return { accepted: true, completion: Promise.resolve(true) };
 }
 
-function createShell({ live = true, withPeer = true } = {}) {
+function createShell({ live = true, authoritative = true, withPeer = true } = {}) {
   const primary = windowFixture("window:primary", 2);
   const peer = windowFixture("window:peer", 1);
   const zoomWindow = vi.fn(() => acceptedOutcome());
   const toggleFloating = vi.fn(() => acceptedOutcome());
   const arrangeLayout = vi.fn();
   const state: OsDesktopRuntimeStore = {
-    snapshot: SNAPSHOT,
-    windowManagerConfig: CONFIG,
-    client: {
-      workspaceId: "workspace:test",
-      clientId: "client:web",
-      activeDesktopId: "desktop:main",
-      focusedWindowId: primary.id,
-      focusOrder: [primary.id],
-      stackActive: {},
-      connectedAt: "2026-07-22T00:00:00Z",
-      presentationRevision: 1,
-    },
+    snapshot: authoritative ? SNAPSHOT : null,
+    windowManagerConfig: authoritative ? CONFIG : null,
+    client: authoritative
+      ? {
+          workspaceId: "workspace:test",
+          clientId: "client:web",
+          activeDesktopId: "desktop:main",
+          focusedWindowId: primary.id,
+          focusOrder: [primary.id],
+          stackActive: {},
+          connectedAt: "2026-07-22T00:00:00Z",
+          presentationRevision: 1,
+        }
+      : null,
     desktops: [],
     projections: {},
     frames: {},
@@ -214,7 +216,7 @@ function createShell({ live = true, withPeer = true } = {}) {
     dockMagnify: true,
     presentation: "floating",
     viewportState: "ready",
-    hydration: "live",
+    hydration: authoritative ? "live" : "pending",
     connectionStatus: live ? "connected" : "disconnected",
     desktopBounds: { width: 1280, height: 800, origin: { x: 0, y: 0 } },
   };
@@ -1533,9 +1535,9 @@ describe("useOsZoomMenu", () => {
     expect(result.current.open).toBe(true);
   });
 
-  it("Should gate placement dispatch on live availability and close after an accepted action", () => {
+  it("Should gate placement dispatch on an authoritative fence and close after an accepted action", () => {
     const liveShell = createShell();
-    const unavailableShell = createShell({ live: false });
+    const unavailableShell = createShell({ authoritative: false });
     const live = renderHook(() => useOsZoomMenu("window:primary"), {
       wrapper: liveShell.wrapper,
     });
@@ -1615,8 +1617,21 @@ describe("useOsWindowCommands", () => {
     expect(actions.makeFloating).toBeNull();
   });
 
-  it("Should withhold every window command while the client is not live", () => {
+  it("Should keep window commands available while the event stream reconnects", () => {
     const shell = createShell({ live: false });
+    const { result } = renderHook(() => useOsWindowCommands(), { wrapper: shell.wrapper });
+
+    expect(result.current.commandsAvailable).toBe(true);
+    expect(result.current.focusedWindowActions).not.toBeNull();
+    expect(result.current.canToggleFloating).toBe(true);
+    expect(result.current.canBalanceLayout).toBe(true);
+    expect(result.current.canEditLayoutHistory).toBe(true);
+    expect(result.current.canFocusDirection).toBe(true);
+    expect(result.current.canSwitchDesktop).toBe(false);
+  });
+
+  it("Should withhold every window command without an authoritative fence", () => {
+    const shell = createShell({ authoritative: false });
     const { result } = renderHook(() => useOsWindowCommands(), { wrapper: shell.wrapper });
 
     expect(result.current.commandsAvailable).toBe(false);

--- a/web/src/systems/os/hooks/__tests__/use-cmd-palette-dispatch.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-cmd-palette-dispatch.test.tsx
@@ -1,8 +1,10 @@
 // Suite: command palette dispatch targeting
-// Invariant: daemon invokes carry the bound client, a stale runById target is
-// announced, and host-target copy writes the clipboard after seam policy gates.
+// Invariant: daemon invokes carry the bound client, navigation preserves route
+// intent, a stale runById target is announced, and host-target copy writes the
+// clipboard after seam policy gates.
 // Boundary IN: resolveInvokeClientId and useCmdPaletteDispatch.run.
-// Boundary OUT: OpenAPI invoke transport, catalog cache, and navigator.clipboard.
+// Boundary OUT: OpenAPI invoke transport, app navigation, catalog cache, and
+// navigator.clipboard.
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
@@ -129,6 +131,37 @@ describe("command palette dispatch targeting", () => {
       args: {},
     });
     expect(input).not.toHaveProperty("attachmentToken");
+  });
+
+  it("Should preserve route intent when a command navigates to an app", async () => {
+    const openApp = vi.fn();
+    const command = paletteCommand({
+      id: "profile.archive",
+      arguments: [{ name: "profile", type: "text", required: true }],
+      action: {
+        kind: "navigate",
+        app: "settings",
+        args: { pathname: "/settings/profiles", flow: "archive" },
+      },
+    });
+    const { result } = renderHook(
+      () =>
+        useCmdPaletteDispatch({
+          registry: emptyRegistry,
+          workspaceId: "ws_home",
+          shell: shellFixture(),
+          openApp,
+        }),
+      { wrapper: wrapper() }
+    );
+
+    await expect(result.current.run(command, { args: { profile: "marketing" } })).resolves.toEqual({
+      status: "ran",
+    });
+    expect(openApp).toHaveBeenCalledExactlyOnceWith("settings", {
+      pathname: "/settings/profiles",
+      search: { flow: "archive", profile: "marketing" },
+    });
   });
 
   it("Should announce when runById names a command the registry no longer carries [RD0094]", async () => {

--- a/web/src/systems/os/hooks/__tests__/use-cmd-palette-stream.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-cmd-palette-stream.test.tsx
@@ -16,6 +16,10 @@ import {
   CMD_PALETTE_CATALOG_CHANGED_EVENT,
   cmdPaletteStreamUrl,
 } from "../../lib/cmd-palette-stream";
+import {
+  backgroundStreamsWithinConnectionBudget,
+  continuityStreamsWithinConnectionBudget,
+} from "../../lib/background-stream-budget";
 import { useCmdPaletteStream } from "../use-cmd-palette-stream";
 
 const WORKSPACE = "ws-hq";
@@ -57,7 +61,7 @@ class FakeEventSource implements StreamEventSource {
   }
 }
 
-function harness(workspaceId: string | null = WORKSPACE) {
+function harness(workspaceId: string | null = WORKSPACE, enabled = true) {
   const sources: FakeEventSource[] = [];
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -70,6 +74,7 @@ function harness(workspaceId: string | null = WORKSPACE) {
     () =>
       useCmdPaletteStream({
         workspaceId,
+        enabled,
         eventSourceFactory: url => {
           const source = new FakeEventSource(url);
           sources.push(source);
@@ -175,6 +180,57 @@ describe("useCmdPaletteStream (UT-104)", () => {
     const { result, sources } = harness(null);
     expect(result.current).toBe("disabled");
     expect(sources).toHaveLength(0);
+  });
+
+  it("Should stay disabled when the desktop reserves capacity for multiple live sessions", () => {
+    const { result, sources } = harness(WORKSPACE, false);
+    expect(result.current).toBe("disabled");
+    expect(sources).toHaveLength(0);
+  });
+
+  it("Should reserve the palette stream connection while any app window is visible", () => {
+    const window = {
+      app: "session" as const,
+      desktopId: "desktop-1",
+      minimized: false,
+      stackActive: true,
+    };
+    expect(
+      backgroundStreamsWithinConnectionBudget({
+        activeDesktopId: "desktop-1",
+        connectionStatus: "connected",
+        windows: { first: window },
+      })
+    ).toBe(false);
+    expect(
+      backgroundStreamsWithinConnectionBudget({
+        activeDesktopId: "desktop-1",
+        connectionStatus: "connected",
+        windows: { first: { ...window, app: "tasks" } },
+      })
+    ).toBe(false);
+    expect(
+      backgroundStreamsWithinConnectionBudget({
+        activeDesktopId: "desktop-1",
+        connectionStatus: "connected",
+        windows: { first: { ...window, minimized: true } },
+      })
+    ).toBe(true);
+    expect(
+      backgroundStreamsWithinConnectionBudget({
+        activeDesktopId: "desktop-1",
+        connectionStatus: "reconnecting",
+        windows: {},
+      })
+    ).toBe(false);
+    expect(continuityStreamsWithinConnectionBudget({ connectionStatus: "connected" })).toBe(true);
+    expect(continuityStreamsWithinConnectionBudget({ connectionStatus: "disconnected" })).toBe(
+      true
+    );
+    expect(continuityStreamsWithinConnectionBudget({ connectionStatus: "connecting" })).toBe(false);
+    expect(continuityStreamsWithinConnectionBudget({ connectionStatus: "reconnecting" })).toBe(
+      false
+    );
   });
 
   it("Should subscribe under the active profile so the daemon never sends another's revisions", () => {

--- a/web/src/systems/os/hooks/__tests__/use-desktop-shell-model.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-desktop-shell-model.test.tsx
@@ -42,10 +42,11 @@ vi.mock("@/systems/workspace", () => ({
 }));
 
 import { useDesktopShellModel } from "../use-desktop-shell-model";
+import { useActiveWorkspace } from "@/systems/workspace";
 
 describe("useDesktopShellModel", () => {
   it("Should mount before the desktop shell context exists", () => {
-    const { result } = renderHook(() => useDesktopShellModel());
+    const { result } = renderHook(() => useDesktopShellModel(useActiveWorkspace()));
 
     expect(result.current.activeWorkspaceId).toBeNull();
     expect(result.current.worktreeListing).toBeUndefined();
@@ -53,7 +54,7 @@ describe("useDesktopShellModel", () => {
 
   it("Should budget optional and continuity streams independently", () => {
     renderHook(() =>
-      useDesktopShellModel({
+      useDesktopShellModel(useActiveWorkspace(), {
         backgroundStreamsEnabled: false,
         continuityStreamsEnabled: true,
       })

--- a/web/src/systems/os/hooks/__tests__/use-desktop-shell-model.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-desktop-shell-model.test.tsx
@@ -1,5 +1,6 @@
 // Suite: desktop shell model boundary
-// Invariant: the shell model mounts before OsShellContext because DesktopShell owns that provider.
+// Invariant: the shell model mounts before OsShellContext and independently budgets optional
+// worktree traffic and continuity-critical session events.
 // Boundary IN: useDesktopShellModel's dependency graph.
 // Boundary OUT: query transports, window-manager projection, and rendered desktop chrome.
 import { renderHook } from "@testing-library/react";
@@ -7,7 +8,9 @@ import { describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   sessionCreate: { store: {} },
+  sessionCatalogStreams: vi.fn((_options: unknown) => "connected"),
   agentCreate: { open: false },
+  worktreeCatalogStream: vi.fn((_workspaces: unknown, _options: unknown) => "connected"),
 }));
 
 vi.mock("@/systems/agent", () => ({
@@ -16,7 +19,7 @@ vi.mock("@/systems/agent", () => ({
 }));
 
 vi.mock("@/systems/session", () => ({
-  useSessionCatalogStreams: () => "connected",
+  useSessionCatalogStreams: (options: unknown) => mocks.sessionCatalogStreams(options),
   useSessionCreateDialogController: () => mocks.sessionCreate,
 }));
 
@@ -33,7 +36,8 @@ vi.mock("@/systems/workspace", () => ({
   }),
   useUserHomeDir: () => "/operator",
   useWorkspace: () => ({ data: undefined, isLoading: false, error: null }),
-  useWorktreeCatalogStream: () => "connected",
+  useWorktreeCatalogStream: (workspaces: unknown, options: unknown) =>
+    mocks.worktreeCatalogStream(workspaces, options),
   useWorktrees: () => ({ data: undefined }),
 }));
 
@@ -45,5 +49,19 @@ describe("useDesktopShellModel", () => {
 
     expect(result.current.activeWorkspaceId).toBeNull();
     expect(result.current.worktreeListing).toBeUndefined();
+  });
+
+  it("Should budget optional and continuity streams independently", () => {
+    renderHook(() =>
+      useDesktopShellModel({
+        backgroundStreamsEnabled: false,
+        continuityStreamsEnabled: true,
+      })
+    );
+
+    expect(mocks.worktreeCatalogStream).toHaveBeenLastCalledWith([], { enabled: false });
+    expect(mocks.sessionCatalogStreams).toHaveBeenLastCalledWith(
+      expect.objectContaining({ enabled: true })
+    );
   });
 });

--- a/web/src/systems/os/hooks/__tests__/use-window-manager-client.test.tsx
+++ b/web/src/systems/os/hooks/__tests__/use-window-manager-client.test.tsx
@@ -58,8 +58,8 @@ function client(presentationRevision = 1): WindowManagerRegisteredClientView {
 
 beforeEach(() => {
   Reflect.deleteProperty(globalThis, WINDOW_MANAGER_CLIENT_ID_MEMORY_KEY);
-  window.localStorage.clear();
-  window.localStorage.setItem(STORAGE_KEY, "client:stable");
+  window.sessionStorage.clear();
+  window.sessionStorage.setItem(STORAGE_KEY, "client:stable");
   vi.mocked(isDesktopShell).mockReturnValue(false);
   // Matches the adapter's real shape: retiring a registration is awaited.
   vi.mocked(unregisterWindowManagerClient).mockResolvedValue(undefined);

--- a/web/src/systems/os/hooks/use-cmd-palette-dispatch.ts
+++ b/web/src/systems/os/hooks/use-cmd-palette-dispatch.ts
@@ -171,12 +171,12 @@ export function useCmdPaletteDispatch({
           invalidateRankSignals();
           return result;
         },
-        navigate: (app, pathname) => {
+        navigate: (app, pathname, search = {}) => {
           if (navigateOverride === undefined) {
-            navigate(app, pathname);
+            navigate(app, pathname, search);
             return;
           }
-          navigateOverride(app as OsAppId, pathname === null ? null : { pathname, search: {} });
+          navigateOverride(app as OsAppId, pathname === null ? null : { pathname, search });
         },
         pushView: viewId => shell.openPaletteView(viewId),
         openUrl: openExternalUrl,

--- a/web/src/systems/os/hooks/use-cmd-palette-registry.ts
+++ b/web/src/systems/os/hooks/use-cmd-palette-registry.ts
@@ -3,7 +3,9 @@ import type { PaletteRegistry } from "../lib/cmd-palette-types";
 import type { WindowManagerAttachedClientView } from "../lib/window-manager-types";
 import { useCmdPaletteCatalog } from "./use-cmd-palette-catalog";
 import { useCmdPaletteContext } from "./use-cmd-palette-context";
+import { backgroundStreamsWithinConnectionBudget } from "../lib/background-stream-budget";
 import { useCmdPaletteStream } from "./use-cmd-palette-stream";
+import { useDesktop } from "./use-desktop";
 
 export interface UseCmdPaletteRegistryOptions {
   readonly workspaceId: string | null;
@@ -36,7 +38,8 @@ export function useCmdPaletteRegistry({
     clientId,
     enabled,
   });
-  useCmdPaletteStream({ workspaceId, enabled });
+  const streamWithinConnectionBudget = useDesktop(backgroundStreamsWithinConnectionBudget);
+  useCmdPaletteStream({ workspaceId, enabled: enabled && streamWithinConnectionBudget });
   const daemonContext = client?.paletteContext;
   const context = useCmdPaletteContext({
     // `shell.desktop` is the daemon's own derivation from the attachment kind;

--- a/web/src/systems/os/hooks/use-desktop-chrome-controller.ts
+++ b/web/src/systems/os/hooks/use-desktop-chrome-controller.ts
@@ -1,0 +1,26 @@
+import { useState } from "react";
+
+import { useDesktopChrome } from "./use-desktop-chrome";
+import { useDesktopShellModel } from "./use-desktop-shell-model";
+import { useWorkspaceSetupDefaults } from "./use-workspace-setup-defaults";
+import { useWorktreeDialogTargets } from "./use-worktree-dialog-targets";
+
+/** Owns the state and supporting models required to mount the desktop chrome. */
+export function useDesktopChromeController() {
+  const [backgroundStreamsEnabled, setBackgroundStreamsEnabled] = useState(true);
+  const [continuityStreamsEnabled, setContinuityStreamsEnabled] = useState(true);
+  const model = useDesktopShellModel({ backgroundStreamsEnabled, continuityStreamsEnabled });
+  const chrome = useDesktopChrome(model.desktopWorkspaceId);
+  const workspaceSetupDefaults = useWorkspaceSetupDefaults();
+  const worktreeDialogs = useWorktreeDialogTargets();
+
+  return {
+    chrome,
+    continuityStreamsEnabled,
+    model,
+    setBackgroundStreamsEnabled,
+    setContinuityStreamsEnabled,
+    workspaceSetupDefaults,
+    worktreeDialogs,
+  };
+}

--- a/web/src/systems/os/hooks/use-desktop-chrome-controller.ts
+++ b/web/src/systems/os/hooks/use-desktop-chrome-controller.ts
@@ -1,16 +1,31 @@
-import { useState } from "react";
+import { useAtom } from "@xstate/store-react";
 
 import { useDesktopChrome } from "./use-desktop-chrome";
 import { useDesktopShellModel } from "./use-desktop-shell-model";
 import { useWorkspaceSetupDefaults } from "./use-workspace-setup-defaults";
 import { useWorktreeDialogTargets } from "./use-worktree-dialog-targets";
+import {
+  backgroundStreamsWithinConnectionBudget,
+  continuityStreamsWithinConnectionBudget,
+} from "../lib/background-stream-budget";
+import { useActiveWorkspace } from "@/systems/workspace";
 
 /** Owns the state and supporting models required to mount the desktop chrome. */
 export function useDesktopChromeController() {
-  const [backgroundStreamsEnabled, setBackgroundStreamsEnabled] = useState(true);
-  const [continuityStreamsEnabled, setContinuityStreamsEnabled] = useState(true);
-  const model = useDesktopShellModel({ backgroundStreamsEnabled, continuityStreamsEnabled });
-  const chrome = useDesktopChrome(model.desktopWorkspaceId);
+  const activeWorkspace = useActiveWorkspace();
+  const chrome = useDesktopChrome(activeWorkspace.desktopWorkspaceId);
+  const backgroundStreamsEnabled = useAtom(
+    chrome.shell.projection,
+    backgroundStreamsWithinConnectionBudget
+  );
+  const continuityStreamsEnabled = useAtom(
+    chrome.shell.projection,
+    continuityStreamsWithinConnectionBudget
+  );
+  const model = useDesktopShellModel(activeWorkspace, {
+    backgroundStreamsEnabled,
+    continuityStreamsEnabled,
+  });
   const workspaceSetupDefaults = useWorkspaceSetupDefaults();
   const worktreeDialogs = useWorktreeDialogTargets();
 
@@ -18,8 +33,6 @@ export function useDesktopChromeController() {
     chrome,
     continuityStreamsEnabled,
     model,
-    setBackgroundStreamsEnabled,
-    setContinuityStreamsEnabled,
     workspaceSetupDefaults,
     worktreeDialogs,
   };

--- a/web/src/systems/os/hooks/use-desktop-chrome.ts
+++ b/web/src/systems/os/hooks/use-desktop-chrome.ts
@@ -105,7 +105,14 @@ export function useDesktopChrome(activeWorkspaceId: string | null): DesktopChrom
     return () => manager.stop();
   }, [manager]);
 
-  useEffect(() => subscribeWorkspaceSwitchBarrier(shell.coordinator), [shell]);
+  useEffect(
+    () =>
+      subscribeWorkspaceSwitchBarrier(
+        shell.coordinator,
+        () => manager.getState().client?.workspaceId ?? null
+      ),
+    [manager, shell]
+  );
 
   useEffect(() => {
     if (activeWorkspaceId === null) {

--- a/web/src/systems/os/hooks/use-desktop-dock.ts
+++ b/web/src/systems/os/hooks/use-desktop-dock.ts
@@ -5,6 +5,7 @@ import { DockIcons, type DockIconId } from "../components/os-dock-icons";
 import type { OsDockEntry } from "../components/os-dock-types";
 import type { OsAttentionBadges } from "../lib/attention-model";
 import { dockAppDescriptors, OS_APP_DESCRIPTORS } from "../lib/app-catalog";
+import { windowManagerCommandsAvailable } from "../lib/window-manager-command-availability";
 import {
   activationTarget,
   appRunState,
@@ -21,6 +22,7 @@ export interface DesktopDockModel {
   presentation: OsPresentation;
   /** Floating-only magnification, gated by the appearance toggle and motion prefs. */
   magnify: boolean;
+  commandsAvailable: boolean;
   handleSelect: (id: string) => void;
 }
 
@@ -43,6 +45,7 @@ export function useDesktopDock(
   // appearance toggle here, the system reduced-motion preference inside
   // `useDockMagnify`, and compact presentation via the tab-bar branch.
   const magnify = useDesktop(state => state.dockMagnify && !state.reduceMotion);
+  const commandsAvailable = useDesktop(windowManagerCommandsAvailable);
   // Dock state aggregates every instance of an app (ADR-010 §3): the icon
   // lights while any window of that app is live, whatever its instance key.
   const windowStates = useDesktop(state => {
@@ -83,6 +86,7 @@ export function useDesktopDock(
   });
 
   const handleSelect = (id: string) => {
+    if (!commandsAvailable) return;
     const appId = id as OsAppId;
     const state = manager.getState();
     if (appId === "session") {
@@ -119,5 +123,5 @@ export function useDesktopDock(
     void coordinator.userActivateWindow(target.id);
   };
 
-  return { entries, presentation, magnify, handleSelect };
+  return { entries, presentation, magnify, commandsAvailable, handleSelect };
 }

--- a/web/src/systems/os/hooks/use-desktop-manager-surfaces.ts
+++ b/web/src/systems/os/hooks/use-desktop-manager-surfaces.ts
@@ -1,6 +1,7 @@
 import { shallowEqual } from "@xstate/store";
 
 import { getOsAppDescriptor } from "../lib/app-catalog";
+import { windowManagerCommandsAvailable } from "../lib/window-manager-command-availability";
 import { useDesktop } from "./use-desktop";
 import {
   useDesktopOverviewSegmentRequest,
@@ -20,10 +21,7 @@ export function useDesktopManagerSurfaces() {
   const hydration = useDesktop(state => state.hydration);
   const connectionStatus = useDesktop(state => state.connectionStatus);
   const activeDesktopId = useDesktop(state => state.activeDesktopId);
-  const canMutate = useDesktop(
-    state =>
-      state.client !== null && state.hydration === "live" && state.connectionStatus === "connected"
-  );
+  const canMutate = useDesktop(windowManagerCommandsAvailable);
   const projection = useDesktop(
     state => ({
       desktops: state.desktops,

--- a/web/src/systems/os/hooks/use-desktop-shell-body.ts
+++ b/web/src/systems/os/hooks/use-desktop-shell-body.ts
@@ -18,6 +18,7 @@ import type { OsAttentionSections, OsSessionAttentionRow } from "../lib/attentio
 import type { PaletteShellHandlers } from "../lib/cmd-palette-client-ops";
 import type { ClientCommandChannel } from "../lib/client-command-channel";
 import type { OsDesktopRuntimeStore, OsOpenTarget } from "../lib/os-types";
+import { windowManagerCommandsAvailable } from "../lib/window-manager-command-availability";
 import { shortcutActionLabel } from "../lib/window-manager-shortcuts";
 import type {
   ProjectedFrameSeam,
@@ -206,10 +207,7 @@ export function useDesktopShellBody(model: DesktopShellModel, options: DesktopSh
       activeDesktopId: state.activeDesktopId,
       desktops: state.desktops,
       compact: state.presentation === "compact",
-      canSwitchDesktop:
-        state.client !== null &&
-        state.hydration === "live" &&
-        state.connectionStatus === "connected",
+      canSwitchDesktop: windowManagerCommandsAvailable(state),
     }),
     shallowEqual
   );

--- a/web/src/systems/os/hooks/use-desktop-shell-model.ts
+++ b/web/src/systems/os/hooks/use-desktop-shell-model.ts
@@ -18,7 +18,13 @@ import {
  * the session/agent create dialog wiring (sidebar state is gone with the
  * sidebar).
  */
-export function useDesktopShellModel() {
+export function useDesktopShellModel({
+  backgroundStreamsEnabled = true,
+  continuityStreamsEnabled = true,
+}: {
+  backgroundStreamsEnabled?: boolean;
+  continuityStreamsEnabled?: boolean;
+} = {}) {
   const {
     workspaces,
     registeredWorkspaces,
@@ -53,6 +59,7 @@ export function useDesktopShellModel() {
   // Attention edges leave the stream through the module-level bus so the
   // notifier can subscribe without ever reopening this connection.
   const sessionCatalogStreamStatus = useSessionCatalogStreams({
+    enabled: continuityStreamsEnabled,
     onAttentionEdge: publishAttentionEdge,
     onOperatorNotification: publishOperatorNotification,
   });
@@ -60,7 +67,7 @@ export function useDesktopShellModel() {
   // One catalog subscription per shell; the query stays the snapshot authority
   // and this only reconciles workspace-qualified invalidations into it.
   const worktreeCatalogStreamStatus = useWorktreeCatalogStream(workspaces, {
-    enabled: hasWorkspaces,
+    enabled: hasWorkspaces && backgroundStreamsEnabled,
   });
   const activeWorktrees = useWorktrees(activeWorkspaceId, { enabled: activeWorkspaceId !== null });
   const userHomeDir = useUserHomeDir();

--- a/web/src/systems/os/hooks/use-desktop-shell-model.ts
+++ b/web/src/systems/os/hooks/use-desktop-shell-model.ts
@@ -18,14 +18,8 @@ import {
  * the session/agent create dialog wiring (sidebar state is gone with the
  * sidebar).
  */
-export function useDesktopShellModel({
-  backgroundStreamsEnabled = true,
-  continuityStreamsEnabled = true,
-}: {
-  backgroundStreamsEnabled?: boolean;
-  continuityStreamsEnabled?: boolean;
-} = {}) {
-  const {
+export function useDesktopShellModel(
+  {
     workspaces,
     registeredWorkspaces,
     hasWorkspaces,
@@ -46,7 +40,15 @@ export function useDesktopShellModel({
     toggleGlobalScope,
     isLoading: areWorkspacesLoading,
     isError: workspacesError,
-  } = useActiveWorkspace();
+  }: ReturnType<typeof useActiveWorkspace>,
+  {
+    backgroundStreamsEnabled = true,
+    continuityStreamsEnabled = true,
+  }: {
+    backgroundStreamsEnabled?: boolean;
+    continuityStreamsEnabled?: boolean;
+  } = {}
+) {
   const { data: agents } = useAgents(runtimeWorkspaceId, {
     enabled: runtimeWorkspaceId !== null,
   });

--- a/web/src/systems/os/lib/__tests__/window-manager-client-identity.test.ts
+++ b/web/src/systems/os/lib/__tests__/window-manager-client-identity.test.ts
@@ -1,6 +1,6 @@
 // Suite: window-manager client identity
-// Invariant: one browser tab keeps one client id across storage failures and
-// does not mint entropy when a persisted id already exists.
+// Invariant: one browser tab keeps one client id across reloads and storage
+// failures without sharing the identity through origin-wide local storage.
 // Owning layer: unit — the identity helper.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -12,6 +12,7 @@ import {
 
 beforeEach(() => {
   Reflect.deleteProperty(globalThis, WINDOW_MANAGER_CLIENT_ID_MEMORY_KEY);
+  window.sessionStorage.clear();
   window.localStorage.clear();
 });
 
@@ -22,10 +23,11 @@ afterEach(() => {
 });
 
 describe("stableWindowManagerClientId", () => {
-  it("Should reuse a persisted id without generating entropy", () => {
+  it("Should reuse the tab-scoped id without generating entropy", () => {
     const randomUUID = vi.fn(() => "generated");
     vi.stubGlobal("crypto", { randomUUID });
-    window.localStorage.setItem(WINDOW_MANAGER_CLIENT_ID_STORAGE_KEY, "client:persisted");
+    window.localStorage.setItem(WINDOW_MANAGER_CLIENT_ID_STORAGE_KEY, "client:other-tab");
+    window.sessionStorage.setItem(WINDOW_MANAGER_CLIENT_ID_STORAGE_KEY, "client:persisted");
 
     expect(stableWindowManagerClientId()).toBe("client:persisted");
     expect(stableWindowManagerClientId()).toBe("client:persisted");

--- a/web/src/systems/os/lib/__tests__/workspace-switch-barrier.test.ts
+++ b/web/src/systems/os/lib/__tests__/workspace-switch-barrier.test.ts
@@ -28,4 +28,17 @@ describe("subscribeWorkspaceSwitchBarrier", () => {
     expect(beginWorkspaceSwitch).toHaveBeenCalledOnce();
     unsubscribe();
   });
+
+  it("Should keep routing live when selection resolves to the already-bound workspace", () => {
+    const beginWorkspaceSwitch = vi.fn();
+    const unsubscribe = subscribeWorkspaceSwitchBarrier(
+      { beginWorkspaceSwitch },
+      () => "workspace:one"
+    );
+
+    setActiveWorkspaceId("workspace:one");
+
+    expect(beginWorkspaceSwitch).not.toHaveBeenCalled();
+    unsubscribe();
+  });
 });

--- a/web/src/systems/os/lib/background-stream-budget.ts
+++ b/web/src/systems/os/lib/background-stream-budget.ts
@@ -1,0 +1,28 @@
+import type { OsDesktopRuntimeStore, OsWindow } from "./os-types";
+
+export interface BackgroundStreamBudgetState {
+  activeDesktopId: OsDesktopRuntimeStore["activeDesktopId"];
+  connectionStatus: OsDesktopRuntimeStore["connectionStatus"];
+  windows: Readonly<
+    Record<string, Pick<OsWindow, "app" | "desktopId" | "minimized" | "stackActive">>
+  >;
+}
+
+/** Leaves browser connection capacity to authoritative and visible-window streams. */
+export function backgroundStreamsWithinConnectionBudget(
+  state: BackgroundStreamBudgetState
+): boolean {
+  return (
+    state.connectionStatus === "connected" &&
+    !Object.values(state.windows).some(
+      win => win.desktopId === state.activeDesktopId && !win.minimized && win.stackActive
+    )
+  );
+}
+
+/** Continuity streams may coexist with windows, but yield during an active authority handshake. */
+export function continuityStreamsWithinConnectionBudget(
+  state: Pick<BackgroundStreamBudgetState, "connectionStatus">
+): boolean {
+  return state.connectionStatus === "connected" || state.connectionStatus === "disconnected";
+}

--- a/web/src/systems/os/lib/window-manager-client-identity.ts
+++ b/web/src/systems/os/lib/window-manager-client-identity.ts
@@ -28,10 +28,10 @@ export function stableWindowManagerClientId(): string {
   const cached = rememberedClientId();
   if (cached) return cached;
   try {
-    const existing = window.localStorage.getItem(WINDOW_MANAGER_CLIENT_ID_STORAGE_KEY)?.trim();
+    const existing = window.sessionStorage.getItem(WINDOW_MANAGER_CLIENT_ID_STORAGE_KEY)?.trim();
     if (existing) return rememberClientId(existing);
     const created = randomClientId();
-    window.localStorage.setItem(WINDOW_MANAGER_CLIENT_ID_STORAGE_KEY, created);
+    window.sessionStorage.setItem(WINDOW_MANAGER_CLIENT_ID_STORAGE_KEY, created);
     return rememberClientId(created);
   } catch {
     return rememberClientId(randomClientId());

--- a/web/src/systems/os/lib/window-manager-command-availability.ts
+++ b/web/src/systems/os/lib/window-manager-command-availability.ts
@@ -1,11 +1,11 @@
 import type { OsDesktopRuntimeStore } from "./os-types";
 
-/** Commands require an authoritative snapshot and the registered live client fence. */
+/** Commands use HTTP and remain available while the event stream reconnects. */
 export function windowManagerCommandsAvailable(state: OsDesktopRuntimeStore): boolean {
   return (
     state.snapshot !== null &&
     state.client !== null &&
-    state.hydration === "live" &&
-    state.connectionStatus === "connected"
+    state.windowManagerConfig !== null &&
+    state.hydration === "live"
   );
 }

--- a/web/src/systems/os/lib/workspace-switch-barrier.ts
+++ b/web/src/systems/os/lib/workspace-switch-barrier.ts
@@ -3,7 +3,8 @@ import { activeWorkspaceStore } from "@/systems/workspace";
 
 /** Enters hydration synchronously, before route layout effects can report the new location. */
 export function subscribeWorkspaceSwitchBarrier(
-  coordinator: Pick<RoutingCoordinator, "beginWorkspaceSwitch">
+  coordinator: Pick<RoutingCoordinator, "beginWorkspaceSwitch">,
+  currentWorkspaceId: () => string | null = () => null
 ): () => void {
   let previousWorkspaceId = activeWorkspaceStore.getSnapshot().context.selectedWorkspaceId;
   return activeWorkspaceStore.subscribe(snapshot => {
@@ -11,6 +12,10 @@ export function subscribeWorkspaceSwitchBarrier(
     if (nextWorkspaceId === previousWorkspaceId) return;
 
     previousWorkspaceId = nextWorkspaceId;
+    // Global mode can acquire a remembered project without changing the
+    // desktop's durable layout partition. Entering hydration in that case
+    // would strand route reconciliation because no runtime rebind follows.
+    if (nextWorkspaceId !== null && nextWorkspaceId === currentWorkspaceId()) return;
     coordinator.beginWorkspaceSwitch();
   }).unsubscribe;
 }

--- a/web/src/systems/profiles/components/profile-lifecycle-host.tsx
+++ b/web/src/systems/profiles/components/profile-lifecycle-host.tsx
@@ -12,13 +12,15 @@ import { ProfileLifecycleDialogs } from "./profile-lifecycle-dialogs";
  * browser.
  */
 export function ProfileLifecycleHost({
+  enabled = true,
   onSetAutomationEnabled,
 }: {
+  enabled?: boolean;
   onSetAutomationEnabled: (identity: string, profile: string, enabled: boolean) => Promise<void>;
 }) {
   const lens = useProfileLens();
   const profiles = useProfiles();
-  useProfileEventStream();
+  useProfileEventStream({ enabled });
   return (
     <ProfileLifecycleDialogs
       profiles={profiles.data ?? []}

--- a/web/src/systems/profiles/components/profile-switcher-menu.tsx
+++ b/web/src/systems/profiles/components/profile-switcher-menu.tsx
@@ -113,14 +113,19 @@ export function ProfileSwitcherMenu({
             </CommandItem>
           ) : null}
           {manageable ? (
-            <CommandItem
-              value="__create-profile"
-              onSelect={onCreate}
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onCreate}
+              onKeyDown={event => {
+                if (event.key === "Enter" || event.key === " ") event.stopPropagation();
+              }}
               data-testid="profile-switcher-create"
+              className="h-auto w-full justify-start gap-2 px-2 py-1.5 text-small-body font-normal tracking-normal"
             >
               <Plus aria-hidden="true" className="size-3.5 shrink-0" />
               <span>Create profile…</span>
-            </CommandItem>
+            </Button>
           ) : null}
         </CommandGroup>
       </CommandList>

--- a/web/src/systems/profiles/hooks/__tests__/use-profile-selection.test.tsx
+++ b/web/src/systems/profiles/hooks/__tests__/use-profile-selection.test.tsx
@@ -1,0 +1,80 @@
+// Suite: active profile view selection
+// Invariant: changing profile lenses carries the source lens's local view before any consumer
+// commits a destination-scoped read.
+// Owning layer: useActiveProfileView.
+// Boundary IN: profile lens changes and profile-view store entries.
+// Boundary OUT: profile API persistence and profile consumers.
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, waitFor } from "@testing-library/react";
+import { useLayoutEffect, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { profileLensKey } from "../../lib/query-keys";
+import {
+  profileViewStore,
+  resetProfileViews,
+  setProfileView,
+} from "../../stores/profile-view-store";
+import type { ProfileLens, ProfileView } from "../../types";
+import { useActiveProfileView } from "../use-profile-selection";
+
+const GLOBAL_LENS: ProfileLens = { scope: "global" };
+const WORKSPACE_LENS: ProfileLens = { scope: "workspace", workspaceId: "ws-2" };
+
+function ViewCommitProbe({
+  lens,
+  onCommit,
+}: {
+  lens: ProfileLens;
+  onCommit: (view: ProfileView) => void;
+}) {
+  const view = useActiveProfileView(lens, false);
+  const lensKey = profileLensKey(lens);
+
+  useLayoutEffect(() => onCommit(view), [lensKey, onCommit, view]);
+  return null;
+}
+
+function createWrapper(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useActiveProfileView", () => {
+  beforeEach(() => resetProfileViews());
+
+  it("Should preserve the source local view throughout a lens transition", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const onCommit = vi.fn();
+    setProfileView(GLOBAL_LENS, { kind: "profile", profile: "marketing" });
+    setProfileView(WORKSPACE_LENS, { kind: "profile", profile: "engineering" });
+    const Wrapper = createWrapper(queryClient);
+    const view = render(
+      <Wrapper>
+        <ViewCommitProbe lens={GLOBAL_LENS} onCommit={onCommit} />
+      </Wrapper>
+    );
+
+    view.rerender(
+      <Wrapper>
+        <ViewCommitProbe lens={WORKSPACE_LENS} onCommit={onCommit} />
+      </Wrapper>
+    );
+
+    await waitFor(() =>
+      expect(
+        profileViewStore.getSnapshot().context.viewByLens[profileLensKey(WORKSPACE_LENS)]
+      ).toEqual({ kind: "profile", profile: "marketing" })
+    );
+    expect(onCommit).toHaveBeenCalled();
+    expect(onCommit.mock.calls.map(([committedView]) => committedView)).toEqual(
+      expect.arrayContaining([{ kind: "profile", profile: "marketing" }])
+    );
+    expect(
+      onCommit.mock.calls.every(([committedView]) => committedView.profile === "marketing")
+    ).toBe(true);
+  });
+});

--- a/web/src/systems/profiles/hooks/use-profile-mutations.ts
+++ b/web/src/systems/profiles/hooks/use-profile-mutations.ts
@@ -11,7 +11,7 @@ import {
   updateProfileIdentity,
 } from "../adapters/profiles-api";
 import { profileKeys } from "../lib/query-keys";
-import { sweepProfileView } from "../stores/profile-view-store";
+import { setProfileView, sweepProfileView } from "../stores/profile-view-store";
 import type { CreateProfileParams, UpdateProfileParams } from "../types";
 
 /**
@@ -43,8 +43,17 @@ export function useCreateProfile() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (params: CreateProfileParams) => createProfile(params),
-    onSuccess: profile => {
+    onSuccess: (profile, input) => {
       notifyUser({ message: `Created ${profile.name}.`, tone: "success" });
+      const activation = input.activate;
+      if (activation?.scope === "global") {
+        setProfileView({ scope: "global" }, { kind: "profile", profile: profile.name });
+      } else if (activation?.scope === "workspace" && activation.workspace_id) {
+        setProfileView(
+          { scope: "workspace", workspaceId: activation.workspace_id },
+          { kind: "profile", profile: profile.name }
+        );
+      }
       return reconcile(queryClient, profile.name);
     },
     onError: reportFailure("Could not create the profile."),

--- a/web/src/systems/profiles/hooks/use-profile-selection.ts
+++ b/web/src/systems/profiles/hooks/use-profile-selection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "@xstate/store-react";
 
@@ -33,18 +33,31 @@ export function useRememberedProfile(lens: ProfileLens, enabled = true) {
 export function useActiveProfileView(lens: ProfileLens, enabled = true): ProfileView {
   const remembered = useRememberedProfile(lens, enabled);
   const viewByLens = useSelector(profileViewStore, state => state.context.viewByLens);
-  const local = viewByLens[profileLensKey(lens)];
   const rememberedProfile = remembered.data?.profile;
   const workspaceId = lens.scope === "workspace" ? lens.workspaceId : null;
   const lensKey = profileLensKey(lens);
-  const previousLens = useRef<ProfileLens>(lens);
+  const [activeLens, setActiveLens] = useState(lens);
+  const [pendingCarry, setPendingCarry] = useState<ProfileViewCarry | null>(null);
+  const activeLensKey = profileLensKey(activeLens);
+  const destinationLocal = viewByLens[lensKey];
+
+  if (activeLensKey !== lensKey) {
+    const sourceView = viewByLens[activeLensKey];
+    setActiveLens(lens);
+    setPendingCarry(sourceView ? { from: activeLens, to: lens, view: sourceView } : null);
+  }
+
+  const carryForCurrentLens =
+    pendingCarry && profileLensKey(pendingCarry.to) === lensKey ? pendingCarry : null;
+  if (carryForCurrentLens && sameProfileView(destinationLocal, carryForCurrentLens.view)) {
+    setPendingCarry(null);
+  }
+  const local = carryForCurrentLens?.view ?? destinationLocal;
 
   useEffect(() => {
-    const previous = previousLens.current;
-    previousLens.current = lens;
-    if (profileLensKey(previous) === lensKey) return;
-    carryProfileView(previous, lens);
-  }, [lens, lensKey]);
+    if (!pendingCarry) return;
+    carryProfileView(pendingCarry.from, pendingCarry.to);
+  }, [pendingCarry]);
 
   useEffect(() => {
     if (!enabled || rememberedProfile === undefined) return;
@@ -55,6 +68,18 @@ export function useActiveProfileView(lens: ProfileLens, enabled = true): Profile
 
   if (local) return local;
   return { kind: "profile", profile: rememberedProfile ?? PERMANENT_PROFILE };
+}
+
+interface ProfileViewCarry {
+  from: ProfileLens;
+  to: ProfileLens;
+  view: ProfileView;
+}
+
+function sameProfileView(left: ProfileView | undefined, right: ProfileView): boolean {
+  if (!left || left.kind !== right.kind) return false;
+  if (left.kind === "aggregate") return true;
+  return right.kind === "profile" && left.profile === right.profile;
 }
 
 /**

--- a/web/src/systems/profiles/hooks/use-profile-selection.ts
+++ b/web/src/systems/profiles/hooks/use-profile-selection.ts
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useSelector } from "@xstate/store-react";
 
@@ -8,6 +9,8 @@ import { PERMANENT_PROFILE } from "../lib/profile-rows";
 import { profileKeys, profileLensKey } from "../lib/query-keys";
 import { profileSelectionOptions } from "../lib/query-options";
 import {
+  carryProfileView,
+  enterProfileView,
   localProfileView,
   profileViewStore,
   restoreProfileView,
@@ -31,8 +34,27 @@ export function useActiveProfileView(lens: ProfileLens, enabled = true): Profile
   const remembered = useRememberedProfile(lens, enabled);
   const viewByLens = useSelector(profileViewStore, state => state.context.viewByLens);
   const local = viewByLens[profileLensKey(lens)];
+  const rememberedProfile = remembered.data?.profile;
+  const workspaceId = lens.scope === "workspace" ? lens.workspaceId : null;
+  const lensKey = profileLensKey(lens);
+  const previousLens = useRef<ProfileLens>(lens);
+
+  useEffect(() => {
+    const previous = previousLens.current;
+    previousLens.current = lens;
+    if (profileLensKey(previous) === lensKey) return;
+    carryProfileView(previous, lens);
+  }, [lens, lensKey]);
+
+  useEffect(() => {
+    if (!enabled || rememberedProfile === undefined) return;
+    const enteredLens: ProfileLens =
+      workspaceId === null ? { scope: "global" } : { scope: "workspace", workspaceId };
+    enterProfileView(enteredLens, { kind: "profile", profile: rememberedProfile });
+  }, [enabled, lens.scope, rememberedProfile, workspaceId]);
+
   if (local) return local;
-  return { kind: "profile", profile: remembered.data?.profile ?? PERMANENT_PROFILE };
+  return { kind: "profile", profile: rememberedProfile ?? PERMANENT_PROFILE };
 }
 
 /**

--- a/web/src/systems/profiles/stores/__tests__/profile-view-store.test.ts
+++ b/web/src/systems/profiles/stores/__tests__/profile-view-store.test.ts
@@ -8,6 +8,8 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
 import {
+  carryProfileView,
+  enterProfileView,
   localProfileView,
   profileViewStore,
   resetProfileViews,
@@ -36,6 +38,22 @@ describe("profile view store", () => {
     expect(localProfileView(ACME)).toEqual({ kind: "profile", profile: "marketing" });
     expect(localProfileView(GLOBAL)).toEqual({ kind: "aggregate" });
     expect(localProfileView(CLIENT)).toBeNull();
+  });
+
+  it("Should capture the remembered choice once when a client enters a lens", () => {
+    enterProfileView(ACME, { kind: "profile", profile: "default" });
+    enterProfileView(ACME, { kind: "profile", profile: "marketing" });
+    expect(localProfileView(ACME)).toEqual({ kind: "profile", profile: "default" });
+  });
+
+  it("Should carry the acting view when workspace breadth changes", () => {
+    setProfileView(ACME, { kind: "aggregate" });
+    setProfileView(GLOBAL, { kind: "profile", profile: "consulting" });
+
+    carryProfileView(ACME, GLOBAL);
+
+    expect(localProfileView(ACME)).toEqual({ kind: "aggregate" });
+    expect(localProfileView(GLOBAL)).toEqual({ kind: "aggregate" });
   });
 
   it("Should roll back to the previous view after a failed persist", () => {

--- a/web/src/systems/profiles/stores/profile-view-store.ts
+++ b/web/src/systems/profiles/stores/profile-view-store.ts
@@ -20,10 +20,19 @@ export const profileViewStore = createStore({
     viewByLens: {} as Record<string, ProfileView>,
   },
   on: {
+    viewEntered: (context, event: { lens: string; view: ProfileView }) => {
+      if (event.lens in context.viewByLens) return undefined;
+      return { ...context, viewByLens: { ...context.viewByLens, [event.lens]: event.view } };
+    },
     viewChanged: (context, event: { lens: string; view: ProfileView }) => {
       const current = context.viewByLens[event.lens];
       if (current && sameView(current, event.view)) return undefined;
       return { ...context, viewByLens: { ...context.viewByLens, [event.lens]: event.view } };
+    },
+    viewCarried: (context, event: { from: string; to: string }) => {
+      const source = context.viewByLens[event.from];
+      if (!source || sameView(context.viewByLens[event.to], source)) return undefined;
+      return { ...context, viewByLens: { ...context.viewByLens, [event.to]: source } };
     },
     viewCleared: (context, event: { lens: string }) => {
       if (!(event.lens in context.viewByLens)) return undefined;
@@ -44,7 +53,8 @@ export const profileViewStore = createStore({
   },
 });
 
-function sameView(left: ProfileView, right: ProfileView): boolean {
+function sameView(left: ProfileView | undefined, right: ProfileView): boolean {
+  if (!left) return false;
   if (left.kind === "aggregate") return right.kind === "aggregate";
   return right.kind === "profile" && left.profile === right.profile;
 }
@@ -60,6 +70,16 @@ export function localProfileView(lens: ProfileLens): ProfileView | null {
 
 export function setProfileView(lens: ProfileLens, view: ProfileView): void {
   profileViewStore.trigger.viewChanged({ lens: profileLensKey(lens), view });
+}
+
+/** Keeps the acting view stable while this client changes workspace breadth. */
+export function carryProfileView(from: ProfileLens, to: ProfileLens): void {
+  profileViewStore.trigger.viewCarried({ from: profileLensKey(from), to: profileLensKey(to) });
+}
+
+/** Captures the remembered default when this client first enters a lens. */
+export function enterProfileView(lens: ProfileLens, view: ProfileView): void {
+  profileViewStore.trigger.viewEntered({ lens: profileLensKey(lens), view });
 }
 
 /** Rolls a lens back after a failed persist, restoring the previous local answer. */

--- a/web/src/systems/session/components/__tests__/session-chat-runtime-provider.test.tsx
+++ b/web/src/systems/session/components/__tests__/session-chat-runtime-provider.test.tsx
@@ -12,6 +12,7 @@ import { createSessionPromptDispatchStore } from "@/components/assistant-ui/sess
 import { Toaster } from "@compozy/ui";
 import { formatMessageError } from "@/components/assistant-ui/session-thread-error";
 import { SessionTranscriptThreadProvider } from "@/systems/session/lib/session-transcript-thread-context";
+import { modelCatalogKeys } from "@/systems/model-catalog";
 
 import { sessionStore } from "@/systems/session/stores/session-store";
 import {
@@ -517,6 +518,15 @@ function countPromptFetches(fetchMock: ReturnType<typeof vi.fn>): number {
   }).length;
 }
 
+function countClarificationFetches(fetchMock: ReturnType<typeof vi.fn>): number {
+  return fetchMock.mock.calls.filter(([input]) => {
+    return (
+      getPathname(input as RequestInfo | URL) ===
+      `/api/workspaces/${primarySessionFixture.workspace_id}/sessions/${primarySessionFixture.id}/clarifications`
+    );
+  }).length;
+}
+
 function fixtureWorkspaceId(): string {
   const workspaceId = primarySessionFixture.workspace_id;
   if (!workspaceId) {
@@ -994,6 +1004,28 @@ describe("SessionChatRuntimeProvider", () => {
     expect(eventSourceFactory).not.toHaveBeenCalled();
   });
 
+  it("Should suspend the live EventSource while a session mutation suppresses its tail", async () => {
+    const sources: FakeSessionEventSource[] = [];
+    const eventSourceFactory = vi.fn((url: string) => {
+      const source = new FakeSessionEventSource(url);
+      sources.push(source);
+      return source;
+    });
+
+    renderSessionThread({ eventSourceFactory });
+    await waitFor(() => expect(eventSourceFactory).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      sessionStore.trigger.sessionLiveTailSuspended({ sessionId: primarySessionFixture.id });
+    });
+    await waitFor(() => expect(sources[0]?.closed).toBe(true));
+
+    act(() => {
+      sessionStore.trigger.sessionLiveTailResumed({ sessionId: primarySessionFixture.id });
+    });
+    await waitFor(() => expect(eventSourceFactory).toHaveBeenCalledTimes(2));
+  });
+
   it("Should preserve a visible message anchor when older history and a live delta arrive together", async () => {
     const user = userEvent.setup();
     transcriptMessages = [sessionTranscriptFixture[1]!];
@@ -1108,6 +1140,81 @@ describe("SessionChatRuntimeProvider", () => {
       .filter(url => url.pathname.endsWith("/prompt"))
       .map(url => url.searchParams.get("ticket"));
     expect(promptTickets).toEqual(["prompt-ticket-one", "prompt-ticket-two"]);
+  });
+
+  // Invariant: a user prompt preempts optional model-catalog reads so browser
+  // connection pressure cannot keep the prompt from reaching the daemon.
+  // Owning layer: chat-runtime provider integration. Canonical suite: this file.
+  it("Should cancel an in-flight model catalog read before dispatching a prompt", async () => {
+    const queryClient = createQueryClient();
+    const catalogStarted = createDeferred<void>();
+    let catalogSignal: AbortSignal | undefined;
+    const catalogQuery = queryClient.fetchQuery({
+      queryKey: modelCatalogKeys.allModels("all", undefined, undefined, true),
+      queryFn: ({ signal }) => {
+        catalogSignal = signal;
+        catalogStarted.resolve();
+        return new Promise<never>((_resolve, reject) => {
+          signal.addEventListener(
+            "abort",
+            () => reject(new DOMException("The operation was aborted", "AbortError")),
+            { once: true }
+          );
+        });
+      },
+    });
+    void catalogQuery.catch(() => undefined);
+    await catalogStarted.promise;
+
+    const user = userEvent.setup();
+    renderSessionThread({ queryClient });
+    await screen.findByTestId("composer-input");
+    await setComposerText("Prompt while provider discovery is slow");
+    await user.click(screen.getByTestId("composer-send-button"));
+
+    await waitFor(() => expect(countPromptFetches(fetchMock)).toBe(1));
+    expect(catalogSignal?.aborted).toBe(true);
+  });
+
+  // Invariant: the prompt response replaces the transcript live tail while it
+  // is active, leaving one browser connection available for control requests.
+  // Owning layer: chat-runtime provider integration. Canonical suite: this file.
+  it("Should suspend the transcript live tail while a prompt stream is active", async () => {
+    const promptResponse = openSseResponse([
+      'data: {"type":"start","messageId":"control-slot-turn"}\n\n',
+    ]);
+    promptResponsePromise = Promise.resolve(promptResponse.response);
+    const sources: FakeSessionEventSource[] = [];
+    const user = userEvent.setup();
+
+    renderSessionThread({
+      eventSourceFactory: url => {
+        const source = new FakeSessionEventSource(url);
+        sources.push(source);
+        return source;
+      },
+    });
+    await waitFor(() => expect(sources).toHaveLength(1));
+    expect(sources[0]?.closed).toBe(false);
+    const initialClarificationFetches = countClarificationFetches(fetchMock);
+
+    await setComposerText("Keep one control connection available");
+    await user.click(screen.getByTestId("composer-send-button"));
+    await waitFor(() => {
+      expect(countPromptFetches(fetchMock)).toBe(1);
+      expect(sources[0]?.closed).toBe(true);
+    });
+    await waitFor(
+      () =>
+        expect(countClarificationFetches(fetchMock)).toBeGreaterThan(initialClarificationFetches),
+      { timeout: 2_500 }
+    );
+
+    promptResponse.close(['data: {"type":"finish","finishReason":"stop"}\n\n', "data: [DONE]\n\n"]);
+    await waitFor(() => {
+      expect(sources).toHaveLength(2);
+      expect(sources[1]?.closed).toBe(false);
+    });
   });
 
   it("Should report a revoked device response from the prompt transport", async () => {

--- a/web/src/systems/session/hooks/__tests__/use-session-actions.test.tsx
+++ b/web/src/systems/session/hooks/__tests__/use-session-actions.test.tsx
@@ -13,6 +13,7 @@ import {
   useQueueSessionPrompt,
   useRepairSession,
   useRenameSession,
+  useResumeSession,
   useSteerSessionPrompt,
   useUnarchiveSession,
 } from "../use-session-actions";
@@ -67,6 +68,7 @@ import {
   deleteSession,
   repairSession,
   renameSession,
+  resumeSession,
   promoteSessionInputToSteer,
   replaceSessionInput,
   rewindSession,
@@ -400,11 +402,14 @@ describe("session actions", () => {
   });
 
   it("useDeleteSession removes cached session data and clears the draft", async () => {
-    vi.mocked(deleteSession).mockResolvedValue(undefined);
+    vi.mocked(deleteSession).mockImplementation(async () => {
+      expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(true);
+    });
 
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
     });
+    const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
     queryClient.setQueryData(sessionKeys.detail(WORKSPACE_ID, createdSession.id), createdSession);
     queryClient.setQueryData(
@@ -433,6 +438,12 @@ describe("session actions", () => {
     });
 
     expect(deleteSession).toHaveBeenCalledWith(WORKSPACE_ID, createdSession.id);
+    expect(cancelSpy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.detail(WORKSPACE_ID, createdSession.id),
+    });
+    expect(cancelSpy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.byIdRoot(createdSession.id),
+    });
     expect(
       queryClient.getQueryData(sessionKeys.detail(WORKSPACE_ID, createdSession.id))
     ).toBeUndefined();
@@ -452,6 +463,9 @@ describe("session actions", () => {
       queryClient.getQueryData(sessionKeys.byId(createdSession.id, PROFILE_AGGREGATE))
     ).toBeUndefined();
     expect(sessionStore.getSnapshot().context.drafts[createdSession.id]).toBeUndefined();
+    expect(
+      sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]
+    ).toBeUndefined();
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: sessionKeys.workspaceLists(WORKSPACE_ID),
     });
@@ -497,6 +511,52 @@ describe("session actions", () => {
       eventsSnapshot
     );
     expect(sessionStore.getSnapshot().context.drafts[createdSession.id]).toBe("keep me");
+    expect(
+      sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]
+    ).toBeUndefined();
+  });
+
+  it("useResumeSession keeps the live tail suspended through state reconciliation", async () => {
+    vi.mocked(resumeSession).mockImplementation(async () => {
+      expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(true);
+      return createdSession;
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const cancelSpy = vi.spyOn(queryClient, "cancelQueries");
+    let releaseInvalidation!: () => void;
+    const invalidation = new Promise<void>(resolve => {
+      releaseInvalidation = resolve;
+    });
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockReturnValue(invalidation);
+    const { result } = renderHook(() => useResumeSession(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    let mutation!: Promise<SessionPayload>;
+    act(() => {
+      mutation = result.current.mutateAsync(createdSession.id);
+    });
+
+    await waitFor(() => expect(invalidateSpy).toHaveBeenCalledTimes(3));
+    expect(cancelSpy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.detail(WORKSPACE_ID, createdSession.id),
+    });
+    expect(cancelSpy).toHaveBeenCalledWith({
+      queryKey: sessionKeys.byIdRoot(createdSession.id),
+    });
+    expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(true);
+
+    releaseInvalidation();
+    await act(async () => {
+      await mutation;
+    });
+
+    expect(
+      sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]
+    ).toBeUndefined();
   });
 
   it("useRepairSession invalidates the owning session query tree after repair completes", async () => {

--- a/web/src/systems/session/hooks/__tests__/use-session-actions.test.tsx
+++ b/web/src/systems/session/hooks/__tests__/use-session-actions.test.tsx
@@ -180,6 +180,7 @@ describe("session actions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     sessionStore.trigger.allDraftsDiscarded();
+    sessionStore.trigger.sessionInteractionRemoved({ sessionId: createdSession.id });
   });
 
   afterEach(() => {
@@ -403,7 +404,7 @@ describe("session actions", () => {
 
   it("useDeleteSession removes cached session data and clears the draft", async () => {
     vi.mocked(deleteSession).mockImplementation(async () => {
-      expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(true);
+      expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(1);
     });
 
     const queryClient = new QueryClient({
@@ -518,7 +519,7 @@ describe("session actions", () => {
 
   it("useResumeSession keeps the live tail suspended through state reconciliation", async () => {
     vi.mocked(resumeSession).mockImplementation(async () => {
-      expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(true);
+      expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(1);
       return createdSession;
     });
 
@@ -547,13 +548,61 @@ describe("session actions", () => {
     expect(cancelSpy).toHaveBeenCalledWith({
       queryKey: sessionKeys.byIdRoot(createdSession.id),
     });
-    expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(true);
+    expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(1);
 
     releaseInvalidation();
     await act(async () => {
       await mutation;
     });
 
+    expect(
+      sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]
+    ).toBeUndefined();
+  });
+
+  it("Should retain live-tail suppression until overlapping mutation owners settle", async () => {
+    let resolveResume!: (session: SessionPayload) => void;
+    let rejectDelete!: (error: Error) => void;
+    vi.mocked(resumeSession).mockReturnValue(
+      new Promise(resolve => {
+        resolveResume = resolve;
+      })
+    );
+    vi.mocked(deleteSession).mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectDelete = reject;
+      })
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const { result } = renderHook(
+      () => ({ remove: useDeleteSession(), resume: useResumeSession() }),
+      { wrapper: createWrapper(queryClient) }
+    );
+
+    let deleteOutcome!: Promise<unknown>;
+    let resumeMutation!: Promise<SessionPayload>;
+    act(() => {
+      deleteOutcome = result.current.remove.mutateAsync(createdSession.id).catch(error => error);
+      resumeMutation = result.current.resume.mutateAsync(createdSession.id);
+    });
+
+    await waitFor(() =>
+      expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(2)
+    );
+
+    const deleteError = new Error("delete failed");
+    rejectDelete(deleteError);
+    await act(async () => {
+      expect(await deleteOutcome).toBe(deleteError);
+    });
+    expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(1);
+
+    resolveResume(createdSession);
+    await act(async () => {
+      await resumeMutation;
+    });
     expect(
       sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]
     ).toBeUndefined();

--- a/web/src/systems/session/hooks/__tests__/use-session-actions.test.tsx
+++ b/web/src/systems/session/hooks/__tests__/use-session-actions.test.tsx
@@ -560,53 +560,63 @@ describe("session actions", () => {
     ).toBeUndefined();
   });
 
-  it("Should retain live-tail suppression until overlapping mutation owners settle", async () => {
-    let resolveResume!: (session: SessionPayload) => void;
-    let rejectDelete!: (error: Error) => void;
-    vi.mocked(resumeSession).mockReturnValue(
-      new Promise(resolve => {
-        resolveResume = resolve;
-      })
-    );
-    vi.mocked(deleteSession).mockReturnValue(
-      new Promise((_resolve, reject) => {
-        rejectDelete = reject;
-      })
-    );
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
-    });
-    const { result } = renderHook(
-      () => ({ remove: useDeleteSession(), resume: useResumeSession() }),
-      { wrapper: createWrapper(queryClient) }
-    );
+  it.each(["success", "failure"] as const)(
+    "Should retain live-tail suppression until overlapping mutation owners settle after delete %s",
+    async deleteResult => {
+      let resolveResume!: (session: SessionPayload) => void;
+      let settleDelete!: () => void;
+      const deleteError = new Error("delete failed");
+      vi.mocked(resumeSession).mockReturnValue(
+        new Promise(resolve => {
+          resolveResume = resolve;
+        })
+      );
+      vi.mocked(deleteSession).mockReturnValue(
+        new Promise((resolve, reject) => {
+          settleDelete = () => {
+            if (deleteResult === "success") {
+              resolve();
+              return;
+            }
+            reject(deleteError);
+          };
+        })
+      );
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      });
+      const { result } = renderHook(
+        () => ({ remove: useDeleteSession(), resume: useResumeSession() }),
+        { wrapper: createWrapper(queryClient) }
+      );
 
-    let deleteOutcome!: Promise<unknown>;
-    let resumeMutation!: Promise<SessionPayload>;
-    act(() => {
-      deleteOutcome = result.current.remove.mutateAsync(createdSession.id).catch(error => error);
-      resumeMutation = result.current.resume.mutateAsync(createdSession.id);
-    });
+      let deleteMutation!: Promise<unknown>;
+      let resumeMutation!: Promise<SessionPayload>;
+      act(() => {
+        deleteMutation = result.current.remove.mutateAsync(createdSession.id).catch(error => error);
+        resumeMutation = result.current.resume.mutateAsync(createdSession.id);
+      });
 
-    await waitFor(() =>
-      expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(2)
-    );
+      await waitFor(() =>
+        expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(2)
+      );
 
-    const deleteError = new Error("delete failed");
-    rejectDelete(deleteError);
-    await act(async () => {
-      expect(await deleteOutcome).toBe(deleteError);
-    });
-    expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(1);
+      settleDelete();
+      await act(async () => {
+        const settledDelete = await deleteMutation;
+        expect(settledDelete).toBe(deleteResult === "success" ? undefined : deleteError);
+      });
+      expect(sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]).toBe(1);
 
-    resolveResume(createdSession);
-    await act(async () => {
-      await resumeMutation;
-    });
-    expect(
-      sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]
-    ).toBeUndefined();
-  });
+      resolveResume(createdSession);
+      await act(async () => {
+        await resumeMutation;
+      });
+      expect(
+        sessionStore.getSnapshot().context.liveTailSuppressions[createdSession.id]
+      ).toBeUndefined();
+    }
+  );
 
   it("useRepairSession invalidates the owning session query tree after repair completes", async () => {
     vi.mocked(repairSession).mockResolvedValue({

--- a/web/src/systems/session/hooks/__tests__/use-session-clarifications.test.tsx
+++ b/web/src/systems/session/hooks/__tests__/use-session-clarifications.test.tsx
@@ -38,7 +38,7 @@ afterEach(() => {
 });
 
 describe("useAnswerSessionClarification", () => {
-  it("Should reconcile only the owning session's clarifications after a successful answer", async () => {
+  it("Should reconcile the owning clarification and transcript after a successful answer", async () => {
     vi.mocked(answerSessionClarification).mockResolvedValue({
       choice: 0,
       fallback: false,
@@ -53,6 +53,10 @@ describe("useAnswerSessionClarification", () => {
       expect(invalidate).toHaveBeenCalledWith({
         exact: true,
         queryKey: sessionKeys.clarifications(WS, ID),
+      });
+      expect(invalidate).toHaveBeenCalledWith({
+        exact: true,
+        queryKey: sessionKeys.transcript(WS, ID),
       });
     });
     expect(invalidate).not.toHaveBeenCalledWith({

--- a/web/src/systems/session/hooks/use-session-actions.ts
+++ b/web/src/systems/session/hooks/use-session-actions.ts
@@ -153,9 +153,6 @@ export function useDeleteSession(options: UseSessionWorkspaceOptions = {}) {
         queryClient.cancelQueries({ queryKey: sessionKeys.byIdRoot(id) }),
       ]);
     },
-    onError: (_error, id) => {
-      sessionStore.trigger.sessionLiveTailResumed({ sessionId: id });
-    },
     onSuccess: (_data, id) => {
       const successWorkspaceId = requireWorkspace(workspaceId);
       sessionStore.trigger.sessionInteractionRemoved({ sessionId: id });
@@ -163,6 +160,9 @@ export function useDeleteSession(options: UseSessionWorkspaceOptions = {}) {
       queryClient.removeQueries({ queryKey: sessionKeys.byIdRoot(id) });
 
       return invalidateWorkspaceSessionCatalog(queryClient, successWorkspaceId);
+    },
+    onSettled: (_data, _error, id) => {
+      sessionStore.trigger.sessionLiveTailResumed({ sessionId: id });
     },
   });
 }

--- a/web/src/systems/session/hooks/use-session-actions.ts
+++ b/web/src/systems/session/hooks/use-session-actions.ts
@@ -145,6 +145,17 @@ export function useDeleteSession(options: UseSessionWorkspaceOptions = {}) {
 
   return useMutation({
     mutationFn: (id: string) => deleteSession(requireWorkspace(workspaceId), id),
+    onMutate: async id => {
+      const deleteWorkspaceId = requireWorkspace(workspaceId);
+      sessionStore.trigger.sessionLiveTailSuspended({ sessionId: id });
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: sessionKeys.detail(deleteWorkspaceId, id) }),
+        queryClient.cancelQueries({ queryKey: sessionKeys.byIdRoot(id) }),
+      ]);
+    },
+    onError: (_error, id) => {
+      sessionStore.trigger.sessionLiveTailResumed({ sessionId: id });
+    },
     onSuccess: (_data, id) => {
       const successWorkspaceId = requireWorkspace(workspaceId);
       sessionStore.trigger.sessionInteractionRemoved({ sessionId: id });
@@ -193,8 +204,22 @@ export function useResumeSession(options: UseSessionWorkspaceOptions = {}) {
 
   return useMutation({
     mutationFn: (id: string) => resumeSession(requireWorkspace(workspaceId), id),
-    onSettled: (_data, _error, id) => {
-      if (workspaceId) void invalidateSessionMutationQueries(queryClient, workspaceId, id);
+    onMutate: async id => {
+      const resumeWorkspaceId = requireWorkspace(workspaceId);
+      sessionStore.trigger.sessionLiveTailSuspended({ sessionId: id });
+      await Promise.all([
+        queryClient.cancelQueries({ queryKey: sessionKeys.detail(resumeWorkspaceId, id) }),
+        queryClient.cancelQueries({ queryKey: sessionKeys.byIdRoot(id) }),
+      ]);
+    },
+    onSettled: async (_data, _error, id) => {
+      try {
+        if (workspaceId) {
+          await invalidateSessionMutationQueries(queryClient, workspaceId, id);
+        }
+      } finally {
+        sessionStore.trigger.sessionLiveTailResumed({ sessionId: id });
+      }
     },
   });
 }

--- a/web/src/systems/session/hooks/use-session-actions.ts
+++ b/web/src/systems/session/hooks/use-session-actions.ts
@@ -212,14 +212,15 @@ export function useResumeSession(options: UseSessionWorkspaceOptions = {}) {
         queryClient.cancelQueries({ queryKey: sessionKeys.byIdRoot(id) }),
       ]);
     },
-    onSettled: async (_data, _error, id) => {
-      try {
-        if (workspaceId) {
-          await invalidateSessionMutationQueries(queryClient, workspaceId, id);
-        }
-      } finally {
+    onSettled: (_data, _error, id) => {
+      if (!workspaceId) {
         sessionStore.trigger.sessionLiveTailResumed({ sessionId: id });
+        return;
       }
+
+      return invalidateSessionMutationQueries(queryClient, workspaceId, id).finally(() => {
+        sessionStore.trigger.sessionLiveTailResumed({ sessionId: id });
+      });
     },
   });
 }

--- a/web/src/systems/session/hooks/use-session-chat-runtime.ts
+++ b/web/src/systems/session/hooks/use-session-chat-runtime.ts
@@ -4,6 +4,7 @@ import { useChatRuntime } from "@assistant-ui/react-ai-sdk";
 
 import { authorizeStreamFetchInput } from "@/lib/gateway-stream-auth";
 import { reportGatewayResponse } from "@/lib/gateway-access-signal";
+import { modelCatalogKeys } from "@/systems/model-catalog";
 
 import type { SessionPromptDispatchStore } from "@/components/assistant-ui/session-prompt-dispatch-store";
 import { sessionKeys } from "../lib/query-keys";
@@ -19,6 +20,49 @@ import { useOptionalSessionPromptRuntimeContext } from "./use-session-prompt-run
 import { loopsKeys } from "@/systems/loops";
 
 type QueryClient = ReturnType<typeof useQueryClient>;
+
+function completeWhenResponseBodySettles(response: Response, onComplete: () => void): Response {
+  if (response.body === null) {
+    onComplete();
+    return response;
+  }
+
+  const reader = response.body.getReader();
+  let completed = false;
+  const complete = () => {
+    if (completed) return;
+    completed = true;
+    onComplete();
+  };
+  const body = new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const chunk = await reader.read();
+        if (chunk.done) {
+          complete();
+          controller.close();
+          return;
+        }
+        controller.enqueue(chunk.value);
+      } catch (error) {
+        complete();
+        controller.error(error);
+      }
+    },
+    async cancel(reason) {
+      try {
+        await reader.cancel(reason);
+      } finally {
+        complete();
+      }
+    },
+  });
+  return new Response(body, {
+    headers: response.headers,
+    status: response.status,
+    statusText: response.statusText,
+  });
+}
 
 function buildSessionRuntimeConfig(
   queryClient: QueryClient,
@@ -65,17 +109,34 @@ function buildSessionRuntimeConfig(
       upstreamSignal?.addEventListener("abort", abortFromUpstream, { once: true });
     }
     promptDispatch.trigger.requestStarted({ controller });
+    let responseOwnsCompletion = false;
+    let requestCompleted = false;
+    const completeRequest = () => {
+      if (requestCompleted) return;
+      requestCompleted = true;
+      upstreamSignal?.removeEventListener("abort", abortFromUpstream);
+      promptDispatch.trigger.requestCompleted({ controller });
+    };
     try {
+      // Local HTTP/1.1 browsers have a small per-origin connection pool. The
+      // desktop already owns several long-lived SSE connections, so a slow
+      // provider discovery can otherwise queue the prompt behind the model
+      // catalog. Prompt dispatch is the user-driven operation, so release any
+      // optional catalog reads first; the selector's explicit refresh remains
+      // available when the operator next needs discovery.
+      await queryClient.cancelQueries({ queryKey: modelCatalogKeys.all });
       // The prompt POST streams its response, so a remote gateway session
       // authenticates it with a fresh single-use ticket like any other stream.
       const target = await authorizeStreamFetchInput(input, controller.signal);
       const response = await goalAwareFetch(target, { ...init, signal: controller.signal });
       await reportGatewayResponse(response);
       if (response.ok) promptRecovery.acknowledge();
-      return response;
+      responseOwnsCompletion = true;
+      return completeWhenResponseBodySettles(response, completeRequest);
     } finally {
-      upstreamSignal?.removeEventListener("abort", abortFromUpstream);
-      promptDispatch.trigger.requestCompleted({ controller });
+      if (!responseOwnsCompletion) {
+        completeRequest();
+      }
     }
   };
   return {

--- a/web/src/systems/session/hooks/use-session-clarifications.ts
+++ b/web/src/systems/session/hooks/use-session-clarifications.ts
@@ -9,9 +9,12 @@ import type { AnswerClarificationBody, AnswerClarificationResult } from "../type
 export function useSessionClarifications(
   workspaceId: string,
   id: string,
-  options: { enabled?: boolean } = {}
+  options: { enabled?: boolean; refetchInterval?: number | false } = {}
 ) {
-  return useQuery(sessionClarificationsOptions(workspaceId, id, options.enabled ?? true));
+  return useQuery({
+    ...sessionClarificationsOptions(workspaceId, id, options.enabled ?? true),
+    refetchInterval: options.refetchInterval ?? false,
+  });
 }
 
 export interface AnswerClarificationVariables {
@@ -20,10 +23,9 @@ export interface AnswerClarificationVariables {
 }
 
 /**
- * Resolve one live clarification and reconcile the exact owner key. Invalidation runs in `onSettled`
- * so the pending list re-reads on both success and the terminal-gone (409/404) races — the
- * `clarifications` key is a child of `detail`, so it needs an explicit exact invalidation that the
- * broader session-surface refresh does not reach.
+ * Resolve one live clarification and reconcile the exact owner keys. Invalidation runs in
+ * `onSettled` so the pending list and its durable transcript receipt re-read on both success and
+ * terminal-gone (409/404) races.
  */
 export function useAnswerSessionClarification(workspaceId: string, id: string) {
   const queryClient = useQueryClient();
@@ -33,6 +35,10 @@ export function useAnswerSessionClarification(workspaceId: string, id: string) {
     onSettled: () => {
       void queryClient.invalidateQueries({
         queryKey: sessionKeys.clarifications(workspaceId, id),
+        exact: true,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: sessionKeys.transcript(workspaceId, id),
         exact: true,
       });
     },

--- a/web/src/systems/session/hooks/use-session-runtime-extensions.ts
+++ b/web/src/systems/session/hooks/use-session-runtime-extensions.ts
@@ -3,10 +3,13 @@ import { useSelector } from "@xstate/store-react";
 
 import type { SessionPromptDispatchStore } from "@/components/assistant-ui/session-prompt-dispatch-store";
 import { derivePendingPermissions } from "../lib/pending-permissions";
+import { sessionStore } from "../stores/session-store";
 import { useMergedSessionRuntimeTranscript } from "./use-merged-session-runtime-transcript";
 import { useSessionClarifications } from "./use-session-clarifications";
 import { useSessionInputs } from "./use-session-inputs";
 import type { SessionStreamEventSourceFactory } from "./use-session-live-tail";
+
+const ACTIVE_PROMPT_CLARIFICATION_REFETCH_MS = 1_000;
 
 export function useSessionRuntimeExtensions({
   eventSourceFactory,
@@ -26,6 +29,11 @@ export function useSessionRuntimeExtensions({
     promptDispatch,
     snapshot => snapshot.context.hasLocalRuntimeTail
   );
+  const promptPending = useSelector(promptDispatch, snapshot => snapshot.context.pending);
+  const liveTailSuppressed = useSelector(
+    sessionStore,
+    snapshot => snapshot.context.liveTailSuppressions[sessionId] === true
+  );
   const streamResetGeneration = useSelector(
     promptDispatch,
     snapshot => snapshot.context.streamResetGeneration
@@ -33,13 +41,17 @@ export function useSessionRuntimeExtensions({
   const transcript = useMergedSessionRuntimeTranscript({
     eventSourceFactory,
     hasLocalRuntimeTail,
-    liveTailEnabled,
+    // The prompt response is already the live source for its turn. Suspending
+    // the parallel transcript SSE leaves an HTTP/1.1 connection available for
+    // approval, clarification, cancel, and other control requests.
+    liveTailEnabled: liveTailEnabled && !promptPending && !liveTailSuppressed,
     resetGeneration: streamResetGeneration,
     sessionId,
     workspaceId,
   });
   const clarifications = useSessionClarifications(workspaceId, sessionId, {
     enabled: liveTailEnabled,
+    refetchInterval: promptPending ? ACTIVE_PROMPT_CLARIFICATION_REFETCH_MS : false,
   });
   const inputs = useSessionInputs(workspaceId, sessionId, { enabled: liveTailEnabled });
   const rewindBlocked =

--- a/web/src/systems/session/hooks/use-session-runtime-extensions.ts
+++ b/web/src/systems/session/hooks/use-session-runtime-extensions.ts
@@ -32,7 +32,7 @@ export function useSessionRuntimeExtensions({
   const promptPending = useSelector(promptDispatch, snapshot => snapshot.context.pending);
   const liveTailSuppressed = useSelector(
     sessionStore,
-    snapshot => snapshot.context.liveTailSuppressions[sessionId] === true
+    snapshot => (snapshot.context.liveTailSuppressions[sessionId] ?? 0) > 0
   );
   const streamResetGeneration = useSelector(
     promptDispatch,

--- a/web/src/systems/session/index.ts
+++ b/web/src/systems/session/index.ts
@@ -253,6 +253,7 @@ export {
   sessionRecapOptions,
   sessionUsageOptions,
   sessionTranscriptOptions,
+  sessionAcrossProfilesOptions,
   sessionScopedDetailOptions,
   sessionsListOptions,
   sessionsCompleteListOptions,

--- a/web/src/systems/session/stores/session-store.ts
+++ b/web/src/systems/session/stores/session-store.ts
@@ -22,7 +22,7 @@ export interface SessionStoreContext {
   drafts: Record<string, string>;
   firstPrompts: Record<string, SessionFirstPrompt>;
   goalFeedback: Record<string, SessionGoalFeedback>;
-  liveTailSuppressions: Record<string, true>;
+  liveTailSuppressions: Record<string, number>;
 }
 
 export const SESSION_DRAFTS_STORAGE_KEY = "compozy:session:drafts:v1";
@@ -184,19 +184,29 @@ export const sessionStore = createStore({
       };
     },
     sessionLiveTailResumed: (context, event: { sessionId: string }) => {
-      const liveTailSuppressions = withoutSessionValue(
-        context.liveTailSuppressions,
-        event.sessionId
-      );
-      return liveTailSuppressions === context.liveTailSuppressions
-        ? undefined
-        : { ...context, liveTailSuppressions };
-    },
-    sessionLiveTailSuspended: (context, event: { sessionId: string }) => {
-      if (context.liveTailSuppressions[event.sessionId]) return;
+      const owners = context.liveTailSuppressions[event.sessionId] ?? 0;
+      if (owners === 0) return;
+      if (owners > 1) {
+        return {
+          ...context,
+          liveTailSuppressions: {
+            ...context.liveTailSuppressions,
+            [event.sessionId]: owners - 1,
+          },
+        };
+      }
       return {
         ...context,
-        liveTailSuppressions: { ...context.liveTailSuppressions, [event.sessionId]: true as const },
+        liveTailSuppressions: withoutSessionValue(context.liveTailSuppressions, event.sessionId),
+      };
+    },
+    sessionLiveTailSuspended: (context, event: { sessionId: string }) => {
+      return {
+        ...context,
+        liveTailSuppressions: {
+          ...context.liveTailSuppressions,
+          [event.sessionId]: (context.liveTailSuppressions[event.sessionId] ?? 0) + 1,
+        },
       };
     },
     sessionInteractionRemoved: (context, event: { sessionId: string }) => {

--- a/web/src/systems/session/stores/session-store.ts
+++ b/web/src/systems/session/stores/session-store.ts
@@ -22,6 +22,7 @@ export interface SessionStoreContext {
   drafts: Record<string, string>;
   firstPrompts: Record<string, SessionFirstPrompt>;
   goalFeedback: Record<string, SessionGoalFeedback>;
+  liveTailSuppressions: Record<string, true>;
 }
 
 export const SESSION_DRAFTS_STORAGE_KEY = "compozy:session:drafts:v1";
@@ -86,6 +87,7 @@ const initialSessionContext: SessionStoreContext = {
   drafts: readPersistedDrafts(),
   firstPrompts: {},
   goalFeedback: {},
+  liveTailSuppressions: {},
 };
 
 export const sessionStore = createStore({
@@ -181,18 +183,39 @@ export const sessionStore = createStore({
         },
       };
     },
+    sessionLiveTailResumed: (context, event: { sessionId: string }) => {
+      const liveTailSuppressions = withoutSessionValue(
+        context.liveTailSuppressions,
+        event.sessionId
+      );
+      return liveTailSuppressions === context.liveTailSuppressions
+        ? undefined
+        : { ...context, liveTailSuppressions };
+    },
+    sessionLiveTailSuspended: (context, event: { sessionId: string }) => {
+      if (context.liveTailSuppressions[event.sessionId]) return;
+      return {
+        ...context,
+        liveTailSuppressions: { ...context.liveTailSuppressions, [event.sessionId]: true as const },
+      };
+    },
     sessionInteractionRemoved: (context, event: { sessionId: string }) => {
       const drafts = withoutSessionValue(context.drafts, event.sessionId);
       const firstPrompts = withoutSessionValue(context.firstPrompts, event.sessionId);
       const goalFeedback = withoutSessionValue(context.goalFeedback, event.sessionId);
+      const liveTailSuppressions = withoutSessionValue(
+        context.liveTailSuppressions,
+        event.sessionId
+      );
       if (
         drafts === context.drafts &&
         firstPrompts === context.firstPrompts &&
-        goalFeedback === context.goalFeedback
+        goalFeedback === context.goalFeedback &&
+        liveTailSuppressions === context.liveTailSuppressions
       ) {
         return;
       }
-      return { ...context, drafts, firstPrompts, goalFeedback };
+      return { ...context, drafts, firstPrompts, goalFeedback, liveTailSuppressions };
     },
   },
 });

--- a/web/src/systems/session/stores/session-store.ts
+++ b/web/src/systems/session/stores/session-store.ts
@@ -213,19 +213,14 @@ export const sessionStore = createStore({
       const drafts = withoutSessionValue(context.drafts, event.sessionId);
       const firstPrompts = withoutSessionValue(context.firstPrompts, event.sessionId);
       const goalFeedback = withoutSessionValue(context.goalFeedback, event.sessionId);
-      const liveTailSuppressions = withoutSessionValue(
-        context.liveTailSuppressions,
-        event.sessionId
-      );
       if (
         drafts === context.drafts &&
         firstPrompts === context.firstPrompts &&
-        goalFeedback === context.goalFeedback &&
-        liveTailSuppressions === context.liveTailSuppressions
+        goalFeedback === context.goalFeedback
       ) {
         return;
       }
-      return { ...context, drafts, firstPrompts, goalFeedback, liveTailSuppressions };
+      return { ...context, drafts, firstPrompts, goalFeedback };
     },
   },
 });

--- a/web/src/systems/settings/lib/__tests__/query-options.test.ts
+++ b/web/src/systems/settings/lib/__tests__/query-options.test.ts
@@ -179,13 +179,16 @@ describe("settings restart options", () => {
     expect(enabled.queryKey).toEqual(["settings", "restart", "op_1"]);
   });
 
-  it("polls while the status is not terminal and stops on terminal states", () => {
+  it("polls through transient errors and stops only on terminal states", () => {
     const options = settingsRestartStatusOptions("op_1", true);
     const refetchInterval = options.refetchInterval as (query: {
-      state: { data?: { status: string } };
+      state: { data?: { status: string }; status?: string };
     }) => number | false;
 
     expect(refetchInterval({ state: {} })).toBe(SETTINGS_QUERY_INTERVALS.restartPollInterval);
+    expect(refetchInterval({ state: { status: "error" } })).toBe(
+      SETTINGS_QUERY_INTERVALS.restartPollInterval
+    );
     expect(refetchInterval({ state: { data: { status: "stopping" } } })).toBe(
       SETTINGS_QUERY_INTERVALS.restartPollInterval
     );

--- a/web/src/systems/settings/lib/__tests__/query-options.test.ts
+++ b/web/src/systems/settings/lib/__tests__/query-options.test.ts
@@ -203,7 +203,9 @@ describe("settings restart options", () => {
     }) => number | false;
 
     expect(
-      refetchInterval({ state: { error: new SettingsApiError("Restart unavailable", status) } })
+      refetchInterval({
+        state: { error: Object.assign(new Error("Restart unavailable"), { status }) },
+      })
     ).toBe(false);
   });
 });

--- a/web/src/systems/settings/lib/__tests__/query-options.test.ts
+++ b/web/src/systems/settings/lib/__tests__/query-options.test.ts
@@ -182,7 +182,7 @@ describe("settings restart options", () => {
   it("polls through transient errors and stops only on terminal states", () => {
     const options = settingsRestartStatusOptions("op_1", true);
     const refetchInterval = options.refetchInterval as (query: {
-      state: { data?: { status: string }; status?: string };
+      state: { data?: { status: string }; error?: Error | null; status?: string };
     }) => number | false;
 
     expect(refetchInterval({ state: {} })).toBe(SETTINGS_QUERY_INTERVALS.restartPollInterval);
@@ -194,6 +194,17 @@ describe("settings restart options", () => {
     );
     expect(refetchInterval({ state: { data: { status: "ready" } } })).toBe(false);
     expect(refetchInterval({ state: { data: { status: "failed" } } })).toBe(false);
+  });
+
+  it.each([403, 404])("Should stop restart polling after terminal HTTP %s errors", status => {
+    const options = settingsRestartStatusOptions("op_1", true);
+    const refetchInterval = options.refetchInterval as (query: {
+      state: { error: Error };
+    }) => number | false;
+
+    expect(
+      refetchInterval({ state: { error: new SettingsApiError("Restart unavailable", status) } })
+    ).toBe(false);
   });
 });
 

--- a/web/src/systems/settings/lib/query-options.ts
+++ b/web/src/systems/settings/lib/query-options.ts
@@ -1,7 +1,6 @@
 import { queryOptions } from "@tanstack/react-query";
 
 import {
-  SettingsApiError,
   getSettingsAttention,
   getSettingsCmdPalette,
   getSettingsAutomation,
@@ -56,7 +55,7 @@ const UPDATE_OPERATION_POLL_INTERVAL = 2_000;
 const SETTINGS_QUERY_RETRY_LIMIT = 2;
 
 export function shouldRetrySettingsQuery(failureCount: number, error: Error): boolean {
-  if (error instanceof SettingsApiError && error.status === 403) {
+  if (getErrorStatus(error) === 403) {
     return false;
   }
 
@@ -306,14 +305,19 @@ export function settingsRestartStatusOptions(operationId: string | null, enabled
         : RESTART_POLL_INTERVAL,
     refetchIntervalInBackground: true,
     retry: (failureCount, error) =>
-      error instanceof SettingsApiError && error.status === 404
-        ? false
-        : shouldRetrySettingsQuery(failureCount, error),
+      getErrorStatus(error) === 404 ? false : shouldRetrySettingsQuery(failureCount, error),
   });
 }
 
 function isTerminalRestartError(error: Error | null): boolean {
-  return error instanceof SettingsApiError && (error.status === 403 || error.status === 404);
+  const status = getErrorStatus(error);
+  return status === 403 || status === 404;
+}
+
+function getErrorStatus(error: unknown): number | null {
+  if (typeof error !== "object" || error === null) return null;
+  const status = Reflect.get(error, "status");
+  return typeof status === "number" ? status : null;
 }
 
 export function settingsApplyRecordsOptions(filter: SettingsApplyRecordsFilter = {}) {

--- a/web/src/systems/settings/lib/query-options.ts
+++ b/web/src/systems/settings/lib/query-options.ts
@@ -301,9 +301,7 @@ export function settingsRestartStatusOptions(operationId: string | null, enabled
     enabled: active,
     staleTime: 0,
     refetchInterval: query =>
-      query.state.status === "error" || isTerminalRestartStatus(query.state.data?.status)
-        ? false
-        : RESTART_POLL_INTERVAL,
+      isTerminalRestartStatus(query.state.data?.status) ? false : RESTART_POLL_INTERVAL,
     refetchIntervalInBackground: true,
     retry: (failureCount, error) =>
       error instanceof SettingsApiError && error.status === 404

--- a/web/src/systems/settings/lib/query-options.ts
+++ b/web/src/systems/settings/lib/query-options.ts
@@ -301,13 +301,19 @@ export function settingsRestartStatusOptions(operationId: string | null, enabled
     enabled: active,
     staleTime: 0,
     refetchInterval: query =>
-      isTerminalRestartStatus(query.state.data?.status) ? false : RESTART_POLL_INTERVAL,
+      isTerminalRestartStatus(query.state.data?.status) || isTerminalRestartError(query.state.error)
+        ? false
+        : RESTART_POLL_INTERVAL,
     refetchIntervalInBackground: true,
     retry: (failureCount, error) =>
       error instanceof SettingsApiError && error.status === 404
         ? false
         : shouldRetrySettingsQuery(failureCount, error),
   });
+}
+
+function isTerminalRestartError(error: Error | null): boolean {
+  return error instanceof SettingsApiError && (error.status === 403 || error.status === 404);
 }
 
 export function settingsApplyRecordsOptions(filter: SettingsApplyRecordsFilter = {}) {


### PR DESCRIPTION
## Context

This is a focused remediation follow-up to #459.

While preparing the Profiles Task 13 QA run, the automated precondition suites exposed a set of production regressions across profile selection, session ownership, browser connection pressure, daemon restart cancellation, and test-fixture workspace authority. Those defects prevented a trustworthy real-user QA pass, so they were fixed first.

This PR intentionally contains **the production fixes and their automated regressions only**. It does **not** claim that Task 13's 11-charter / 49-scenario real-user QA matrix is complete. The intended sequence is:

1. merge this remediation PR once CI and review are green;
2. resume Task 13 from the updated `main` in a fresh isolated worktree;
3. publish the durable QA verdicts and final gates in a separate follow-up PR.

## What changed

### Runtime and daemon lifecycle

- Admit model-catalog reads into the daemon worker group so shutdown waits for or cancels them deterministically.
- Link each model-catalog request to the daemon lifecycle context instead of allowing refresh work to outlive a restart.
- Stop source/provider refresh loops immediately after cancellation.
- Avoid recording a canceled refresh as a provider/source failure.
- Preserve creator notifications for user-originated spawns while forcing internal spawn roles to remain silent.
- Extend the ACP browser-session fixture and canonical Go suites for the corrected lifecycle behavior.

### Profile selection and lifecycle state

- Preserve the acting profile or aggregate view when moving between workspace and Global breadth.
- Hydrate the remembered profile only when first entering a lens, without overwriting a newer local selection.
- Apply create-and-activate results directly to the correct workspace or Global lens.
- Reconcile profile lifecycle events without leaving stale archived or renamed selections in the client.
- Keep the profile lifecycle stream enabled only while the browser connection budget can safely own it.
- Make the profile-switcher create action an explicit button, avoiding command-item selection side effects.

### Session ownership, deep links, and live tails

- Keep Global data scope separate from the remembered project desktop used to host session windows.
- Resolve a session owner across profiles before classifying a deep link as foreign or missing.
- Correctly handle a session owned by another profile in the same workspace.
- Fence route preload and permalink hydration so transcript/session reads agree before the window renders.
- Suspend the live session tail while prompt, clarification, resume, and delete mutations need the browser's HTTP connection slot.
- Release every suppression path after success or failure, preventing permanently paused session windows.
- Cancel stale session-resolution reads when the window identity changes.
- Reconcile model-catalog/session caches after lifecycle transitions.

### Browser connection and window-manager stability

- Store the window-manager client identity in `sessionStorage`, making it stable across reloads but isolated per browser tab.
- Separate optional background streams from continuity streams.
- Pause optional streams when the page has no safe connection budget.
- Preserve continuity while connected or temporarily disconnected, but pause it during active connect/reconnect pressure.
- Keep Dock and command surfaces behind authoritative hydration instead of optimistic local state.
- Preserve command availability during transient stream reconnects.
- Keep workspace-switch barriers and desktop/data bindings aligned across Global and project scope.

### Settings restart recovery

- Continue polling restart status through the expected transient network outage while the daemon restarts.
- Stop polling only after a terminal restart state rather than treating a temporary request error as completion.
- Cover the polling contract in the canonical Settings query-options suite and daemon-served E2E flow.

### Drag performance

- Pre-promote only the focused window for compositor movement.
- Remove full-window scale rasterization during drag while retaining the opacity affordance.
- Keep ordering, coordinates, snap resolution, and window-manager commands unchanged.

### E2E and fixture authority

- Make task/approval fixtures workspace-scoped where the UI is operating through a project workspace.
- Carry the real workspace id through Profiles, Tasks, Sessions, Triggers, Marketplace, Bridges, Worktrees, and Settings flows.
- Harden selectors and retained-loop seeding around the authoritative runtime contract.
- Expand Profiles lifecycle coverage for create, switch, rename, archive, aggregate, deep-link, and cross-tab behavior.
- Add canonical regressions for session-tail suppression, profile-view carry, workspace-switch barriers, client identity, Dock hydration, and background-stream budgeting.

## File-level map

| Area | Main files |
| --- | --- |
| Model catalog cancellation | `internal/daemon/model_catalog.go`, `internal/modelcatalog/service_refresh.go` |
| Spawn notification semantics | `internal/session/spawn.go`, ACP lifecycle fixture |
| Session routes and ownership | `web/src/routes/_app/*session*`, `web/src/systems/os/apps/session/`, `web/src/systems/session/` |
| Profile state and lifecycle | `web/src/systems/profiles/` |
| Window-manager connection budget | `web/src/systems/os/components/desktop-shell.tsx`, `web/src/systems/os/lib/background-stream-budget.ts` |
| Client identity and switch barriers | `web/src/systems/os/lib/window-manager-client-identity.ts`, `workspace-switch-barrier.ts` |
| Settings restart | `web/src/systems/settings/lib/query-options.ts` |
| E2E authority and regressions | `web/e2e/__tests__/`, `web/e2e/fixtures/` |

## Completed in this PR

- [x] Fix daemon model-catalog cancellation across restart.
- [x] Fix internal spawn creator-notification semantics.
- [x] Fix profile selection carry and remembered-view hydration.
- [x] Fix create-and-activate profile projection.
- [x] Fix session owner resolution and permalink hydration across profiles.
- [x] Fix live-tail connection starvation during session mutations.
- [x] Isolate window-manager client identity per browser tab.
- [x] Add optional/continuity stream budgeting.
- [x] Fix Dock/command authority during hydration and reconnect.
- [x] Keep Settings restart polling alive through transient daemon downtime.
- [x] Remove the drag-path full-window rasterization spike.
- [x] Add or extend regressions in the canonical owning suites.
- [x] Normalize daemon-served E2E fixtures to workspace authority.
- [x] Run pre-commit Go formatting, Oxfmt, and Oxlint with zero reported errors.
- [x] Publish commit `a8e77c615` on `profiles-qa-exec`.

## Verification evidence

### Passed

- Profiles daemon-served cohort: **15/15 passed**.
- Session daemon-served cohort: **11/11 passed**.
- Loop E2E-030, degraded reconnect E2E-012, Settings restart, Attention, Tasks, Triggers lifecycle, and Storybook bootstrap passed in focused reruns.
- Model-catalog and daemon restart regressions passed in their canonical Go suites.
- Profile-view, session-tail, Dock, client-identity, workspace-barrier, stream-budget, and Settings polling regressions passed in their canonical Web suites.
- E2E-023 performance envelope after the drag fix: **10/10 passed**, with no drag long task above 50 ms.
- Pre-commit hooks completed successfully for the final commit: Go formatting, Oxfmt, and `oxlint --deny-warnings`.
- GitHub preflight, PR title, React Doctor, CodeRabbit, and Vercel checks are green at the time of this update; the remaining CI lanes are still running.

### Important limitation

The last complete local Web sweep before the final drag fix reported **246 passed, 3 skipped, and 1 failed**; the only failure was E2E-023's drag-performance tail. E2E-023 then passed 10/10 after the production fix, but the final full local Web sweep was interrupted before completion.

`make gate-full` was **not** run for this exact tree. This PR must rely on the GitHub CI result for its merge decision and must not be described as the final Task 13 QA closure.

## Merge checklist for this remediation PR

- [x] Scope is limited to production fixes and automated regressions discovered during Task 13 preparation.
- [x] No schema migration, OpenAPI contract, config key, or native-tool id changed.
- [x] Branch is published and the worktree is clean.
- [x] PR description separates completed remediation from deferred QA.
- [ ] All required GitHub CI jobs are green.
- [ ] Code review is approved.
- [ ] Merge into `main` before starting the follow-up Task 13 execution branch.

## Explicitly deferred to the follow-up Task 13 PR

These items are **not blockers for the scope of this remediation PR**; they are the remaining deliverables of `.compozy/tasks/profiles/task_13.md` and will run from fresh `main` after this merges.

- [ ] Bootstrap a fresh manifest-driven isolated QA lab.
- [ ] Walk all **11 Profiles charters / 49 matrix rows** in persona.
- [ ] Record terminal scenario verdicts and session debriefs in `docs/qa/`.
- [ ] Compare persisted profile state across CLI, HTTP, UDS, Web, and native palette surfaces.
- [ ] Exercise structured CLI errors, command-palette catalog/view/invoke, and agent-manageability paths.
- [ ] Exercise declared-profile extension install, per-profile enablement, layered config writes, denylist feedback, and per-profile credentials.
- [ ] Re-verify the deferred Visual Contract rows from Tasks 05, 07, and 09, including Task 05 VC-01..VC-16.
- [ ] Register and link any reproduced bugs; fix contained production causes and re-walk affected scenarios.
- [ ] Run both final E2E lanes: `make test-e2e-runtime` and `make test-e2e-web`.
- [ ] Run `make gate-full` once after the final follow-up mutation.
- [ ] Complete `docs/qa/reports/<date>-profiles.md` with zero Pending rows.
- [ ] Prove the fresh lab teardown with `teardown.json` containing `"clean": true`.

## Compozy Impact Audit

- **Native tools:** no tool ids, descriptors, schemas, digests, risk flags, or capability gates changed. Profile/palette native parity remains a follow-up live-QA obligation.
- **Extensibility and hooks:** no extension manifest, hook event, skill/capability, bridge SDK, MCP sidecar, registry contract, or config lifecycle contract changed. This PR only budgets existing profile lifecycle streams; live extension/config lifecycle validation is deferred above.
- **Workspace data isolation:** strengthened. Session ownership, task fixtures, profile lens carry, Global data scope, and remembered desktop workspace are kept distinct and exercised by focused regression suites. The full CLI/HTTP/UDS/Web/native leak probe remains deferred to Task 13.
- **Official Compozy skill:** no public CLI path, tool id, hook event, capability, extension resource, or memory/network/task semantic changed; `skills/compozy/` requires no update for this remediation scope.

## Review guidance

Review this PR as a production-remediation batch, not as a QA-report PR. The highest-risk areas are:

1. daemon shutdown ownership around model-catalog reads;
2. session live-tail suppression release paths;
3. distinction between Global data scope and project-backed desktop authority;
4. per-tab client identity and connection-budget transitions;
5. profile-view carry across workspace/Global lenses.

Once the required CI lanes are green and those areas are approved, this PR is ready to merge. The durable Task 13 matrix and final release-readiness claim belong to the follow-up PR listed above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Open session links across profiles and workspaces without unnecessary workspace prompts.
  - Preserve profile views when switching between workspace scopes.
  - Automatically update the active profile after creating one.
  - Preserve command navigation parameters and improve session window handling.
- **Bug Fixes**
  - Prevent dock actions while desktop state is loading, while keeping them available during reconnects.
  - Prevent stale live updates during session deletion, resumption, and prompt handling.
  - Stop model discovery promptly during shutdown or cancellation.
  - Stop restart-status checks after terminal errors.
  - Suppress internal notifications for automatic-title sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->