### PR TITLE
fix: publish npm packages with trusted identity

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,11 +1,15 @@
 name: "Setup Node.js Environment"
-description: "Sets up Node.js with npm registry authentication for CompozyOS release publishing"
+description: "Sets up Node.js and an optional npm version for release workflows"
 
 inputs:
   node-version:
     description: "Node.js version to install"
     required: false
     default: "22"
+  npm-version:
+    description: "npm version to install; leave empty to use the Node.js bundled version"
+    required: false
+    default: ""
 
 outputs:
   node-version:
@@ -22,3 +26,10 @@ runs:
         node-version: ${{ inputs.node-version }}
         registry-url: "https://registry.npmjs.org"
         scope: "@compozy"
+
+    - name: Install pinned npm
+      if: inputs.npm-version != ''
+      shell: bash
+      env:
+        NPM_VERSION: ${{ inputs.npm-version }}
+      run: npm install --global "npm@${NPM_VERSION}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,10 @@ env:
   CGO_ENABLED: 0
   GO_VERSION: "1.26.4"
   NODE_VERSION: "22"
+  NPM_VERSION: "11.9.0"
   COSIGN_VERSION: "v3.1.3"
   INITIAL_VERSION: "v0.0.2"
   PR_RELEASE_MODULE: github.com/compozy/releasepr@v0.0.29
-  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 permissions:
   contents: write
@@ -245,6 +244,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
+          npm-version: ${{ env.NPM_VERSION }}
 
       - uses: ./.github/actions/setup-bun
         with:
@@ -280,18 +280,26 @@ jobs:
       - name: Verify explicit release plan contract
         run: scripts/release-plan-contract.sh "${{ env.PR_RELEASE_MODULE }}"
 
-      - name: Verify npm publish authentication
-        if: ${{ env.ACT != 'true' }}
+      - name: Verify npm trusted publishing prerequisites
         run: |
-          if [ -z "${NPM_TOKEN:-}" ]; then
-            echo "::error::NPM_TOKEN is required to publish @compozy/cli and @compozy/extension-sdk"
+          set -euo pipefail
+          if [[ -n "${NPM_TOKEN:-}" || -n "${NODE_AUTH_TOKEN:-}" ]]; then
+            echo "::error::npm publication must use GitHub Actions OIDC, not a long-lived token"
             exit 1
           fi
-          npm whoami --registry=https://registry.npmjs.org
-
-      - name: Verify npm secret is available for local act
-        if: ${{ env.ACT == 'true' }}
-        run: test -n "${NPM_TOKEN:-}"
+          node -e '
+            const actual = process.argv[1].split(".").map(Number)
+            const minimum = [11, 5, 1]
+            const comparison = actual.reduce(
+              (result, part, index) => result || Math.sign(part - minimum[index]),
+              0,
+            )
+            if (comparison < 0) {
+              console.error("npm " + process.argv[1] + " does not support trusted publishing; require >=11.5.1")
+              process.exit(1)
+            }
+          ' "$(npm --version)"
+          npm ping --registry=https://registry.npmjs.org --userconfig=/dev/null
 
       - name: Validate TypeScript extension SDK package
         run: scripts/publish-extension-sdk.sh --dry-run 0.0.0-beta.0 beta
@@ -1527,6 +1535,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ env.NODE_VERSION }}
+          npm-version: ${{ env.NPM_VERSION }}
 
       - uses: ./.github/actions/setup-bun
         with:

--- a/internal/config/release_config_test.go
+++ b/internal/config/release_config_test.go
@@ -706,6 +706,7 @@ func TestDesktopReleaseWorkflowFailsClosedAndPublishesDraftLast(t *testing.T) {
 
 	root := findRepoRootForReleaseConfigTest(t)
 	workflow := readTextFile(t, root, filepath.Join(".github", "workflows", "release.yml"))
+	setupNode := readTextFile(t, root, filepath.Join(".github", "actions", "setup-node", "action.yml"))
 	gitignore := readTextFile(t, root, ".gitignore")
 	goreleaserData, err := os.ReadFile(filepath.Join(root, ".goreleaser.yml"))
 	if err != nil {
@@ -763,6 +764,32 @@ func TestDesktopReleaseWorkflowFailsClosedAndPublishesDraftLast(t *testing.T) {
 		assertContainsText(t, "public CLI smoke", cliSmokeJob, "smoke-public-cli-package.sh")
 		npmPublishJob := workflowJobSection(t, workflow, "npm-publish", "")
 		assertContainsText(t, "npm publisher", npmPublishJob, "name: Publish verified CLI package")
+		dryRunJob := workflowJobSection(t, workflow, "dry-run", "desktop-dry-run")
+		assertContainsText(t, "dry-run npm", dryRunJob, "npm-version: ${{ env.NPM_VERSION }}")
+		assertContainsText(t, "npm publisher", npmPublishJob, "npm-version: ${{ env.NPM_VERSION }}")
+		if got := strings.Count(workflow, "npm-version: ${{ env.NPM_VERSION }}"); got != 2 {
+			t.Fatalf("trusted-publishing npm setup count = %d, want dry-run and npm publisher", got)
+		}
+		for _, required := range []string{
+			"id-token: write",
+			"NPM_VERSION: \"11.9.0\"",
+			"name: Verify npm trusted publishing prerequisites",
+		} {
+			assertContainsText(t, "npm trusted publisher", workflow, required)
+		}
+		for _, forbidden := range []string{
+			"secrets.NPM_TOKEN",
+			"npm whoami",
+		} {
+			assertNotContainsText(t, "npm token publisher", workflow, forbidden)
+		}
+		for _, required := range []string{
+			"npm-version:",
+			"name: Install pinned npm",
+			`run: npm install --global "npm@${NPM_VERSION}"`,
+		} {
+			assertContainsText(t, "npm setup action", setupNode, required)
+		}
 		assertContainsText(t, "isolated release staging ignore", gitignore, ".release-dist/")
 		assertEqualString(t, "checksum.algorithm", stringAt(t, checksum, "algorithm"), "sha256")
 


### PR DESCRIPTION
## Summary

- replace the expired long-lived npm token path with GitHub Actions OIDC trusted publishing
- pin an OIDC-capable npm version only in release validation and package publication jobs
- keep the dry run fail-closed on unsupported npm clients or accidental token injection

## Verification

- `make gate`
- `actionlint .github/workflows/release.yml`
- `CGO_ENABLED=1 go test -race ./internal/config -count=1`

## QA Impact

No user-visible behavior change. This only changes internal release automation.

## Compozy Impact Audit

- Native tools: no impact; checked `.github/workflows/release.yml` and package publication commands, with no `compozy__*` descriptor, schema, digest, risk, or capability-gate changes.
- Extensibility and hooks: no runtime impact; checked extension SDK packaging and release workflow. Package contents and extension contracts are unchanged; only npm authentication moves from an organization token to GitHub Actions OIDC. No `config.toml` lifecycle change.
- Workspace data isolation: no impact; no runtime datum or `workspace_id` path changes across CLI, HTTP, UDS, core, store, web, SSE, cache, or events.
- Official Compozy skill: no impact; public behavior, tool IDs, CLI paths, hook events, capabilities, resources, and memory/network/task semantics are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow validation to ensure npm publishing uses a pinned npm version.
  * Added safeguards confirming trusted publishing configuration and preventing token-based authentication or unnecessary authentication checks.
  * Ensured the configured npm version is installed consistently across publishing and dry-run jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->