### PR TITLE
fix: keep inactive loop routes out of task projection

### DIFF
--- a/docs/qa/reports/2026-08-25-issue-479.md
+++ b/docs/qa/reports/2026-08-25-issue-479.md
@@ -1,0 +1,82 @@
+# QA Run Report — 2026-08-25 — issue-479
+
+- **Scope:** Exclusive Loop routing must omit inactive-route Tasks so selected downstream work remains claimable.
+- **Cadence tier:** targeted
+- **Build:** `issue-479` working tree · **Environment:** fresh isolated local daemon; CLI and HTTP/runtime surfaces; no provider required
+- **Started:** 2026-08-25T18:35:43-03:00 · **Status:** closed
+
+## Personas
+
+| Persona | Base | Device / Network / Locale | Sessions |
+|---|---|---|---|
+| Bruno | Power User | desktop / wifi-fast / en-US | CH-loop-partial-runtime |
+| Ada | Power User | desktop / wifi-fast / en-US | CH-loop-legibility-calm-catalog-parity |
+
+## Flows in Scope
+
+- `J-complete-partial-loop` — Author and complete a routed partial Loop (`../journeys/J-complete-partial-loop.md`)
+- `J-operate-loop-run-headless` — Read and settle a Loop run with no screen (`../journeys/J-operate-loop-run-headless.md`)
+
+## Session Matrix & Results
+
+| # | Charter | Journey / Scenario | Persona | Tour | Status | Issue | Fix commit |
+|---|---|---|---|---|---|---|---|
+| 1 | CH-loop-partial-runtime | J-complete-partial-loop / LP-exclusive-route-history | Bruno | Interrupt Tour | Pass | | |
+| 2 | CH-loop-legibility-calm-catalog-parity | J-operate-loop-run-headless / adjacent canary | Ada | Feature Tour | Pass | | |
+
+Status legend: `Pending | Pass | Fixed | Skipped | Blocked (needs human verify) | Blocked (human decision)`
+
+## Session Debriefs
+
+### CH-loop-partial-runtime — Bruno
+
+- **Ran:** 2026-08-25T18:40:01-03:00 → 2026-08-25T18:41:48-03:00 (box respected: yes)
+- **Findings:** None. The default route selected `analyze_sentry`, both dominated nodes retained `route_not_taken` history, and the selected join completed.
+- **Bugs filed/updated:** None.
+- **Scenarios settled:** LP-exclusive-route-history → pass.
+- **Paper cuts:** None.
+- **Surprises:** The Task catalog made the corrected ownership boundary explicit: four records total, with no Task for `create_spec`.
+- **Suggested next charter:** Re-run the wider partial-fan-out interruption charter in the next full Loop cycle.
+
+### CH-loop-legibility-calm-catalog-parity — Ada
+
+- **Ran:** 2026-08-25T18:41:06-03:00 → 2026-08-25T18:42:05-03:00 (box respected: yes)
+- **Findings:** None. Calm CLI and HTTP catalogs returned zero Loop records; the typed run filter returned four; an unknown run filter returned an empty page; a cross-workspace run read returned 404.
+- **Bugs filed/updated:** None.
+- **Scenarios settled:** Adjacent canary only; the broader durable scenario remained unchanged.
+- **Paper cuts:** None.
+- **Surprises:** The terminal run and its exact dependency survived a daemon restart with identical CLI and HTTP reads.
+- **Suggested next charter:** Keep the full four-transport parity charter in its existing release cadence.
+
+## What Was Fixed
+
+The implementation fix was completed before this QA round. Its red-before/green-after regression is `internal/store/globaldb/global_db_task_claim_test.go` in the canonical GlobalDB coordinator suite.
+
+## Paper Cuts
+
+None recorded yet.
+
+## Runtime Errors Observed
+
+- The scoped `make gate` passed strict Go lint, `internal/loop`, and `internal/store`, then the GlobalDB package was killed by its 11-minute process limit while another worktree was running `go test ./...`. No assertion failure was reported. The exact inactive-route GlobalDB regression subsequently passed with `-race` in 130.429s.
+
+## Human Verifications Needed
+
+None.
+
+## Decisions for a Human
+
+None.
+
+## Learnings
+
+- Restarting the daemon is the relevant Interrupt Tour probe for this headless journey; persisted route history and Task ownership stayed stable.
+- Lens pass: usability, accessibility, and visual compatibility are not applicable to structured-only surfaces; perceived performance was immediate; error recovery was deterministic for unknown/cross-workspace reads; production parity used the real local binary, SQLite streams, UDS, and HTTP with no mocks or provider dependency.
+- Teardown: `/Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/teardown.json` reports `clean: true`, daemon PID `93208` stopped, and zero survivors.
+
+## Final Status
+
+- **Exit gate (full automated suite):** Delegated to PR CI by operator request. Local scoped evidence: strict Go lint passed with zero issues; the exact GlobalDB regression passed with `-race`; the broad scoped attempt was inconclusive due concurrent-machine timeout, not an assertion failure.
+- **Issues by user impact:** Blocks-Completion 0 · Data-Loss 0 · Trust-Damage 0 · Friction 0 · Cosmetic 0
+- **Coverage:** 2/2 journeys walked; the changed route journey plus one adjacent structured-catalog canary
+- **Verdict:** BLOCKED — behavior QA passed, but release readiness depends on the full gate delegated to PR CI.

--- a/docs/qa/scenarios/LP-exclusive-route-history.md
+++ b/docs/qa/scenarios/LP-exclusive-route-history.md
@@ -4,16 +4,16 @@ area: LP
 title: Author an exclusive route and inspect its durable cause
 persona: Bruno
 journey: J-complete-partial-loop
-expected: A route node takes the first matching direct forward edge or its mandatory default, skips every dominated non-selected path without failure, and exposes the exact decision cause consistently through CLI, HTTP, native-tool status, and SSE replay; a gate object route follows the same durable history contract.
+expected: A route node takes the first matching direct forward edge or its mandatory default, skips every dominated non-selected path without failure, omits inactive-route Tasks so they cannot block the selected downstream work, and exposes the exact decision cause consistently through CLI, HTTP, native-tool status, and SSE replay; a gate object route follows the same durable history contract.
 entry_points: compozy loop validate|run|status; GET /loop-runs/:id over HTTP and UDS; compozy__loop_status; Loop SSE; web Loop editor and run detail; /docs/loops/dsl-reference; skills/compozy/references/loops.md
 qa_status: pass
 bug_ids:
 fix_status:
 retest_status:
 fix_commits:
-evidence:
-last_report: docs/qa/reports/2026-08-18-graph-eng.md
+evidence: /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-runtime-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/cli-task-catalog-verdict.json; /Users/pedronauck/dev/qa-labs/compozy-issue-479-exclusive-route-20260825-213535-019283-lab/qa-artifacts/qa/notes/http-independent-verdict.json
+last_report: docs/qa/reports/2026-08-25-issue-479.md
 overlaps:
 ---
 
-acceptance-walk: Publish a Loop with two ordered route conditions, a default, and a gate `on_result` object route. Run matching and default inputs. Confirm exactly one route runs each time, dominated nodes read as `route_not_taken`, broken CEL fails instead of defaulting, and every structured read shows the same `route_causes` facts.
+acceptance-walk: Publish a Loop with two ordered route conditions, a default, a downstream join, and a gate `on_result` object route. Run matching and default inputs. Confirm exactly one route runs each time, dominated nodes read as `route_not_taken`, inactive-route Tasks are absent from the Task catalog and do not block the selected downstream work, broken CEL fails instead of defaulting, and every structured read shows the same `route_causes` facts.

--- a/internal/loop/control_plan_finish.go
+++ b/internal/loop/control_plan_finish.go
@@ -20,17 +20,6 @@ func finishInitialControlPlan(
 ) (task.CoordinatorCompletionPlan, error) {
 	graph := resolved.Definition.Graph
 	postReserveOutputs := cloneGenerationOutputs(outputs)
-	if err := appendCoordinatorArtifactsForOutputs(
-		plan,
-		run,
-		generation,
-		graph,
-		topology,
-		gateEvaluator != nil,
-		postReserveOutputs,
-	); err != nil {
-		return task.CoordinatorCompletionPlan{}, err
-	}
 	if err := appendReadyNodeRunsControlAware(
 		plan,
 		run,
@@ -40,6 +29,17 @@ func finishInitialControlPlan(
 		gateEvaluator != nil,
 		postReserveOutputs,
 		scheduledAt,
+	); err != nil {
+		return task.CoordinatorCompletionPlan{}, err
+	}
+	if err := appendCoordinatorArtifactsForOutputs(
+		plan,
+		run,
+		generation,
+		graph,
+		topology,
+		gateEvaluator != nil,
+		postReserveOutputs,
 	); err != nil {
 		return task.CoordinatorCompletionPlan{}, err
 	}

--- a/internal/loop/control_tasks.go
+++ b/internal/loop/control_tasks.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/compozy/compozy/internal/loop/dsl"
 	"github.com/compozy/compozy/internal/task"
@@ -53,6 +54,7 @@ func appendCoordinatorTasksForOutputs(
 	for _, spec := range plan.NodeTasks {
 		existing[spec.TaskID] = struct{}{}
 	}
+	planned := coordinatorPlannedNodeTaskIDs(plan.NodeRuns)
 	for _, output := range sortedGenerationOutputs(outputs) {
 		if GenerationOutputStatusParked(output.Status) {
 			continue
@@ -68,6 +70,9 @@ func appendCoordinatorTasksForOutputs(
 			continue
 		}
 		taskID := coordinatorNodeTaskID(run.ID, generation, node.ID, output.ItemIndex)
+		if _, ok := planned[taskID]; !ok {
+			continue
+		}
 		if _, ok := existing[taskID]; ok {
 			continue
 		}
@@ -104,6 +109,7 @@ func appendCoordinatorDependenciesForOutputs(
 	for _, dependency := range plan.Dependencies {
 		existing[dependencyKey(dependency.TaskID, dependency.DependsOnTaskID)] = struct{}{}
 	}
+	planned := coordinatorPlannedNodeTaskIDs(plan.NodeRuns)
 	outputMap := generationOutputMap(outputs)
 	for _, output := range sortedGenerationOutputs(outputs) {
 		if GenerationOutputStatusParked(output.Status) {
@@ -115,6 +121,10 @@ func appendCoordinatorDependenciesForOutputs(
 		nodeID := dsl.NodeID(output.NodeID)
 		node, ok := graphNode(graph, nodeID)
 		if !ok || isCoordinatorOwnedNodeWithGates(node, gatesEnabled) {
+			continue
+		}
+		taskID := coordinatorNodeTaskID(run.ID, generation, nodeID, output.ItemIndex)
+		if _, ok := planned[taskID]; !ok {
 			continue
 		}
 		for _, dependency := range topology.dependencies[nodeID] {
@@ -137,7 +147,14 @@ func appendCoordinatorDependenciesForOutputs(
 				if dependencyOutput.NodeID == "" || GenerationOutputStatusParked(dependencyOutput.Status) {
 					continue
 				}
-				taskID := coordinatorNodeTaskID(run.ID, generation, nodeID, output.ItemIndex)
+				if !generationOutputOwnsTaskInGeneration(
+					run,
+					generation,
+					dependencyNode,
+					dependencyOutput,
+				) {
+					continue
+				}
 				dependsOnTaskID := coordinatorNodeTaskID(
 					run.ID,
 					generation,
@@ -157,6 +174,40 @@ func appendCoordinatorDependenciesForOutputs(
 			}
 		}
 	}
+}
+
+func coordinatorPlannedNodeTaskIDs(runs []task.EnqueueSpec) map[string]struct{} {
+	taskIDs := make(map[string]struct{}, len(runs))
+	for _, run := range runs {
+		taskID := strings.TrimSpace(run.TaskID)
+		if taskID != "" {
+			taskIDs[taskID] = struct{}{}
+		}
+	}
+	return taskIDs
+}
+
+func generationOutputOwnsTaskInGeneration(
+	run Run,
+	generation int,
+	node dsl.Node,
+	output GenerationOutput,
+) bool {
+	taskRunID := strings.TrimSpace(output.TaskRunID)
+	if taskRunID == "" || outputRefMarksSkippedRoute(output.OutputRef) {
+		return false
+	}
+	if dsl.ActionKind(node.Kind) == dsl.ActionGoal {
+		baseRunID := coordinatorNodeRunID(run.ID, generation, node.ID, output.ItemIndex)
+		return strings.HasPrefix(taskRunID, baseRunID+":goal-segment:")
+	}
+	return taskRunID == NodeCellAttemptRunID(
+		run.ID,
+		generation,
+		string(node.ID),
+		output.ItemIndex,
+		output.Attempt,
+	)
 }
 
 func isAuthoredErrorRouteDependency(source dsl.Node, target dsl.NodeID) bool {

--- a/internal/loop/coordinator_generation_ready.go
+++ b/internal/loop/coordinator_generation_ready.go
@@ -19,17 +19,6 @@ func appendReadyNodeRunsToPlan(
 	scheduledAt time.Time,
 ) (bool, error) {
 	postReserveOutputs := cloneGenerationOutputs(sortedGenerationOutputs(advancedOutputs))
-	if err := appendCoordinatorArtifactsForOutputs(
-		plan,
-		run,
-		generation,
-		resolved.Definition.Graph,
-		topology,
-		gateEvaluator != nil,
-		postReserveOutputs,
-	); err != nil {
-		return false, err
-	}
 	if err := appendReadyNodeRunsControlAware(
 		plan,
 		run,
@@ -39,6 +28,17 @@ func appendReadyNodeRunsToPlan(
 		gateEvaluator != nil,
 		postReserveOutputs,
 		scheduledAt,
+	); err != nil {
+		return false, err
+	}
+	if err := appendCoordinatorArtifactsForOutputs(
+		plan,
+		run,
+		generation,
+		resolved.Definition.Graph,
+		topology,
+		gateEvaluator != nil,
+		postReserveOutputs,
 	); err != nil {
 		return false, err
 	}

--- a/internal/loop/coordinator_lifecycle_test.go
+++ b/internal/loop/coordinator_lifecycle_test.go
@@ -234,34 +234,6 @@ func TestCoordinatorRunnerShouldApplyNodeFailurePrecedence(t *testing.T) {
 			lifecycleNode("success"),
 		)
 		def.Graph.Edges = []dsl.Edge{{From: "work", To: "fallback"}, {From: "work", To: "success"}}
-		topology := newControlTopology(def.Graph)
-		initialOutputs := initialGenerationOutputs(def.Graph, topology, 1)
-		initialPlan, err := newInitialControlCoordinatorPlan(
-			Run{ID: "looprun-lifecycle-route", LoopName: "route"},
-			1,
-			def.Graph,
-			topology,
-			false,
-			initialOutputs,
-		)
-		if err != nil {
-			t.Fatalf("newInitialControlCoordinatorPlan() error = %v", err)
-		}
-		if got, want := len(initialPlan.Dependencies), 1; got != want {
-			t.Fatalf(
-				"initial route dependencies = %#v, want only the success-path dependency",
-				initialPlan.Dependencies,
-			)
-		}
-		dependency := initialPlan.Dependencies[0]
-		wantTaskID := coordinatorNodeTaskID("looprun-lifecycle-route", 1, "success", 0)
-		if got, want := dependency.TaskID, wantTaskID; got != want {
-			t.Fatalf("initial route dependency task_id = %q, want %q", got, want)
-		}
-		wantDependsOnTaskID := coordinatorNodeTaskID("looprun-lifecycle-route", 1, "work", 0)
-		if got, want := dependency.DependsOnTaskID, wantDependsOnTaskID; got != want {
-			t.Fatalf("initial route dependency prerequisite = %q, want %q", got, want)
-		}
 		plan := runLifecycleFailurePlan(t, "route", now, def)
 		payload := coordinatorSnapshotPayloadForTest(t, plan)
 		outputs := outputsByNodeAndItemForTest(payload.Outputs)

--- a/internal/loop/coordinator_test.go
+++ b/internal/loop/coordinator_test.go
@@ -3803,15 +3803,13 @@ func testRouteVerdict(action gate.RouteAction) gate.Verdict {
 
 func TestCoordinatorRunnerShouldPlanReattemptStrategy(t *testing.T) {
 	cases := []struct {
-		name             string
-		strategy         ReattemptStrategy
-		graph            dsl.Graph
-		outputs          []GenerationOutput
-		wantStatuses     map[string]string
-		wantCarriedRefs  map[string]string
-		wantClearedRefs  []string
-		wantNextRunID    string
-		wantNodeTaskSize int
+		name            string
+		strategy        ReattemptStrategy
+		graph           dsl.Graph
+		outputs         []GenerationOutput
+		wantStatuses    map[string]string
+		wantCarriedRefs map[string]string
+		wantClearedRefs []string
 	}{
 		{
 			name:     "failed-only carries succeeded outputs and reruns failed pending dependents",
@@ -3886,8 +3884,7 @@ func TestCoordinatorRunnerShouldPlanReattemptStrategy(t *testing.T) {
 				"setup":   "sha256:setup",
 				"archive": "sha256:archive",
 			},
-			wantClearedRefs:  []string{"test", "deploy", "notify", "doc"},
-			wantNodeTaskSize: 5,
+			wantClearedRefs: []string{"test", "deploy", "notify", "doc"},
 		},
 		{
 			name:     "full-body reruns every node",
@@ -3913,8 +3910,7 @@ func TestCoordinatorRunnerShouldPlanReattemptStrategy(t *testing.T) {
 				"load":  generationOutputPending,
 				"agent": generationOutputPending,
 			},
-			wantClearedRefs:  []string{"load", "agent"},
-			wantNodeTaskSize: 1,
+			wantClearedRefs: []string{"load", "agent"},
 		},
 	}
 
@@ -3956,8 +3952,8 @@ func TestCoordinatorRunnerShouldPlanReattemptStrategy(t *testing.T) {
 			if got, want := len(plan.NodeRuns), 0; got != want {
 				t.Fatalf("node runs = %d, want %d until next coordinator", got, want)
 			}
-			if got, want := len(plan.NodeTasks), tc.wantNodeTaskSize; got != want {
-				t.Fatalf("node tasks = %d, want %d", got, want)
+			if got := len(plan.NodeTasks); got != 0 {
+				t.Fatalf("node tasks = %d, want none before the next coordinator schedules work", got)
 			}
 			if plan.NextCoordinator == nil {
 				t.Fatal("NextCoordinator = nil, want retry coordinator")

--- a/internal/store/globaldb/global_db_task_claim_test.go
+++ b/internal/store/globaldb/global_db_task_claim_test.go
@@ -4594,6 +4594,81 @@ func successionLoopRunForTest(
 	return run
 }
 
+func routeNotTakenJoinLoopRunForTest(t *testing.T, id string, at time.Time) looppkg.Run {
+	t.Helper()
+
+	transform := func(nodeID dsl.NodeID) dsl.Node {
+		return dsl.Node{
+			ID: nodeID, Class: dsl.NodeClassAction, Kind: string(dsl.ActionTransform),
+			Params: dsl.NodeParams{
+				"map": map[string]any{"value": map[string]any{"value": string(nodeID)}},
+			},
+		}
+	}
+	selectSource := transform("select_source")
+	selectSource.Produces = dsl.Schema{"risk": "string"}
+	definition := dsl.Definition{
+		Meta: dsl.Meta{Name: "delivery", Version: 1},
+		Contract: dsl.Contract{
+			Goal: "Prepare delivery", DefinitionOfDone: "Worktree is prepared",
+			IterationCap: 3, NoProgress: dsl.NoProgress{Window: 3},
+			Budget: dsl.Budget{Tokens: 100_000, WallClockSec: 3_600, OnExceeded: dsl.BudgetExceededHalt},
+		},
+		Graph: dsl.Graph{
+			Nodes: []dsl.Node{
+				selectSource,
+				{
+					ID:    "route_source",
+					Class: dsl.NodeClassControl,
+					Kind:  string(dsl.ControlRoute),
+					Routes: []dsl.RouteSpec{{
+						When: `nodes.select_source.output.risk == "linear"`, To: "analyze_linear",
+					}},
+					Default: "analyze_sentry",
+				},
+				transform("analyze_linear"),
+				transform("create_spec"),
+				transform("analyze_sentry"),
+				transform("prepare_worktree"),
+			},
+			Edges: []dsl.Edge{
+				{From: "select_source", To: "route_source"},
+				{From: "route_source", To: "analyze_linear"},
+				{From: "route_source", To: "analyze_sentry"},
+				{From: "analyze_linear", To: "create_spec"},
+				{From: "create_spec", To: "prepare_worktree"},
+				{From: "analyze_sentry", To: "prepare_worktree"},
+			},
+		},
+	}
+	definition.Normalize()
+	resolved, err := looppkg.NewCompiler().Compile(definition)
+	if err != nil {
+		t.Fatalf("Compile(route-not-taken definition) error = %v", err)
+	}
+	effective, err := looppkg.ResolveEffectiveConfig(
+		resolved,
+		looppkg.DefaultLoopDefaults(),
+		nil,
+		looppkg.LoopConfig{},
+	)
+	if err != nil {
+		t.Fatalf("ResolveEffectiveConfig(route-not-taken definition) error = %v", err)
+	}
+	snapshot, digest, err := looppkg.BuildExecutedDefinitionSnapshot(resolved, effective)
+	if err != nil {
+		t.Fatalf("BuildExecutedDefinitionSnapshot(route-not-taken definition) error = %v", err)
+	}
+	run := testLoopRun(id, at, looppkg.StatusRunning)
+	run.DefinitionVersion = resolved.DefinitionVersion
+	run.DefinitionDigest = digest
+	run.DefinitionSnapshot = snapshot
+	run.IterationCap = 3
+	run.BudgetTokens = 100_000
+	run.BudgetWallSec = 3_600
+	return run
+}
+
 func claimExactLoopTaskRunForTest(
 	ctx context.Context,
 	t *testing.T,
@@ -6617,6 +6692,11 @@ func TestGlobalDBCompleteCoordinatorAndEnqueueNextShouldCreateNodeTasksDependenc
 		testGlobalDBCompleteCoordinatorAndEnqueueNextShouldCreateNodeTasksDependenciesAndRuns(t)
 	})
 
+	t.Run("Should claim a join after an inactive route settles", func(t *testing.T) {
+		t.Parallel()
+		testGlobalDBCompleteCoordinatorAndEnqueueNextShouldClaimJoinAfterInactiveRoute(t)
+	})
+
 	t.Run("Should drain open descendants when the coordinator terminates", func(t *testing.T) {
 		t.Parallel()
 		testGlobalDBCoordinatorTerminalShouldDrainOpenDescendants(t)
@@ -6866,6 +6946,188 @@ func testGlobalDBCompleteCoordinatorAndEnqueueNextShouldCreateNodeTasksDependenc
 	}
 	if status != "enqueued" {
 		t.Fatalf("generation output status = %q, want enqueued", status)
+	}
+}
+
+func testGlobalDBCompleteCoordinatorAndEnqueueNextShouldClaimJoinAfterInactiveRoute(t *testing.T) {
+	t.Helper()
+
+	globalDB := openLoopTestGlobalDB(t)
+	ctx := testutil.Context(t)
+	now := time.Date(2026, 8, 25, 21, 0, 0, 0, time.UTC)
+	loopRun := routeNotTakenJoinLoopRunForTest(t, "looprun-route-not-taken-join", now)
+	created, err := globalDB.CreateLoopRunForStart(ctx, loopRun, dsl.ConcurrencyAllow)
+	if err != nil {
+		t.Fatalf("CreateLoopRunForStart() error = %v", err)
+	}
+	runner, err := looppkg.NewCoordinatorRunner(globalDB, globalDB, globalDB, slog.Default())
+	if err != nil {
+		t.Fatalf("NewCoordinatorRunner() error = %v", err)
+	}
+
+	initialClaim := claimCoordinatorRunForTest(
+		ctx,
+		t,
+		globalDB,
+		created.ID,
+		"route-not-taken-initial",
+		now,
+	)
+	initialPlan, err := runner.Run(ctx, taskpkg.RunID(initialClaim.Run.ID))
+	if err != nil {
+		t.Fatalf("CoordinatorRunner.Run(initial) error = %v", err)
+	}
+	if got, want := len(initialPlan.NodeRuns), 1; got != want {
+		t.Fatalf("initial node runs = %d, want %d", got, want)
+	}
+	if _, err := globalDB.CompleteCoordinatorAndEnqueueNext(ctx, taskpkg.CoordinatorCompletion{
+		RunID: initialClaim.Run.ID, ClaimToken: initialClaim.ClaimToken,
+		Actor: coordinatorActorContextForTest(), Plan: initialPlan, Now: now.Add(time.Second),
+	}, looppkg.NewStoreFinalizer()); err != nil {
+		t.Fatalf("CompleteCoordinatorAndEnqueueNext(initial) error = %v", err)
+	}
+
+	sourceClaim := claimExactLoopTaskRunForTest(
+		ctx,
+		t,
+		globalDB,
+		created,
+		initialPlan.NodeRuns[0].RunID,
+		taskpkg.RunKindWorker,
+		now.Add(2*time.Second),
+	)
+	if _, err := globalDB.CompleteRunLease(ctx, taskpkg.LeaseCompletion{
+		Actor: coordinatorActorContextForTest(), RunID: sourceClaim.Run.ID,
+		ClaimToken: sourceClaim.ClaimToken,
+		Result:     taskpkg.RunResult{Value: json.RawMessage(`{"risk":"sentry"}`)},
+		Now:        now.Add(3 * time.Second),
+	}); err != nil {
+		t.Fatalf("CompleteRunLease(select_source) error = %v", err)
+	}
+
+	routeWake, added, err := globalDB.EnqueueLoopCoordinatorWake(
+		ctx,
+		string(created.ID),
+		"route-selection-settled",
+		taskpkg.Origin{Kind: taskpkg.OriginKindDaemon, Ref: "loop"},
+		now.Add(4*time.Second),
+	)
+	if err != nil || !added {
+		t.Fatalf("EnqueueLoopCoordinatorWake(route) = %#v, %v, want added", routeWake, err)
+	}
+	routeClaim := claimExactLoopTaskRunForTest(
+		ctx,
+		t,
+		globalDB,
+		created,
+		routeWake.ID,
+		taskpkg.RunKindCoordinator,
+		now.Add(5*time.Second),
+	)
+	routePlan, err := runner.Run(ctx, taskpkg.RunID(routeClaim.Run.ID))
+	if err != nil {
+		t.Fatalf("CoordinatorRunner.Run(route) error = %v", err)
+	}
+	if got, want := len(routePlan.NodeRuns), 1; got != want {
+		t.Fatalf("route node runs = %d, want %d", got, want)
+	}
+	selectedTaskID := fmt.Sprintf("loop.%s.g1.node.analyze_sentry.0", created.ID)
+	if got, want := routePlan.NodeRuns[0].TaskID, selectedTaskID; got != want {
+		t.Fatalf("route node task = %q, want %q", got, want)
+	}
+	if _, err := globalDB.CompleteCoordinatorAndEnqueueNext(ctx, taskpkg.CoordinatorCompletion{
+		RunID: routeClaim.Run.ID, ClaimToken: routeClaim.ClaimToken,
+		Actor: coordinatorActorContextForTest(), Plan: routePlan, Now: now.Add(6 * time.Second),
+	}, looppkg.NewStoreFinalizer()); err != nil {
+		t.Fatalf("CompleteCoordinatorAndEnqueueNext(route) error = %v", err)
+	}
+
+	sentryClaim := claimExactLoopTaskRunForTest(
+		ctx,
+		t,
+		globalDB,
+		created,
+		routePlan.NodeRuns[0].RunID,
+		taskpkg.RunKindWorker,
+		now.Add(7*time.Second),
+	)
+	if _, err := globalDB.CompleteRunLease(ctx, taskpkg.LeaseCompletion{
+		Actor: coordinatorActorContextForTest(), RunID: sentryClaim.Run.ID,
+		ClaimToken: sentryClaim.ClaimToken,
+		Result:     taskpkg.RunResult{Value: json.RawMessage(`{"analysis":"complete"}`)},
+		Now:        now.Add(8 * time.Second),
+	}); err != nil {
+		t.Fatalf("CompleteRunLease(analyze_sentry) error = %v", err)
+	}
+
+	joinWake, added, err := globalDB.EnqueueLoopCoordinatorWake(
+		ctx,
+		string(created.ID),
+		"selected-analysis-settled",
+		taskpkg.Origin{Kind: taskpkg.OriginKindDaemon, Ref: "loop"},
+		now.Add(9*time.Second),
+	)
+	if err != nil || !added {
+		t.Fatalf("EnqueueLoopCoordinatorWake(join) = %#v, %v, want added", joinWake, err)
+	}
+	joinCoordinatorClaim := claimExactLoopTaskRunForTest(
+		ctx,
+		t,
+		globalDB,
+		created,
+		joinWake.ID,
+		taskpkg.RunKindCoordinator,
+		now.Add(10*time.Second),
+	)
+	joinPlan, err := runner.Run(ctx, taskpkg.RunID(joinCoordinatorClaim.Run.ID))
+	if err != nil {
+		t.Fatalf("CoordinatorRunner.Run(join) error = %v", err)
+	}
+	if got, want := len(joinPlan.NodeRuns), 1; got != want {
+		t.Fatalf("join node runs = %d, want %d", got, want)
+	}
+	joinRun := joinPlan.NodeRuns[0]
+	joinTaskID := fmt.Sprintf("loop.%s.g1.node.prepare_worktree.0", created.ID)
+	if got, want := joinRun.TaskID, joinTaskID; got != want {
+		t.Fatalf("join node task = %q, want %q", got, want)
+	}
+	if _, err := globalDB.CompleteCoordinatorAndEnqueueNext(ctx, taskpkg.CoordinatorCompletion{
+		RunID: joinCoordinatorClaim.Run.ID, ClaimToken: joinCoordinatorClaim.ClaimToken,
+		Actor: coordinatorActorContextForTest(), Plan: joinPlan, Now: now.Add(11 * time.Second),
+	}, looppkg.NewStoreFinalizer()); err != nil {
+		t.Fatalf("CompleteCoordinatorAndEnqueueNext(join) error = %v", err)
+	}
+
+	claimedJoin, err := globalDB.ClaimNextRun(ctx, taskpkg.ClaimCriteria{
+		RunID: joinRun.RunID, Scope: taskpkg.ScopeWorkspace, WorkspaceID: string(created.WorkspaceID),
+		ClaimerSessionID: "daemon-route-not-taken-join",
+		ClaimedBy:        &taskpkg.ActorIdentity{Kind: taskpkg.ActorKindDaemon, Ref: "loop"},
+		LeaseDuration:    time.Minute,
+		Now:              now.Add(12 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("ClaimNextRun(join) error = %v", err)
+	}
+	if got, want := claimedJoin.Run.ID, joinRun.RunID; got != want {
+		t.Fatalf("claimed join run = %q, want %q", got, want)
+	}
+
+	for _, inactiveNodeID := range []string{"analyze_linear", "create_spec"} {
+		inactiveTaskID := fmt.Sprintf("loop.%s.g1.node.%s.0", created.ID, inactiveNodeID)
+		if _, err := globalDB.GetTask(ctx, inactiveTaskID); !errors.Is(err, taskpkg.ErrTaskNotFound) {
+			t.Fatalf("GetTask(inactive %s) error = %v, want %v", inactiveNodeID, err, taskpkg.ErrTaskNotFound)
+		}
+	}
+	dependencies, err := globalDB.ListDependencies(ctx, joinTaskID)
+	if err != nil {
+		t.Fatalf("ListDependencies(join) error = %v", err)
+	}
+	wantDependencyID := selectedTaskID
+	if got, want := len(dependencies), 1; got != want {
+		t.Fatalf("join dependencies = %#v, want %d active dependency", dependencies, want)
+	}
+	if got, want := dependencies[0].DependsOnTaskID, wantDependencyID; got != want {
+		t.Fatalf("join dependency = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## What & why

Fixes #479.

Exclusive Loop routing already settled dominated nodes as `route_not_taken`, but the generic Task projection independently materialized Tasks and blocking dependency edges for every graph output. In the reported topology, choosing the sentry branch still created a ready `create_spec` Task on the inactive linear branch. The downstream `prepare_worktree` Task then depended on that phantom prerequisite, so its already queued run could not be claimed.

This change makes persisted Task ownership follow actual runtime scheduling: a generic node Task is created only when the coordinator plan also queues that node's worker run. Dependencies are emitted only for a Task scheduled by the current plan and only toward predecessor outputs that prove they own a worker run in the same generation. Route history remains complete in Loop generation outputs, while inactive work no longer enters the runnable Task graph.

### Root cause

The coordinator built Task artifacts before it built ready node runs. `appendCoordinatorTasksForOutputs` and `appendCoordinatorDependenciesForOutputs` therefore had no scheduling boundary and eagerly projected all non-parked generation outputs, including synthetic `route_not_taken` outputs. The Task claim predicate behaved correctly: it refused to claim `prepare_worktree` while the projected `create_spec` dependency remained incomplete.

### Implementation

- Build ready node runs before projecting generic Task artifacts in both initial-plan and subsequent-generation paths.
- Treat the plan's queued node runs as the authoritative set of Tasks to create in that coordinator transaction.
- Emit dependency edges only for target Tasks scheduled in the plan.
- Require dependency outputs to carry the canonical current-generation worker run identity; synthetic route skips and carried outputs from another generation cannot become prerequisites.
- Preserve Goal segment run identities through their canonical generation-scoped prefix.
- Remove old assertions that froze eager Task/dependency materialization before the next coordinator had scheduled work.

This is a greenfield hard cut. It does not add compatibility rows, fallback aliases, claim exceptions, or repair logic for old alpha databases.

## Regression coverage

The regression belongs to the existing real-SQLite coordinator materialization suite:

`TestGlobalDBCompleteCoordinatorAndEnqueueNextShouldCreateNodeTasksDependenciesAndRuns / Should claim a join after an inactive route settles`

The test runs the full persisted coordinator sequence for:

```text
select_source -> route_source
  -> analyze_linear -> create_spec -----\
  -> analyze_sentry ---------------------> prepare_worktree
```

With the sentry/default route selected, it:

1. creates the Loop run in the real GlobalDB store;
2. executes and persists each coordinator plan;
3. settles `select_source` with `risk=sentry`;
4. verifies that the selected `analyze_sentry` worker is queued;
5. settles that worker and persists the queued `prepare_worktree` worker;
6. calls the real `ClaimNextRun` for `prepare_worktree`;
7. requires both inactive Tasks (`analyze_linear` and `create_spec`) to be absent;
8. requires the join to have exactly one blocking dependency, `analyze_sentry`.

Before the production fix, the same test failed at step 6 with `task: no claimable run`. After the fix, it passed with the race detector enabled.

Existing Loop suites continue to cover route causes, fan-out, gates, retries, reattempt strategies, error routes, and lifecycle settlement. The changed reattempt expectations now assert that no generic Task exists before the successor coordinator actually schedules work.

## Real runtime QA

The living scenario `LP-exclusive-route-history` was reset, walked, and returned to `pass`. The run used a fresh isolated lab with a dedicated `COMPOZY_HOME`, HTTP port, UDS path, and tmux socket.

Observed through the built CLI, real daemon, SQLite, UDS, and independent HTTP reads:

- run `looprun-4bbdac0da3a2d3e5` settled as `done / complete`;
- `analyze_linear` and `create_spec` remained visible in Loop history as `route_not_taken`;
- the typed Task catalog contained only the coordinator plus `select_source`, `analyze_sentry`, and `prepare_worktree`;
- `prepare_worktree` completed and exposed exactly one dependency, `analyze_sentry`;
- the same run, catalog, and dependency survived a daemon restart;
- calm Task catalogs still excluded Loop records;
- an unknown Loop-run filter returned an empty catalog, while a cross-workspace run read returned 404.
- targeted teardown completed with `clean: true`, stopped daemon PID `93208`, and reported zero survivors.

Durable QA report: `docs/qa/reports/2026-08-25-issue-479.md`.

## How you verified it

- Red-before proof: the new GlobalDB regression failed with `task: no claimable run` before the production change.
- Focused race regression: passed after the fix.
- `go test -race ./internal/loop/...`: 1,025 tests passed.
- Canonical GlobalDB coordinator materialization suite: passed.
- `make build`: passed (`CodegenCheck` and Go build).
- Isolated CLI/API/runtime QA: passed for `LP-exclusive-route-history` plus the adjacent headless Task-catalog canary.
- Scoped Go lint for `./internal/loop/... ./internal/store/...`: passed with zero issues after the final mutation.
- `make gate`: inconclusive under machine contention. It passed lint, `internal/loop`, and `internal/store`; GlobalDB was killed only by the 11-minute package limit while another worktree's full `go test ./...` was active. No assertion failed.
- `make gate-full`: intentionally not run locally at the operator's request; the complete monorepo gate is delegated to this PR's CI.
- Strict QA evidence audit: behavior evidence is complete; release closure remains blocked only on the intentionally delegated full gate (`C14`).

The competing verification remained active for more than 16 minutes in GlobalDB. Rather than start another broad local package run and reproduce contention, the exact regression was rerun after the final test strengthening and passed with `-race` in 130.429s. CI is the required broad verification authority for this PR.

## Impact

### User-visible behavior

Task catalogs no longer expose or schedule inactive-route work, and selected downstream Loop work is no longer blocked by phantom dependencies. Loop status/history keeps the existing `route_not_taken` explanation.

### Compozy Impact Audit

- **Native tools:** behavior observed by `compozy__task_list` / `compozy__loop_status` is corrected through their existing API/core projections. Tool IDs, toolsets, descriptors, input/output schemas, digests, risk flags, capability gates, and availability diagnostics are unchanged.
- **Extensibility and hooks:** no extension, hook event, capability, registry, bridge SDK, MCP sidecar, or resource contract changes. Loop hook-originated Task records now contain only workers the coordinator actually schedules; existing hook/tool surfaces require no new wiring.
- **Workspace data isolation:** no new datum or scope. Loop Tasks remain workspace-scoped, preserve the existing `workspace_id`, and are claimed with the existing workspace criteria. QA independently confirmed a foreign-workspace run read returns 404.
- **Official Compozy skill:** no text change required. `skills/compozy/references/tasks-and-orchestration.md` already describes Task catalogs as real work and typed Loop execution records; this fix restores that documented contract without changing a command, flag, tool ID, or workflow.

### Web / docs / config lifecycle

- **Web:** no route, component, hook, cache key, SSE payload, or generated type change. Existing Task and Loop screens consume the corrected persisted projection.
- **packages/site:** no public documentation change; the documented route history and Task-catalog behavior were already correct.
- **config.toml:** no key, default, lifecycle class, or settings attachment changed. Existing `[loops]` and Task orchestration settings remain valid.

### Storage and contracts

- No schema or migration change.
- No OpenAPI, HTTP, UDS, CLI, native-tool, or SSE shape change.
- No compatibility path for obsolete alpha state.

## Risk and review notes

The main risk is accidentally dropping a legitimate dependency when its prerequisite completed in an earlier coordinator transaction. The implementation avoids using only the current plan's node-run set for prerequisites: it validates the persisted output's canonical worker run identity for the same generation and attempt. Goal nodes use their canonical generation-scoped segment prefix. The real-SQLite regression proves prior selected work remains the only dependency on the newly scheduled join.

The change deliberately does not modify generic claim SQL. Relaxing claim eligibility would hide malformed Task graphs and allow dependent work to run early; the projection is corrected at its ownership boundary instead.

---

- [ ] `make gate` passes locally (`make gate-full` delegated to CI by operator request)
- [x] New or changed behavior is covered by a red-before/green-after real-SQLite regression and real runtime QA
- [x] Codex co-wrote this change; the result was independently exercised through focused race tests, a built daemon, CLI, UDS, HTTP, and the living QA tracker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow planning so control-related tasks are scheduled in the correct order.
  * Prevented tasks from inactive routes or outside the current workflow generation from being created.
  * Ensured shared join steps are created and claimed only for the selected route.
  * Improved dependency handling for goal segments, skipped routes, and selected branches.

* **Tests**
  * Updated retry and failure-routing coverage to reflect corrected planning behavior.
  * Added integration coverage for route selection and shared join execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->